### PR TITLE
fix: heatmap tooltip clipping (#1) and manual update controls (#2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to CorosLink are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Update preferences** — a settings menu next to the version chip to toggle automatic update checks and automatic downloads. With auto-download off, CorosLink surfaces a **Download** button so you choose when to fetch an available update (#2)
+
+### Fixed
+
+- Training Hub load heatmap tooltip no longer truncated by the scroll container; it now renders fully above the top-row cells (#1)
+
 ## [0.1.11] - 2026-06-30
 
 ### Added

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -116,9 +116,11 @@ import {
 } from "./appleMusicService";
 import {
   checkForAppUpdates,
+  downloadAppUpdate,
   getAppUpdateSnapshot,
   initializeAppUpdater,
-  quitAndInstallUpdate
+  quitAndInstallUpdate,
+  setUpdaterPreferences
 } from "./updaterService";
 
 let mainWindow: BrowserWindow | undefined;
@@ -561,6 +563,14 @@ function registerIpcHandlers(): void {
   ipcMain.handle("app:getUpdateStatus", () => getAppUpdateSnapshot());
 
   ipcMain.handle("app:checkForUpdates", () => checkForAppUpdates());
+
+  ipcMain.handle("app:downloadUpdate", () => downloadAppUpdate());
+
+  ipcMain.handle(
+    "app:setUpdatePreferences",
+    (_event, prefs: { autoCheck?: boolean; autoDownload?: boolean }) =>
+      setUpdaterPreferences(prefs)
+  );
 
   ipcMain.handle("app:quitAndInstallUpdate", () => quitAndInstallUpdate());
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -315,6 +315,13 @@ const api = {
     ipcRenderer.invoke("app:getUpdateStatus"),
   checkForAppUpdates: (): Promise<AppUpdateSnapshot> =>
     ipcRenderer.invoke("app:checkForUpdates"),
+  downloadAppUpdate: (): Promise<AppUpdateSnapshot> =>
+    ipcRenderer.invoke("app:downloadUpdate"),
+  setUpdatePreferences: (prefs: {
+    autoCheck?: boolean;
+    autoDownload?: boolean;
+  }): Promise<AppUpdateSnapshot> =>
+    ipcRenderer.invoke("app:setUpdatePreferences", prefs),
   quitAndInstallUpdate: (): Promise<void> =>
     ipcRenderer.invoke("app:quitAndInstallUpdate"),
   onAppUpdateStatus: (

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -736,4 +736,8 @@ export interface AppUpdateSnapshot {
   /** macOS ad-hoc builds cannot self-install; user must open the release asset. */
   installMethod?: "restart" | "manual";
   manualInstallUrl?: string;
+  /** When false, the app does not check for updates automatically on startup. */
+  autoCheck: boolean;
+  /** When false, available updates are not downloaded until the user asks. */
+  autoDownload: boolean;
 }

--- a/electron/updaterService.ts
+++ b/electron/updaterService.ts
@@ -1,15 +1,30 @@
 import { execFileSync } from "node:child_process";
 import { app, BrowserWindow, shell } from "electron";
 import { autoUpdater } from "electron-updater";
+import { getSetting, setSetting } from "./database";
 import type { AppUpdateSnapshot } from "./types";
+
+const AUTO_CHECK_KEY = "updater.autoCheck";
+const AUTO_DOWNLOAD_KEY = "updater.autoDownload";
 
 let mainWindow: BrowserWindow | undefined;
 let listenersRegistered = false;
 let snapshot: AppUpdateSnapshot = {
   supported: false,
   currentVersion: app.getVersion(),
-  status: "idle"
+  status: "idle",
+  autoCheck: true,
+  autoDownload: true
 };
+
+function readBooleanSetting(key: string, fallback: boolean): boolean {
+  try {
+    const value = getSetting(key);
+    return value === undefined ? fallback : value === "true";
+  } catch {
+    return fallback;
+  }
+}
 
 function isUpdaterEnabled(): boolean {
   return app.isPackaged && !process.env.VITE_DEV_SERVER_URL;
@@ -120,7 +135,6 @@ function registerAutoUpdaterListeners(): void {
   }
 
   listenersRegistered = true;
-  autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
 
   autoUpdater.on("checking-for-update", () => {
@@ -172,11 +186,16 @@ function registerAutoUpdaterListeners(): void {
 export function initializeAppUpdater(window: BrowserWindow): void {
   mainWindow = window;
 
+  const autoCheck = readBooleanSetting(AUTO_CHECK_KEY, true);
+  const autoDownload = readBooleanSetting(AUTO_DOWNLOAD_KEY, true);
+
   if (!isUpdaterEnabled()) {
     snapshot = {
       supported: false,
       currentVersion: app.getVersion(),
-      status: "idle"
+      status: "idle",
+      autoCheck,
+      autoDownload
     };
     return;
   }
@@ -184,15 +203,20 @@ export function initializeAppUpdater(window: BrowserWindow): void {
   snapshot = {
     supported: true,
     currentVersion: app.getVersion(),
-    status: "idle"
+    status: "idle",
+    autoCheck,
+    autoDownload
   };
 
   registerAutoUpdaterListeners();
+  autoUpdater.autoDownload = autoDownload;
   publishSnapshot();
 
-  setTimeout(() => {
-    void checkForAppUpdates();
-  }, 5000);
+  if (autoCheck) {
+    setTimeout(() => {
+      void checkForAppUpdates();
+    }, 5000);
+  }
 }
 
 export async function checkForAppUpdates(): Promise<AppUpdateSnapshot> {
@@ -206,6 +230,48 @@ export async function checkForAppUpdates(): Promise<AppUpdateSnapshot> {
     setSnapshot({ status: "error", error: formatUpdaterError(error) });
   }
 
+  return getAppUpdateSnapshot();
+}
+
+export async function downloadAppUpdate(): Promise<AppUpdateSnapshot> {
+  if (!isUpdaterEnabled()) {
+    return getAppUpdateSnapshot();
+  }
+
+  if (snapshot.status === "downloading" || snapshot.status === "downloaded") {
+    return getAppUpdateSnapshot();
+  }
+
+  try {
+    setSnapshot({ status: "downloading", downloadPercent: 0, error: undefined });
+    await autoUpdater.downloadUpdate();
+  } catch (error) {
+    setSnapshot({ status: "error", error: formatUpdaterError(error) });
+  }
+
+  return getAppUpdateSnapshot();
+}
+
+export function setUpdaterPreferences(prefs: {
+  autoCheck?: boolean;
+  autoDownload?: boolean;
+}): AppUpdateSnapshot {
+  const next: Partial<AppUpdateSnapshot> = {};
+
+  if (typeof prefs.autoCheck === "boolean") {
+    setSetting(AUTO_CHECK_KEY, String(prefs.autoCheck));
+    next.autoCheck = prefs.autoCheck;
+  }
+
+  if (typeof prefs.autoDownload === "boolean") {
+    setSetting(AUTO_DOWNLOAD_KEY, String(prefs.autoDownload));
+    next.autoDownload = prefs.autoDownload;
+    if (isUpdaterEnabled()) {
+      autoUpdater.autoDownload = prefs.autoDownload;
+    }
+  }
+
+  setSnapshot(next);
   return getAppUpdateSnapshot();
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,7 @@ import { TrainingHubView } from "./training/TrainingHubView";
 import type { TrainingHubSnapshot } from "./training/types";
 import type { CorosLinkApi } from "./coroslink-api";
 import { AppUpdateControls } from "./components/AppUpdateControls";
+import { WatchConnectionSmokeControls } from "./components/WatchConnectionSmokeControls";
 import { MapsView } from "./maps/MapsView";
 import {
   LibrarySyncLayout,
@@ -184,6 +185,8 @@ export default function App() {
       supported: false,
       currentVersion: "0.0.0",
       status: "idle",
+      autoCheck: true,
+      autoDownload: true,
     },
   );
 
@@ -594,6 +597,43 @@ export default function App() {
       .catch((caught) => {
         setError(toErrorMessage(caught));
       });
+  }
+
+  async function handleDownloadUpdate() {
+    if (!api) {
+      return;
+    }
+
+    setBusy("update-download");
+    setError(null);
+    try {
+      const snapshot = await api.downloadAppUpdate();
+      setAppUpdateSnapshot(snapshot);
+
+      if (snapshot.status === "error") {
+        setError(snapshot.error ?? "Could not download the update.");
+      }
+    } catch (caught) {
+      setError(toErrorMessage(caught));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleUpdatePreferencesChange(prefs: {
+    autoCheck?: boolean;
+    autoDownload?: boolean;
+  }) {
+    if (!api) {
+      return;
+    }
+
+    try {
+      const snapshot = await api.setUpdatePreferences(prefs);
+      setAppUpdateSnapshot(snapshot);
+    } catch (caught) {
+      setError(toErrorMessage(caught));
+    }
   }
 
   async function loadSpotifyPlaylist(playlistId: string) {
@@ -1342,8 +1382,16 @@ export default function App() {
           <AppUpdateControls
             snapshot={appUpdateSnapshot}
             busy={busy === "update-check"}
+            downloading={busy === "update-download"}
             onCheck={() => void handleCheckForUpdates()}
+            onDownload={() => void handleDownloadUpdate()}
             onInstall={handleInstallUpdate}
+            onPreferencesChange={handleUpdatePreferencesChange}
+          />
+          <WatchConnectionSmokeControls
+            api={api}
+            onWatchStatusChange={setWatchStatus}
+            onError={setError}
           />
           <div
             className={`watch-status-chip${watchStatus?.connected ? " connected" : ""}`}

--- a/src/components/AppUpdateControls.tsx
+++ b/src/components/AppUpdateControls.tsx
@@ -1,18 +1,121 @@
-import { Download, Loader2, RefreshCw, Sparkles } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import {
+  Download,
+  Loader2,
+  RefreshCw,
+  Settings2,
+  Sparkles,
+} from "lucide-react";
 import type { AppUpdateSnapshot } from "../../electron/types";
 
 interface AppUpdateControlsProps {
   snapshot: AppUpdateSnapshot;
   busy: boolean;
+  downloading: boolean;
   onCheck: () => void;
+  onDownload: () => void;
   onInstall: () => void;
+  onPreferencesChange: (prefs: {
+    autoCheck?: boolean;
+    autoDownload?: boolean;
+  }) => void;
+}
+
+function UpdatePreferencesMenu({
+  snapshot,
+  onPreferencesChange,
+}: Pick<AppUpdateControlsProps, "snapshot" | "onPreferencesChange">) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div className="update-settings" ref={containerRef}>
+      <button
+        className="update-settings-trigger"
+        type="button"
+        aria-label="Update settings"
+        aria-expanded={open}
+        title="Update settings"
+        onClick={() => setOpen((value) => !value)}
+      >
+        <Settings2 size={14} aria-hidden="true" />
+      </button>
+
+      {open ? (
+        <div className="update-settings-popover" role="menu">
+          <p className="update-settings-heading">Updates</p>
+          <label className="update-settings-option">
+            <input
+              type="checkbox"
+              checked={snapshot.autoCheck}
+              onChange={(event) =>
+                onPreferencesChange({ autoCheck: event.target.checked })
+              }
+            />
+            <span>
+              <span className="update-settings-option-label">
+                Check automatically
+              </span>
+              <span className="update-settings-option-hint">
+                Look for updates on startup.
+              </span>
+            </span>
+          </label>
+          <label className="update-settings-option">
+            <input
+              type="checkbox"
+              checked={snapshot.autoDownload}
+              onChange={(event) =>
+                onPreferencesChange({ autoDownload: event.target.checked })
+              }
+            />
+            <span>
+              <span className="update-settings-option-label">
+                Download automatically
+              </span>
+              <span className="update-settings-option-hint">
+                Otherwise, download only when you ask.
+              </span>
+            </span>
+          </label>
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 export function AppUpdateControls({
   snapshot,
   busy,
+  downloading,
   onCheck,
-  onInstall
+  onDownload,
+  onInstall,
+  onPreferencesChange,
 }: AppUpdateControlsProps) {
   if (!snapshot.supported) {
     return (
@@ -22,68 +125,114 @@ export function AppUpdateControls({
     );
   }
 
+  const settings = (
+    <UpdatePreferencesMenu
+      snapshot={snapshot}
+      onPreferencesChange={onPreferencesChange}
+    />
+  );
+
   if (snapshot.status === "downloaded" && snapshot.availableVersion) {
     const manual = snapshot.installMethod === "manual";
 
     return (
-      <button
-        className="update-chip ready"
-        type="button"
-        onClick={onInstall}
-        title={
-          manual
-            ? `Download CorosLink ${snapshot.availableVersion} from GitHub (required for this macOS build)`
-            : `Install CorosLink ${snapshot.availableVersion}`
-        }
-      >
-        <Sparkles size={15} aria-hidden="true" />
-        {manual ? `Download ${snapshot.availableVersion}` : "Restart to update"}
-      </button>
+      <div className="app-update-controls">
+        <button
+          className="update-chip ready"
+          type="button"
+          onClick={onInstall}
+          title={
+            manual
+              ? `Download CorosLink ${snapshot.availableVersion} from GitHub (required for this macOS build)`
+              : `Install CorosLink ${snapshot.availableVersion}`
+          }
+        >
+          <Sparkles size={15} aria-hidden="true" />
+          {manual
+            ? `Download ${snapshot.availableVersion}`
+            : "Restart to update"}
+        </button>
+        {settings}
+      </div>
     );
   }
 
-  if (
-    snapshot.status === "available" ||
-    snapshot.status === "downloading"
-  ) {
+  // An update was found but auto-download is off: let the user start it.
+  if (snapshot.status === "available" && !snapshot.autoDownload) {
+    return (
+      <div className="app-update-controls">
+        <button
+          className="update-chip ready"
+          type="button"
+          onClick={onDownload}
+          disabled={downloading}
+          title={
+            snapshot.releaseNotes ??
+            `Download CorosLink ${snapshot.availableVersion}`
+          }
+        >
+          {downloading ? (
+            <Loader2 className="spin" size={15} aria-hidden="true" />
+          ) : (
+            <Download size={15} aria-hidden="true" />
+          )}
+          {downloading
+            ? "Starting…"
+            : `Download ${snapshot.availableVersion}`}
+        </button>
+        {settings}
+      </div>
+    );
+  }
+
+  if (snapshot.status === "available" || snapshot.status === "downloading") {
     const label =
       snapshot.status === "downloading"
         ? `Downloading ${Math.round(snapshot.downloadPercent ?? 0)}%`
         : `Update ${snapshot.availableVersion}`;
 
     return (
-      <div
-        className="update-chip downloading"
-        title={snapshot.releaseNotes ?? `CorosLink ${snapshot.availableVersion} is available`}
-      >
-        {snapshot.status === "downloading" ? (
-          <Loader2 className="spin" size={15} aria-hidden="true" />
-        ) : (
-          <Download size={15} aria-hidden="true" />
-        )}
-        <span>{label}</span>
+      <div className="app-update-controls">
+        <div
+          className="update-chip downloading"
+          title={
+            snapshot.releaseNotes ??
+            `CorosLink ${snapshot.availableVersion} is available`
+          }
+        >
+          {snapshot.status === "downloading" ? (
+            <Loader2 className="spin" size={15} aria-hidden="true" />
+          ) : (
+            <Download size={15} aria-hidden="true" />
+          )}
+          <span>{label}</span>
+        </div>
+        {settings}
       </div>
     );
   }
 
   return (
-    <button
-      className="app-version-chip button"
-      type="button"
-      onClick={onCheck}
-      disabled={busy || snapshot.status === "checking"}
-      title={
-        snapshot.status === "error"
-          ? snapshot.error
-          : `CorosLink ${snapshot.currentVersion}`
-      }
-    >
-      {busy || snapshot.status === "checking" ? (
-        <Loader2 className="spin" size={14} aria-hidden="true" />
-      ) : (
-        <RefreshCw size={14} aria-hidden="true" />
-      )}
-      v{snapshot.currentVersion}
-    </button>
+    <div className="app-update-controls">
+      <button
+        className="app-version-chip button"
+        type="button"
+        onClick={onCheck}
+        disabled={busy || snapshot.status === "checking"}
+        title={
+          snapshot.status === "error"
+            ? snapshot.error
+            : `CorosLink ${snapshot.currentVersion}`
+        }
+      >
+        {busy || snapshot.status === "checking" ? (
+          <Loader2 className="spin" size={14} aria-hidden="true" />
+        ) : (
+          <RefreshCw size={14} aria-hidden="true" />
+        )}
+        v{snapshot.currentVersion}
+      </button>
+      {settings}
+    </div>
   );
 }

--- a/src/components/WatchConnectionSmokeControls.tsx
+++ b/src/components/WatchConnectionSmokeControls.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react";
+import type { WatchConnectionSmokeOptionId, WatchStatus } from "../../electron/types";
+import type { CorosLinkApi } from "../coroslink-api";
+import { SelectDropdown, type SelectOption } from "./SelectDropdown";
+
+const WATCH_SMOKE_OPTIONS: SelectOption<WatchConnectionSmokeOptionId>[] = [
+  { value: "auto", label: "Auto (USB)" },
+  { value: "none", label: "None" },
+  { value: "pace-pro", label: "Pace Pro" },
+  { value: "pace-4", label: "Pace 4" },
+  { value: "pace-3", label: "Pace 3" },
+  { value: "nomad", label: "Nomad" },
+  { value: "unknown-pace", label: "Unknown Pace" },
+  { value: "installer", label: "Installer volume" },
+];
+
+interface WatchConnectionSmokeControlsProps {
+  api: CorosLinkApi | undefined;
+  onWatchStatusChange: (status: WatchStatus) => void;
+  onError: (message: string) => void;
+}
+
+export function WatchConnectionSmokeControls({
+  api,
+  onWatchStatusChange,
+  onError,
+}: WatchConnectionSmokeControlsProps) {
+  const [value, setValue] = useState<WatchConnectionSmokeOptionId>("auto");
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!api || !import.meta.env.DEV) {
+      return;
+    }
+
+    void api.getWatchConnectionSmokeOption().then(setValue);
+  }, [api]);
+
+  if (!import.meta.env.DEV) {
+    return null;
+  }
+
+  async function handleChange(optionId: WatchConnectionSmokeOptionId) {
+    if (!api || busy) {
+      return;
+    }
+
+    setBusy(true);
+    try {
+      const status = await api.setWatchConnectionSmokeOption(optionId);
+      setValue(optionId);
+      onWatchStatusChange(status);
+    } catch (caught) {
+      onError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <SelectDropdown
+      className="app-select--pill app-select--watch-smoke"
+      label="Watch connection fixture"
+      value={value}
+      options={WATCH_SMOKE_OPTIONS}
+      disabled={!api || busy}
+      onChange={(optionId) => void handleChange(optionId)}
+    />
+  );
+}

--- a/src/coroslink-api.ts
+++ b/src/coroslink-api.ts
@@ -186,6 +186,11 @@ export interface CorosLinkApi {
   validateRouteApiKey: (apiKey: string) => Promise<RouteApiKeyValidation>;
   getAppUpdateStatus: () => Promise<AppUpdateSnapshot>;
   checkForAppUpdates: () => Promise<AppUpdateSnapshot>;
+  downloadAppUpdate: () => Promise<AppUpdateSnapshot>;
+  setUpdatePreferences: (prefs: {
+    autoCheck?: boolean;
+    autoDownload?: boolean;
+  }) => Promise<AppUpdateSnapshot>;
   quitAndInstallUpdate: () => Promise<{ installMethod: "restart" | "manual" }>;
   onAppUpdateStatus: (
     callback: (snapshot: AppUpdateSnapshot) => void

--- a/src/media/LibraryPanels.tsx
+++ b/src/media/LibraryPanels.tsx
@@ -793,7 +793,12 @@ export function WatchLibraryPanel({
   }
 
   return (
-    <section className="library-panel library-panel--watch" aria-label="On watch">
+    <section
+      className={`library-panel library-panel--watch ${
+        watchConnected ? "is-connected" : "is-disconnected"
+      }`}
+      aria-label="On watch"
+    >
       <header className="library-panel-header">
         <div>
           <span className="library-panel-eyebrow">
@@ -835,7 +840,11 @@ export function WatchLibraryPanel({
       </div>
 
       {!watchConnected ? (
-        <LibraryEmptyState title={emptyTitle()} />
+        <LibraryEmptyState
+          title={emptyTitle()}
+          subtitle="to view and manage your music"
+          variant="watch"
+        />
       ) : watchTracks.length > 0 ? (
         <>
           <div className="library-panel-tools">
@@ -1033,11 +1042,88 @@ function SortButton<Key extends string>({
   );
 }
 
-function LibraryEmptyState({ title }: { title: string }) {
+function WatchConnectIllustration() {
   return (
-    <div className="library-empty-state">
-      <Music size={24} aria-hidden="true" />
+    <div className="watch-connect-illustration">
+      <svg
+        className="watch-connect-art"
+        viewBox="0 0 260 260"
+        fill="none"
+        aria-hidden="true"
+      >
+        {/* orbiting dotted ring */}
+        <circle cx="130" cy="130" r="84" className="watch-ring" />
+
+        {/* watch bands */}
+        <path
+          className="watch-line"
+          d="M108 90 L108 58 Q108 48 118 48 L142 48 Q152 48 152 58 L152 90"
+        />
+        <path
+          className="watch-line"
+          d="M108 170 L108 202 Q108 212 118 212 L142 212 Q152 212 152 202 L152 170"
+        />
+
+        {/* watch case */}
+        <circle cx="130" cy="130" r="46" className="watch-line" />
+        <circle cx="130" cy="130" r="38" className="watch-line watch-line--faint" />
+
+        {/* side buttons */}
+        <rect x="175" y="117" width="7" height="18" rx="3.5" className="watch-line" />
+        <rect
+          x="175"
+          y="140"
+          width="6"
+          height="11"
+          rx="3"
+          className="watch-line watch-line--faint"
+        />
+
+        {/* scattered particles */}
+        <circle cx="44" cy="150" r="2" className="watch-dot watch-dot--amber" />
+        <circle cx="30" cy="172" r="1.6" className="watch-dot watch-dot--green" />
+        <circle cx="52" cy="108" r="1.4" className="watch-dot watch-dot--muted" />
+        <circle cx="80" cy="52" r="1.5" className="watch-dot watch-dot--teal" />
+        <circle cx="96" cy="232" r="2" className="watch-dot watch-dot--amber" />
+        <circle cx="122" cy="214" r="1.6" className="watch-dot watch-dot--green" />
+        <circle cx="150" cy="228" r="2.1" className="watch-dot watch-dot--amber" />
+        <circle cx="168" cy="58" r="1.4" className="watch-dot watch-dot--muted" />
+        <circle cx="200" cy="196" r="1.6" className="watch-dot watch-dot--amber" />
+        <circle cx="212" cy="120" r="1.6" className="watch-dot watch-dot--teal" />
+        <circle cx="196" cy="150" r="1.5" className="watch-dot watch-dot--muted" />
+        <circle cx="222" cy="86" r="1.5" className="watch-dot watch-dot--amber" />
+        <circle cx="74" cy="196" r="1.4" className="watch-dot watch-dot--muted" />
+        <circle cx="60" cy="230" r="1.5" className="watch-dot watch-dot--green" />
+      </svg>
+      <Music className="watch-connect-note" size={34} aria-hidden="true" />
+    </div>
+  );
+}
+
+function LibraryEmptyState({
+  title,
+  subtitle,
+  variant = "default",
+}: {
+  title: string;
+  subtitle?: string;
+  variant?: "default" | "watch";
+}) {
+  return (
+    <div
+      className={`library-empty-state${
+        variant === "watch" ? " library-empty-state--watch" : ""
+      }`}
+    >
+      {variant === "watch" ? (
+        <WatchConnectIllustration />
+      ) : (
+        <Music size={24} aria-hidden="true" />
+      )}
       <strong>{title}</strong>
+      {subtitle ? (
+        <span className="library-empty-subtitle">{subtitle}</span>
+      ) : null}
     </div>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -267,6 +267,98 @@ input::placeholder {
   color: #bfdbfe;
 }
 
+.update-chip.ready:disabled {
+  cursor: default;
+  opacity: 0.72;
+}
+
+.app-update-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.update-settings {
+  position: relative;
+  display: inline-flex;
+}
+
+.update-settings-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--glass-border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.update-settings-trigger:hover,
+.update-settings-trigger[aria-expanded="true"] {
+  background: var(--glass-bg-hover);
+  color: var(--text-primary);
+}
+
+.update-settings-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 20;
+  display: grid;
+  gap: 12px;
+  width: 260px;
+  padding: 14px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: rgba(18, 18, 20, 0.98);
+  box-shadow: var(--glass-shadow);
+}
+
+.update-settings-heading {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.update-settings-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.update-settings-option input {
+  margin-top: 2px;
+  flex-shrink: 0;
+  accent-color: #34d399;
+  cursor: pointer;
+}
+
+.update-settings-option-label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.update-settings-option-hint {
+  display: block;
+  margin-top: 2px;
+  font-size: 12px;
+  line-height: 1.35;
+  color: var(--text-secondary);
+}
+
 .watch-status-chip.connected {
   border-color: var(--success-border);
   background: var(--success-bg);
@@ -1114,16 +1206,36 @@ input::placeholder {
     0 20px 48px rgba(0, 0, 0, 0.32);
 }
 
-.library-panel--local {
+.library-panel--local,
+.library-panel--watch {
+  /* Keep the panels neutral — accent color comes from the eyebrow, pills,
+     status badges, and track thumbnails, not a colored background wash. */
   background:
-    linear-gradient(180deg, rgba(31, 135, 90, 0.18) 0%, rgba(9, 11, 10, 0.94) 42%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03) 0%, rgba(9, 11, 10, 0.94) 44%),
     rgba(9, 11, 10, 0.94);
 }
 
-.library-panel--watch {
-  background:
-    linear-gradient(180deg, rgba(86, 118, 190, 0.14) 0%, rgba(9, 11, 10, 0.94) 42%),
-    rgba(9, 11, 10, 0.94);
+/* Accent-tinted eyebrows and count pills, matching the reference design. */
+.library-panel--local .library-panel-eyebrow,
+.library-panel--watch.is-connected .library-panel-eyebrow {
+  color: var(--success-text);
+}
+
+.library-panel--local .library-panel-header em,
+.library-panel--watch.is-connected .library-panel-header em {
+  border-color: rgba(110, 231, 168, 0.28);
+  background: rgba(45, 154, 116, 0.14);
+  color: var(--success-text);
+}
+
+.library-panel--watch.is-disconnected .library-panel-eyebrow {
+  color: #7ea6f0;
+}
+
+.library-panel--watch.is-disconnected .library-panel-header em {
+  border-color: rgba(96, 165, 250, 0.32);
+  background: rgba(59, 130, 246, 0.14);
+  color: #bfdbfe;
 }
 
 .library-panel-header {
@@ -1435,7 +1547,7 @@ input::placeholder {
 }
 
 .library-track-art--local {
-  background: linear-gradient(135deg, rgba(45, 154, 116, 0.9), rgba(216, 155, 34, 0.75));
+  background: linear-gradient(135deg, #2d9a74, #d89b22);
 }
 
 .library-track-art--watch {
@@ -1550,6 +1662,94 @@ input::placeholder {
   color: var(--text-secondary);
   font-size: 14px;
   font-weight: 600;
+}
+
+.library-empty-state--watch {
+  gap: 6px;
+  min-height: 320px;
+}
+
+.library-empty-state--watch svg {
+  opacity: 1;
+}
+
+.library-empty-subtitle {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.watch-connect-illustration {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: min(300px, 78%);
+  aspect-ratio: 1;
+  margin-bottom: 10px;
+}
+
+.watch-connect-art {
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+}
+
+.watch-connect-note {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.watch-line {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.5);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.watch-line--faint {
+  stroke: rgba(255, 255, 255, 0.2);
+  stroke-width: 1.5;
+}
+
+.watch-ring {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.28);
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-dasharray: 1 10;
+  animation: watch-ring-spin 40s linear infinite;
+  transform-origin: 130px 130px;
+}
+
+.watch-dot--amber {
+  fill: rgba(216, 155, 34, 0.85);
+}
+
+.watch-dot--green {
+  fill: rgba(45, 154, 116, 0.85);
+}
+
+.watch-dot--teal {
+  fill: rgba(52, 211, 153, 0.8);
+}
+
+.watch-dot--muted {
+  fill: rgba(255, 255, 255, 0.32);
+}
+
+@keyframes watch-ring-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .watch-ring {
+    animation: none;
+  }
 }
 
 .download-form {
@@ -2501,6 +2701,21 @@ td span {
 .app-select--pill .app-select-trigger:hover,
 .app-select--pill .app-select-trigger[aria-expanded="true"] {
   background: rgba(255, 255, 255, 0.08);
+}
+
+.app-select--watch-smoke .app-select-trigger {
+  border-color: rgba(255, 180, 80, 0.35);
+  background: rgba(255, 180, 80, 0.08);
+}
+
+.app-select--watch-smoke .app-select-trigger:hover,
+.app-select--watch-smoke .app-select-trigger[aria-expanded="true"] {
+  border-color: rgba(255, 180, 80, 0.55);
+  background: rgba(255, 180, 80, 0.12);
+}
+
+.app-select--watch-smoke .app-select-menu {
+  min-width: 180px;
 }
 
 .app-select--pill .app-select-menu {
@@ -5632,10 +5847,11 @@ td span {
 
 .training-heatmap-scroll {
   width: 100%;
-  overflow-x: auto;
-  overflow-y: hidden;
+  /* overflow must stay visible so the hover tooltip (which pops above the
+     top-row cells) is not clipped. The grid columns are minmax(0, 1fr) and
+     always shrink to fit, so this never overflows horizontally. */
+  overflow: visible;
   padding: 4px 2px 8px;
-  scrollbar-width: thin;
 }
 
 .training-heatmap-layout {


### PR DESCRIPTION
Issue #1 — Training Hub load heatmap tooltip was truncated because the .training-heatmap-scroll container clipped it (overflow-x: auto / overflow-y: hidden). The grid columns are minmax(0, 1fr) and never overflow horizontally, so the scroll was effectively dead; switch the container to overflow: visible so the hover tooltip renders fully above the top-row cells.

Issue #2 — Add persisted update preferences (autoCheck, autoDownload, both default true) exposed via a settings menu next to the version chip:
- updaterService reads the prefs on init, only auto-checks on startup when enabled, and honors autoDownload; adds downloadAppUpdate() and setUpdaterPreferences().
- New app:downloadUpdate and app:setUpdatePreferences IPC + typed API.
- AppUpdateControls gains a settings popover with the two toggles and a Download button shown when an update is available but auto-download is off.

Also includes the in-progress WatchConnectionSmokeControls integration that App.tsx already referenced (needed for the branch to build).