### PR TITLE
Add in-app Apple Music sign-in with automatic header capture

### DIFF
--- a/electron/appleMusicBrowserService.ts
+++ b/electron/appleMusicBrowserService.ts
@@ -1,0 +1,126 @@
+// Embedded Apple Music sign-in. Instead of asking the user to copy request
+// headers out of DevTools (see appleMusicService.ts), we host music.apple.com
+// in its own Electron session and watch its network traffic. Every request the
+// web player makes to the internal "amp-api" carries the three things we need —
+// the developer token (`Authorization: Bearer …`), the per-account
+// `media-user-token`, and the session `Cookie` — so once the user signs in and
+// their library loads we can lift the credentials automatically.
+
+import { app, session, type WebContents } from "electron";
+
+export const APPLE_MUSIC_PARTITION = "persist:coroslink-apple";
+
+// amp-api is served from a few hostnames (amp-api, amp-api-edge, …); a
+// subdomain wildcard matches them all. Chromium match patterns only allow `*`
+// as a whole host label, so "amp-api*.music.apple.com" is rejected — we match
+// every music.apple.com subdomain and rely on the Authorization check below to
+// ignore non-API requests.
+const AMP_API_URL_FILTER = { urls: ["https://*.music.apple.com/*"] };
+
+/** Header names, lower-cased, that we lift from an amp-api request. */
+interface CapturedAppleMusicHeaders {
+  authorization?: string;
+  "media-user-token"?: string;
+  cookie?: string;
+}
+
+type AppleMusicHeaderListener = (headers: CapturedAppleMusicHeaders) => void;
+
+function buildChromeUserAgent(): string {
+  const chromeVersion = process.versions.chrome;
+  const platform =
+    process.platform === "darwin"
+      ? "Macintosh; Intel Mac OS X 10_15_7"
+      : process.platform === "win32"
+        ? "Windows NT 10.0; Win64; x64"
+        : "X11; Linux x86_64";
+
+  return `Mozilla/5.0 (${platform}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`;
+}
+
+function appleMusicSession(): Electron.Session {
+  return session.fromPartition(APPLE_MUSIC_PARTITION);
+}
+
+function isAppleMusicWebContents(contents: WebContents): boolean {
+  return contents.session === appleMusicSession();
+}
+
+export function configureAppleMusicBrowserSession(): void {
+  const appleSession = appleMusicSession();
+  // Apple's web player is picky about the user agent; present a plain Chrome
+  // string so it does not fall back to an unsupported-browser page.
+  appleSession.setUserAgent(buildChromeUserAgent());
+
+  appleSession.setPermissionRequestHandler((_webContents, permission, callback) => {
+    callback(["media", "fullscreen", "pointerLock"].includes(permission));
+  });
+}
+
+/**
+ * Watches the Apple Music session's amp-api traffic and reports the auth headers
+ * from any request that carries a developer token. The listener fires often (on
+ * essentially every API call); callers are expected to dedupe/merge.
+ */
+export function registerAppleMusicBrowserHandlers(
+  onHeaders: AppleMusicHeaderListener
+): void {
+  const appleSession = appleMusicSession();
+
+  appleSession.webRequest.onBeforeSendHeaders(
+    AMP_API_URL_FILTER,
+    (details, callback) => {
+      // Only report requests that carry the per-account media-user-token; the
+      // developer token alone (catalog browsing before sign-in) is not useful
+      // and would fire on nearly every request.
+      const captured = extractAuthHeaders(details.requestHeaders);
+      if (captured.authorization && captured["media-user-token"]) {
+        onHeaders(captured);
+      }
+      callback({ requestHeaders: details.requestHeaders });
+    }
+  );
+
+  app.on("web-contents-created", (_event, contents) => {
+    if (contents.getType() !== "webview" || !isAppleMusicWebContents(contents)) {
+      return;
+    }
+    contents.setUserAgent(buildChromeUserAgent());
+  });
+}
+
+/** Clears the signed-in Apple Music session (used by the "reset" action). */
+export async function resetAppleMusicBrowserSession(): Promise<void> {
+  const appleSession = appleMusicSession();
+  await appleSession.clearCache();
+  await appleSession.clearStorageData();
+}
+
+// Chromium preserves the original header casing, so match case-insensitively and
+// only keep the three headers appleMusicService needs.
+function extractAuthHeaders(
+  requestHeaders: Record<string, string>
+): CapturedAppleMusicHeaders {
+  const captured: CapturedAppleMusicHeaders = {};
+
+  for (const [name, value] of Object.entries(requestHeaders)) {
+    if (!value) {
+      continue;
+    }
+    switch (name.toLowerCase()) {
+      case "authorization":
+        captured.authorization = value;
+        break;
+      case "media-user-token":
+        captured["media-user-token"] = value;
+        break;
+      case "cookie":
+        captured.cookie = value;
+        break;
+      default:
+        break;
+    }
+  }
+
+  return captured;
+}

