### PR TITLE
Show track counts in Apple Music playlist list (#17)

### DIFF
--- a/electron/appleMusicService.ts
+++ b/electron/appleMusicService.ts
@@ -149,6 +149,7 @@ export async function listAppleMusicPlaylists(): Promise<AppleMusicPlaylist[]> {
         lastModifiedAt: attributes.lastModifiedDate,
         artworkUrl: buildArtworkUrl(attributes.artwork),
         url: attributes.url,
+        // The library playlists collection omits trackCount; filled in below.
         trackCount: attributes.trackCount ?? 0,
         tracks: []
       });
@@ -157,8 +158,47 @@ export async function listAppleMusicPlaylists(): Promise<AppleMusicPlaylist[]> {
     path = page.next;
   }
 
+  // The collection endpoint can't include the `tracks` relationship, so fetch
+  // each playlist's total separately (a tiny limit=1 call that returns
+  // `meta.total`). Best-effort + bounded concurrency so it never blocks or
+  // breaks the listing.
+  await fillLibraryPlaylistTrackCounts(playlists, credentials);
+
   return playlists.sort((left, right) =>
     left.name.localeCompare(right.name, undefined, { sensitivity: "base" })
+  );
+}
+
+/** Populates `trackCount` for each playlist via its tracks relationship total. */
+async function fillLibraryPlaylistTrackCounts(
+  playlists: AppleMusicPlaylist[],
+  credentials: AppleMusicCredentials
+): Promise<void> {
+  const CONCURRENCY = 8;
+  let cursor = 0;
+
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const index = cursor++;
+      if (index >= playlists.length) return;
+      const playlist = playlists[index];
+      if (playlist.trackCount > 0) continue;
+      try {
+        const response = await ampApiGet<AmpResponse<AmpTrack>>(
+          `/v1/me/library/playlists/${encodeURIComponent(playlist.id)}/tracks?limit=1`,
+          {},
+          credentials
+        );
+        playlist.trackCount = response.meta?.total ?? playlist.trackCount;
+      } catch {
+        // Best-effort: leave the count at 0 if this playlist can't be read
+        // (e.g. an empty playlist returns 404 for its tracks relationship).
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, playlists.length) }, worker)
   );
 }
 
@@ -617,6 +657,7 @@ function tokenizeShellCommand(input: string): string[] {
 interface AmpResponse<T> {
   data?: T[];
   next?: string;
+  meta?: { total?: number };
 }
 
 interface AmpPlaylist {
@@ -634,6 +675,9 @@ interface AmpPlaylist {
     tracks?: {
       data?: AmpTrack[];
       next?: string;
+      // Library playlist relationships include the full track total even when
+      // only the first page of `data` is returned.
+      meta?: { total?: number };
     };
   };
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5189,30 +5189,36 @@ function AppleMusicView({
                 <span className="count-pill">{playlists.length}</span>
               </div>
               <div className="playlist-list">
-                {playlists.map((entry) => (
-                  <button
-                    key={entry.id}
-                    className={
-                      entry.id === selectedId
-                        ? "playlist-button apple-music-playlist-button active"
-                        : "playlist-button apple-music-playlist-button"
-                    }
-                    type="button"
-                    onClick={() => void handleSelectPlaylist(entry.id)}
-                  >
-                    <AppleMusicArtwork
-                      className="apple-music-playlist-thumb"
-                      artworkUrl={entry.artworkUrl}
-                    />
-                    <span className="apple-music-playlist-copy">
-                      <strong>{entry.name}</strong>
-                      <span>
-                        {entry.trackCount} track
-                        {entry.trackCount === 1 ? "" : "s"}
+                {playlists.map((entry) => {
+                  // Once a playlist has been opened, its cached detail has the
+                  // exact count (tracks.length); prefer it over the list value.
+                  const trackCount =
+                    detailCache[entry.id]?.trackCount ?? entry.trackCount;
+                  return (
+                    <button
+                      key={entry.id}
+                      className={
+                        entry.id === selectedId
+                          ? "playlist-button apple-music-playlist-button active"
+                          : "playlist-button apple-music-playlist-button"
+                      }
+                      type="button"
+                      onClick={() => void handleSelectPlaylist(entry.id)}
+                    >
+                      <AppleMusicArtwork
+                        className="apple-music-playlist-thumb"
+                        artworkUrl={entry.artworkUrl}
+                      />
+                      <span className="apple-music-playlist-copy">
+                        <strong>{entry.name}</strong>
+                        <span>
+                          {trackCount} track
+                          {trackCount === 1 ? "" : "s"}
+                        </span>
                       </span>
-                    </span>
-                  </button>
-                ))}
+                    </button>
+                  );
+                })}
               </div>
             </aside>
 


### PR DESCRIPTION
The library playlists collection endpoint omits `trackCount`, and Apple rejects `include=tracks` on a collection fetch ("may only be activated with a single resource fetch"), so the left-hand playlist list always showed 0 tracks even though the detail view had the count.

Fetch each playlist's total separately via its tracks relationship (`/tracks?limit=1` → `meta.total`), run best-effort with bounded concurrency so it never blocks or breaks the listing. The list render also prefers a cached detail's exact count once a playlist is opened.

## Description
<!-- Briefly describe what this PR does and why -->


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement / enhancement
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [ ] Breaking change

## How to Test
<!-- Steps to verify your changes work correctly -->
1. 
2. 

## Checklist
- [x] I have tested my changes
- [ ] My changes do not break existing functionality
- [ ] I have added comments where necessary
