### PR TITLE
Fix smoke-fixture temp directory leak on quit and crash

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -81,6 +81,8 @@ import type {
   YouTubeMusicConfig
 } from "./types";
 import {
+  cleanupStaleSmokeFixtures,
+  clearActiveSmokeFixtureSync,
   deleteWatchTrack,
   getWatchConnectionSmokeOption,
   getWatchStatus,
@@ -266,6 +268,7 @@ app.whenReady().then(() => {
     }
   });
   initializeDatabase(app.getPath("userData"));
+  void cleanupStaleSmokeFixtures();
   registerIpcHandlers();
   setJobListener((jobs) => {
     if (mainWindow && !mainWindow.isDestroyed()) {
@@ -300,6 +303,7 @@ app.on("window-all-closed", () => {
 
 app.on("before-quit", () => {
   stopRouteShare();
+  clearActiveSmokeFixtureSync();
 });
 
 function registerIpcHandlers(): void {

--- a/electron/watchService.ts
+++ b/electron/watchService.ts
@@ -489,6 +489,61 @@ async function clearActiveSmokeFixture(): Promise<void> {
   }
 }
 
+export function clearActiveSmokeFixtureSync(): void {
+  const tempRoot = activeSmokeTempRoot;
+  activeSmokeTempRoot = undefined;
+  activeSmokeWatchRoot = undefined;
+  activeSmokeTotalBytes = undefined;
+
+  if (tempRoot) {
+    try {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    } catch {
+      // Cleanup must never block quit.
+    }
+  }
+}
+
+const SMOKE_FIXTURE_PREFIXES = ["coroslink-watch-smoke-", "coros-watch-smoke-"];
+const STALE_SMOKE_FIXTURE_MIN_AGE_MS = 15 * 60 * 1000;
+
+export async function cleanupStaleSmokeFixtures(): Promise<void> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(os.tmpdir(), { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  const now = Date.now();
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    if (!SMOKE_FIXTURE_PREFIXES.some((prefix) => entry.name.startsWith(prefix))) {
+      continue;
+    }
+
+    const fixturePath = path.join(os.tmpdir(), entry.name);
+    if (fixturePath === activeSmokeTempRoot) {
+      continue;
+    }
+
+    try {
+      const stats = await fs.promises.stat(fixturePath);
+      // A recent mtime may belong to another running instance's fixture.
+      if (now - stats.mtimeMs < STALE_SMOKE_FIXTURE_MIN_AGE_MS) {
+        continue;
+      }
+
+      await fs.promises.rm(fixturePath, { recursive: true, force: true });
+    } catch {
+      // Cleanup must never block startup.
+    }
+  }
+}
+
 function restoreOriginalWatchPathOverride(): void {
   if (ORIGINAL_COROS_WATCH_PATH) {
     process.env.COROS_WATCH_PATH = ORIGINAL_COROS_WATCH_PATH;

--- a/scripts/smoke-watch-service.mjs
+++ b/scripts/smoke-watch-service.mjs
@@ -237,6 +237,49 @@ async function runNomadSmoke() {
   }
 }
 
+async function runStaleFixtureCleanupSmoke() {
+  const staleRoot = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), "coroslink-watch-smoke-stale-")
+  );
+  const freshRoot = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), "coroslink-watch-smoke-fresh-")
+  );
+
+  try {
+    await fs.promises.writeFile(path.join(staleRoot, "leftover.map"), "map");
+    const agedTime = new Date(Date.now() - 60 * 60 * 1000);
+    await fs.promises.utimes(staleRoot, agedTime, agedTime);
+
+    const { cleanupStaleSmokeFixtures } = await loadWatchService();
+    await cleanupStaleSmokeFixtures();
+
+    assert.equal(fs.existsSync(staleRoot), false, "stale fixture swept");
+    assert.equal(fs.existsSync(freshRoot), true, "fresh fixture kept");
+  } finally {
+    await fs.promises.rm(staleRoot, { recursive: true, force: true });
+    await fs.promises.rm(freshRoot, { recursive: true, force: true });
+  }
+}
+
+async function runSyncClearSmoke() {
+  const { clearActiveSmokeFixtureSync, setWatchConnectionSmokeOption } =
+    await loadWatchService();
+
+  try {
+    const status = await setWatchConnectionSmokeOption("pace-pro");
+    assert.equal(status.connected, true);
+    assert.ok(status.rootPath, "fixture root path set");
+
+    const tempRoot = path.dirname(status.rootPath);
+    assert.equal(fs.existsSync(tempRoot), true, "fixture exists before clear");
+
+    clearActiveSmokeFixtureSync();
+    assert.equal(fs.existsSync(tempRoot), false, "fixture removed by sync clear");
+  } finally {
+    delete process.env.COROS_WATCH_PATH;
+  }
+}
+
 await runPaceProSmoke();
 await runPace4Smoke();
 await runPace3Smoke();
@@ -246,5 +289,7 @@ await runPace3NameVariantSmoke("PACE-3", "pace-3-hyphen");
 await runPace3NameVariantSmoke("PACE3", "pace-3-compact");
 await runAmbiguousCorosPaceSmoke();
 await runInstallerVolumeIgnoredSmoke();
+await runStaleFixtureCleanupSmoke();
+await runSyncClearSmoke();
 
 console.log("Watch service smoke checks passed.");


### PR DESCRIPTION
## Problem

The watch-connection smoke feature builds fake watch volumes under `os.tmpdir()`, but `clearActiveSmokeFixture` only runs when switching smoke options within a live session — nothing cleans up on app quit, and nothing recovers from a killed or crashed session. Because map installs write real map packages into the fake watch, one orphaned fixture can reach several gigabytes.

Hit this in practice today: a dev session that got SIGTERM'd left a 4.7 GB `coroslink-watch-smoke-nomad-*` directory behind, which filled the 6.3 GB `/tmp` tmpfs on Fedora and started failing unrelated tools with "Disk quota exceeded".

## Fix

- **`cleanupStaleSmokeFixtures()`** (new) — runs at app startup via `app.whenReady()`; sweeps leftover `coros(link)-watch-smoke-*` directories from `os.tmpdir()`. Skips the active fixture and anything modified in the last 15 minutes (protects a concurrently running second instance). Per-directory try/catch — cleanup never blocks startup. Covers crash/SIGKILL leaks from any prior run, including ones from `scripts/smoke-watch-service.mjs`.
- **`clearActiveSmokeFixtureSync()`** (new) — synchronous twin of the existing async cleanup, called from the existing `before-quit` handler (Electron won't await a promise there). Covers clean exits.

## Tests

`scripts/smoke-watch-service.mjs` gains two checks: an aged fake fixture is swept while a fresh one is kept, and the sync clear removes a live `pace-pro` fixture created through the real `setWatchConnectionSmokeOption` path.

`npm run build:electron` typechecks clean; `npm run smoke:watch` (including the new checks) and `npm run test:watch-models` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)