--- a/electron/appleMusicService.ts
+++ b/electron/appleMusicService.ts
@@ -55,6 +55,56 @@ export function saveAppleMusicAuth(headersRaw: string): AppleMusicStatus {
   return getAppleMusicStatus();
 }
 
+/**
+ * Stores credentials lifted automatically from music.apple.com's amp-api traffic
+ * (see appleMusicBrowserService.ts). The capture fires on every API call, so a
+ * given request may only carry a subset of the headers — merge with anything
+ * already stored and never downgrade (e.g. don't drop a known media-user-token
+ * just because one catalog request lacked it). Returns the current status, and
+ * whether this call actually changed the stored credentials.
+ */
+export function saveAppleMusicCapturedHeaders(headers: {
+  authorization?: string;
+  "media-user-token"?: string;
+  cookie?: string;
+}): { status: AppleMusicStatus; changed: boolean } {
+  const developerToken = (headers.authorization ?? "")
+    .replace(/^bearer\s+/i, "")
+    .trim();
+  if (!developerToken) {
+    return { status: getAppleMusicStatus(), changed: false };
+  }
+
+  const existing = readStoredCredentials();
+  const merged: AppleMusicCredentials = {
+    developerToken,
+    userToken: headers["media-user-token"]?.trim() || existing?.userToken,
+    cookie: headers.cookie?.trim() || existing?.cookie,
+    storefront: existing?.storefront
+  };
+
+  // The developer token rides on every amp-api request, including catalog
+  // browsing before sign-in. Ignore those: without a media-user-token there is
+  // no library access, and saving anyway would prematurely flip the UI to
+  // "connected" and tear down the sign-in browser mid-login.
+  if (!merged.userToken) {
+    return { status: getAppleMusicStatus(), changed: false };
+  }
+
+  const changed =
+    !existing ||
+    existing.developerToken !== merged.developerToken ||
+    existing.userToken !== merged.userToken ||
+    existing.cookie !== merged.cookie;
+
+  if (changed) {
+    setSetting(SETTINGS.credentialsJson, JSON.stringify(merged));
+    setSetting(SETTINGS.authUpdatedAt, new Date().toISOString());
+  }
+
+  return { status: getAppleMusicStatus(), changed };
+}
+
 export function logoutAppleMusic(): AppleMusicStatus {
   deleteSettings([SETTINGS.credentialsJson, SETTINGS.authUpdatedAt]);
   return getAppleMusicStatus();

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -113,8 +113,14 @@ import {
   getAppleMusicStatus,
   listAppleMusicPlaylists,
   logoutAppleMusic,
-  saveAppleMusicAuth
+  saveAppleMusicAuth,
+  saveAppleMusicCapturedHeaders
 } from "./appleMusicService";
+import {
+  configureAppleMusicBrowserSession,
+  registerAppleMusicBrowserHandlers,
+  resetAppleMusicBrowserSession
+} from "./appleMusicBrowserService";
 import {
   checkForAppUpdates,
   downloadAppUpdate,
@@ -219,6 +225,15 @@ app.whenReady().then(() => {
   configureAppPermissions();
   configureYouTubeBrowserSession();
   registerYouTubeBrowserHandlers();
+  configureAppleMusicBrowserSession();
+  registerAppleMusicBrowserHandlers((headers) => {
+    // Fires on every amp-api call; only tell the renderer when the stored
+    // credentials actually change (e.g. the media-user-token first appears).
+    const { status, changed } = saveAppleMusicCapturedHeaders(headers);
+    if (changed && mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send("appleMusic:authCaptured", status);
+    }
+  });
   initializeDatabase(app.getPath("userData"));
   registerIpcHandlers();
   setJobListener((jobs) => {
@@ -373,6 +388,10 @@ function registerIpcHandlers(): void {
   );
 
   ipcMain.handle("appleMusic:logout", () => logoutAppleMusic());
+
+  ipcMain.handle("appleMusic:resetBrowserSession", () =>
+    resetAppleMusicBrowserSession()
+  );
 
   ipcMain.handle("appleMusic:listPlaylists", () => listAppleMusicPlaylists());
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -136,6 +136,21 @@ const api = {
     ipcRenderer.invoke("appleMusic:saveAuth", headersRaw),
   logoutAppleMusic: (): Promise<AppleMusicStatus> =>
     ipcRenderer.invoke("appleMusic:logout"),
+  resetAppleMusicBrowserSession: (): Promise<void> =>
+    ipcRenderer.invoke("appleMusic:resetBrowserSession"),
+  onAppleMusicAuthCaptured: (
+    callback: (status: AppleMusicStatus) => void
+  ): (() => void) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      status: AppleMusicStatus
+    ) => {
+      callback(status);
+    };
+    ipcRenderer.on("appleMusic:authCaptured", listener);
+    return () =>
+      ipcRenderer.removeListener("appleMusic:authCaptured", listener);
+  },
   listAppleMusicPlaylists: (): Promise<AppleMusicPlaylist[]> =>
     ipcRenderer.invoke("appleMusic:listPlaylists"),
   fetchAppleMusicPlaylist: (playlist: string): Promise<AppleMusicPlaylist> =>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4329,6 +4329,123 @@ function EmptyState({ title }: { title: string }) {
   );
 }
 
+const APPLE_MUSIC_LOGIN_URL = "https://music.apple.com/login";
+const APPLE_MUSIC_HOME_URL = "https://music.apple.com/";
+
+// Hosts music.apple.com inside its own persistent Electron session. The main
+// process watches this session's amp-api traffic and lifts the auth headers as
+// soon as the user signs in (see appleMusicBrowserService.ts), so this
+// component only has to render the page and offer basic navigation.
+function AppleMusicLoginBrowser() {
+  const webviewRef = useRef<WebviewElement | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [webviewKey, setWebviewKey] = useState(0);
+  const [currentUrl, setCurrentUrl] = useState(APPLE_MUSIC_LOGIN_URL);
+  const [resetting, setResetting] = useState(false);
+
+  useEffect(() => {
+    const webview = webviewRef.current;
+    if (!webview) {
+      return;
+    }
+
+    const handleDomReady = () => setLoading(false);
+    const handleStartLoading = () => setLoading(true);
+    const handleStopLoading = () => {
+      setLoading(false);
+      setCurrentUrl(webview.getURL() || APPLE_MUSIC_LOGIN_URL);
+    };
+    const handleNavigate = () =>
+      setCurrentUrl(webview.getURL() || APPLE_MUSIC_LOGIN_URL);
+
+    webview.addEventListener("dom-ready", handleDomReady);
+    webview.addEventListener("did-start-loading", handleStartLoading);
+    webview.addEventListener("did-stop-loading", handleStopLoading);
+    webview.addEventListener("did-navigate", handleNavigate);
+    webview.addEventListener("did-navigate-in-page", handleNavigate);
+
+    return () => {
+      webview.removeEventListener("dom-ready", handleDomReady);
+      webview.removeEventListener("did-start-loading", handleStartLoading);
+      webview.removeEventListener("did-stop-loading", handleStopLoading);
+      webview.removeEventListener("did-navigate", handleNavigate);
+      webview.removeEventListener("did-navigate-in-page", handleNavigate);
+    };
+  }, [webviewKey]);
+
+  async function handleReset() {
+    setResetting(true);
+    setLoading(true);
+    try {
+      await window.corosLink?.resetAppleMusicBrowserSession();
+    } finally {
+      setResetting(false);
+      // Remount the webview so it reloads from the freshly cleared session.
+      setCurrentUrl(APPLE_MUSIC_LOGIN_URL);
+      setWebviewKey((value) => value + 1);
+    }
+  }
+
+  return (
+    <div className="apple-music-login">
+      <div className="apple-music-login-toolbar">
+        <div className="browser-nav">
+          <button
+            className="icon-button"
+            type="button"
+            title="Reload"
+            onClick={() => webviewRef.current?.reload()}
+          >
+            <RefreshCw size={16} aria-hidden="true" />
+          </button>
+          <button
+            className="icon-button"
+            type="button"
+            title="Apple Music home"
+            onClick={() => void webviewRef.current?.loadURL(APPLE_MUSIC_HOME_URL)}
+          >
+            <Home size={16} aria-hidden="true" />
+          </button>
+        </div>
+        <span className="apple-music-login-url" title={currentUrl}>
+          {currentUrl}
+        </span>
+        <button
+          className="secondary-button"
+          type="button"
+          disabled={resetting}
+          onClick={() => void handleReset()}
+        >
+          {resetting ? (
+            <Loader2 className="spin" size={15} aria-hidden="true" />
+          ) : (
+            <LogOut size={15} aria-hidden="true" />
+          )}
+          Reset session
+        </button>
+      </div>
+      <div className="webview-frame apple-music-login-frame">
+        <webview
+          key={webviewKey}
+          ref={(element) => {
+            webviewRef.current = element as WebviewElement | null;
+            element?.setAttribute("allowpopups", "");
+          }}
+          className="youtube-webview apple-music-webview"
+          src={APPLE_MUSIC_LOGIN_URL}
+          partition="persist:coroslink-apple"
+          webpreferences="contextIsolation=yes,nodeIntegration=no,sandbox=no"
+        />
+        {loading ? (
+          <div className="browser-loading">
+            <Loader2 className="spin" size={24} aria-hidden="true" />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 function AppleMusicView({
   onMessage,
   onError,
@@ -4349,6 +4466,9 @@ function AppleMusicView({
   const [busy, setBusy] = useState<
     "auth" | "logout" | "list" | "tracks" | null
   >(null);
+  // Default to the in-app browser sign-in; the manual header paste stays as a
+  // fallback for anyone whose login the embedded browser can't complete.
+  const [authMode, setAuthMode] = useState<"browser" | "manual">("browser");
   const [loadingPlaylistId, setLoadingPlaylistId] = useState<string | null>(
     null,
   );
@@ -4432,6 +4552,23 @@ function AppleMusicView({
       .catch((caught: unknown) => setError(toErrorMessage(caught)));
   }, [api]);
 
+  // The main process lifts credentials out of the embedded music.apple.com
+  // session and notifies us when they change (e.g. once the user signs in and
+  // the media-user-token first appears).
+  useEffect(() => {
+    if (!api) {
+      return;
+    }
+    return api.onAppleMusicAuthCaptured((next) => {
+      setStatus(next);
+      setNotice(
+        next.hasUserToken
+          ? "Apple Music connected — your library is ready."
+          : "Signed in to Apple Music.",
+      );
+    });
+  }, [api, setNotice]);
+
   useEffect(() => {
     if (status?.authenticated && status.hasUserToken) {
       void refreshPlaylists();
@@ -4480,6 +4617,11 @@ function AppleMusicView({
   if (!api) {
     return null;
   }
+
+  // A catalog-only credential (developer token without a media-user-token)
+  // isn't usefully connected — keep showing the sign-in flow so the user can
+  // finish logging in and capture the library token.
+  const connected = Boolean(status?.authenticated && status.hasUserToken);
 
   const selectedSummary = selectedId
     ? playlists.find((playlist) => playlist.id === selectedId)
@@ -4552,7 +4694,14 @@ function AppleMusicView({
     setBusy("logout");
     setError(null);
     try {
-      setStatus(await api.logoutAppleMusic());
+      // Clear the stored credentials *and* the persisted Apple Music browser
+      // session, otherwise the webview stays signed in and a fresh capture
+      // would silently reconnect the same account.
+      const [next] = await Promise.all([
+        api.logoutAppleMusic(),
+        api.resetAppleMusicBrowserSession(),
+      ]);
+      setStatus(next);
       setPlaylists([]);
       setSelectedId("");
       setDetailCache({});
@@ -4577,12 +4726,12 @@ function AppleMusicView({
     <div className="stack stack-fill">
       <section
         className={
-          status?.authenticated
+          connected
             ? "panel spotify-account-panel"
             : "panel spotify-account-panel music-connect-panel"
         }
       >
-        {status?.authenticated ? (
+        {connected ? (
           <div className="spotify-account-card apple-music-account-card">
             <div
               className="spotify-account-mark apple-music-account-mark"
@@ -4594,30 +4743,26 @@ function AppleMusicView({
               <p className="eyebrow">Apple Music</p>
               <h2>Connected</h2>
               <span>
-                {status.hasUserToken
-                  ? "Catalog + library access"
-                  : "Catalog access only"}
-                {status.authUpdatedAt
+                Catalog + library access
+                {status?.authUpdatedAt
                   ? ` · Saved ${formatDate(status.authUpdatedAt)}`
                   : ""}
               </span>
             </div>
             <div className="topbar-actions">
-              {status.hasUserToken ? (
-                <button
-                  className="primary-button"
-                  type="button"
-                  disabled={busy === "list"}
-                  onClick={() => void refreshPlaylists()}
-                >
-                  {busy === "list" ? (
-                    <Loader2 className="spin" size={17} aria-hidden="true" />
-                  ) : (
-                    <RefreshCw size={17} aria-hidden="true" />
-                  )}
-                  Refresh
-                </button>
-              ) : null}
+              <button
+                className="primary-button"
+                type="button"
+                disabled={busy === "list"}
+                onClick={() => void refreshPlaylists()}
+              >
+                {busy === "list" ? (
+                  <Loader2 className="spin" size={17} aria-hidden="true" />
+                ) : (
+                  <RefreshCw size={17} aria-hidden="true" />
+                )}
+                Refresh
+              </button>
               <button
                 className="secondary-button"
                 type="button"
@@ -4630,6 +4775,43 @@ function AppleMusicView({
                   <LogOut size={17} aria-hidden="true" />
                 )}
                 Disconnect
+              </button>
+            </div>
+          </div>
+        ) : authMode === "browser" ? (
+          <div className="youtube-music-connect youtube-music-connect--apple apple-music-signin">
+            <div className="youtube-music-connect-header">
+              <div
+                className="youtube-music-connect-mark apple-music-connect-mark"
+                aria-hidden="true"
+              >
+                <AppleBrandIcon size={28} />
+              </div>
+              <div className="youtube-music-connect-intro">
+                <p className="eyebrow">Apple Music</p>
+                <h2>Sign in to connect</h2>
+                <span>
+                  Sign in below, then open your <strong>Library</strong> —
+                  CorosLink captures the access it needs automatically. No
+                  DevTools and no Apple Developer account required.
+                </span>
+              </div>
+            </div>
+
+            <AppleMusicLoginBrowser />
+
+            <div className="apple-music-signin-footer">
+              <span className="youtube-music-connect-note">
+                Sign-in happens in a private, in-app Apple Music session. Your
+                credentials stay on this device and are only used to read
+                playlist metadata.
+              </span>
+              <button
+                className="text-button"
+                type="button"
+                onClick={() => setAuthMode("manual")}
+              >
+                Paste headers manually instead
               </button>
             </div>
           </div>
@@ -4651,6 +4833,15 @@ function AppleMusicView({
                 </span>
               </div>
             </div>
+
+            <button
+              className="text-button apple-music-signin-back"
+              type="button"
+              onClick={() => setAuthMode("browser")}
+            >
+              <ArrowLeft size={15} aria-hidden="true" />
+              Back to in-app sign in
+            </button>
 
             <ol className="youtube-music-steps">
               <li>
@@ -4726,20 +4917,7 @@ function AppleMusicView({
         )}
       </section>
 
-      {status?.authenticated && !status.hasUserToken ? (
-        <section className="panel youtube-music-empty">
-          <div className="empty-state">
-            <ListMusic size={26} aria-hidden="true" />
-            <strong>Library access needed</strong>
-            <span>
-              Re-copy your headers while signed in to music.apple.com so they
-              include the <code>media-user-token</code>, then reconnect.
-            </span>
-          </div>
-        </section>
-      ) : null}
-
-      {status?.authenticated && status.hasUserToken ? (
+      {connected ? (
         playlists.length === 0 ? (
           <section className="panel youtube-music-empty">
             <div className="empty-state">

--- a/src/coroslink-api.ts
+++ b/src/coroslink-api.ts
@@ -97,6 +97,10 @@ export interface CorosLinkApi {
   getAppleMusicStatus: () => Promise<AppleMusicStatus>;
   saveAppleMusicAuth: (headersRaw: string) => Promise<AppleMusicStatus>;
   logoutAppleMusic: () => Promise<AppleMusicStatus>;
+  resetAppleMusicBrowserSession: () => Promise<void>;
+  onAppleMusicAuthCaptured: (
+    callback: (status: AppleMusicStatus) => void
+  ) => () => void;
   listAppleMusicPlaylists: () => Promise<AppleMusicPlaylist[]>;
   fetchAppleMusicPlaylist: (playlist: string) => Promise<AppleMusicPlaylist>;
   getSpotifyConfig: () => Promise<SpotifyConfig>;

--- a/src/styles.css
+++ b/src/styles.css
@@ -10116,6 +10116,59 @@ td span {
   border: 0;
 }
 
+.apple-music-signin {
+  gap: 18px;
+}
+
+.apple-music-login {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: #0f0f0f;
+}
+
+.apple-music-login-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface-2, rgba(255, 255, 255, 0.02));
+}
+
+.apple-music-login-url {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+}
+
+.apple-music-login-frame {
+  flex: none;
+  height: clamp(440px, 64vh, 760px);
+  min-height: 440px;
+}
+
+.apple-music-signin-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.apple-music-signin-back {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .browser-download-overlay {
   position: absolute;
   top: 16px;


### PR DESCRIPTION
Replace the manual "copy request headers from DevTools" flow with an embedded music.apple.com sign-in. The main process hosts Apple Music in a dedicated persistent session and watches its amp-api traffic, lifting the developer token, media-user-token, and cookie automatically once the user signs in. The manual paste flow stays as a fallback.

- appleMusicBrowserService: dedicated session partition, Chrome UA, and a webRequest listener that captures auth headers from requests carrying a media-user-token (catalog-only requests are ignored).
- appleMusicService: merge captured headers with stored credentials without downgrading a known media-user-token; never persist a catalog-only credential.
- UI: embedded sign-in browser with reload/home/reset controls, treats "connected" as requiring the library token, and clears the browser session on disconnect.