### PR TITLE
Fix COROS Training Hub re-auth race and add Reconnect action

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -36,6 +36,7 @@ import {
   listTrainingHubActivities,
   loginTrainingHub,
   logoutTrainingHub,
+  reconnectTrainingHub,
   uploadTrainingPlan
 } from "./trainingHubService";
 import {
@@ -659,6 +660,8 @@ function registerIpcHandlers(): void {
   );
 
   ipcMain.handle("trainingHub:logout", () => logoutTrainingHub());
+
+  ipcMain.handle("trainingHub:reconnect", () => reconnectTrainingHub());
 
   ipcMain.handle(
     "trainingHub:listActivities",

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -235,6 +235,8 @@ const api = {
     ipcRenderer.invoke("trainingHub:login", email, password, remember),
   logoutTrainingHub: (): Promise<TrainingHubStatus> =>
     ipcRenderer.invoke("trainingHub:logout"),
+  reconnectTrainingHub: (): Promise<TrainingHubStatus> =>
+    ipcRenderer.invoke("trainingHub:reconnect"),
   listTrainingHubActivities: (
     page: number,
     size: number

--- a/electron/trainingHubService.ts
+++ b/electron/trainingHubService.ts
@@ -377,6 +377,21 @@ export function logoutTrainingHub(): TrainingHubStatus {
   return getTrainingHubStatus();
 }
 
+/**
+ * Re-establish a COROS session from the stored (encrypted) credentials without
+ * asking the user to re-enter their password. Used by the "Reconnect" action
+ * when the access token has expired but remembered credentials are available.
+ */
+export async function reconnectTrainingHub(): Promise<TrainingHubStatus> {
+  const session = await reauthenticateFromStoredCredentials();
+  if (!session) {
+    throw new Error(
+      "Couldn't reconnect with saved credentials. Please log in again."
+    );
+  }
+  return getTrainingHubStatus();
+}
+
 export async function listTrainingHubActivities(
   page = 1,
   size = 50
@@ -4161,7 +4176,15 @@ async function recoverExpiredTrainingHubSession<T>(
     throw new Error("COROS session expired. Log in again.");
   }
 
-  return executeTrainingHubRequest<T>(refreshed, path, options);
+  try {
+    return await executeTrainingHubRequest<T>(refreshed, path, options);
+  } catch (error) {
+    if (getTrainingHubRetryReason(error) === "token") {
+      clearTrainingHubAuth();
+      throw new Error("COROS session expired. Log in again.");
+    }
+    throw error;
+  }
 }
 
 async function executeTrainingHubRequest<T>(
@@ -4374,6 +4397,11 @@ function clearTrainingHubAuth(): void {
 
 function storeCredentials(account: string, pwdHash: string): boolean {
   if (!safeStorage.isEncryptionAvailable()) {
+    console.warn(
+      "[trainingHub] Cannot remember COROS credentials: OS secure storage " +
+        "(safeStorage) is unavailable. The access token will still be saved, " +
+        "but the session cannot be refreshed automatically once it expires."
+    );
     return false;
   }
 
@@ -4385,7 +4413,12 @@ function storeCredentials(account: string, pwdHash: string): boolean {
     const encrypted = safeStorage.encryptString(blob).toString("base64");
     setSetting(SETTINGS.credentials, encrypted);
     return true;
-  } catch {
+  } catch (error) {
+    console.warn(
+      "[trainingHub] Failed to encrypt and store COROS credentials; " +
+        "automatic session refresh will not be available.",
+      error
+    );
     return false;
   }
 }
@@ -4414,9 +4447,31 @@ function clearStoredCredentials(): void {
   deleteSettings([SETTINGS.credentials]);
 }
 
-async function reauthenticateFromStoredCredentials(): Promise<TrainingHubAuthState | null> {
+// A single in-flight re-authentication shared by all concurrent callers.
+// When a token expires, every parallel request would otherwise trigger its own
+// full COROS login; because COROS invalidates the previous token each time a new
+// one is minted, those concurrent logins cannibalise each other and the retried
+// requests end up using an already-stale token. De-duplicating re-auth here means
+// all callers await the same login and reuse the same fresh token.
+let pendingReauth: Promise<TrainingHubAuthState | null> | null = null;
+
+function reauthenticateFromStoredCredentials(): Promise<TrainingHubAuthState | null> {
+  if (!pendingReauth) {
+    pendingReauth = performReauthentication().finally(() => {
+      pendingReauth = null;
+    });
+  }
+  return pendingReauth;
+}
+
+async function performReauthentication(): Promise<TrainingHubAuthState | null> {
   const credentials = getStoredCredentials();
   if (!credentials) {
+    console.warn(
+      "[trainingHub] COROS access token expired but no stored credentials " +
+        "are available to refresh it (was 'Remember me' enabled and is secure " +
+        "storage available?). The user must log in again."
+    );
     return null;
   }
 
@@ -4427,7 +4482,12 @@ async function reauthenticateFromStoredCredentials(): Promise<TrainingHubAuthSta
     );
     persistTrainingHubSession(session);
     return session;
-  } catch {
+  } catch (error) {
+    console.warn(
+      "[trainingHub] Automatic re-login with stored COROS credentials failed; " +
+        "the user must log in again.",
+      error
+    );
     return null;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -895,6 +895,27 @@ export default function App() {
     }
   }
 
+  async function handleTrainingHubReconnect() {
+    if (!api) {
+      return;
+    }
+
+    setBusy("training-reconnect");
+    setError(null);
+    setMessage(null);
+
+    try {
+      const status = await api.reconnectTrainingHub();
+      setTrainingHubStatus(status);
+      setMessage("COROS Training Hub reconnected.");
+      await loadTrainingHubData();
+    } catch (caught) {
+      setError(toErrorMessage(caught));
+    } finally {
+      setBusy(null);
+    }
+  }
+
   async function handleTrainingHubLogout() {
     if (!api) {
       return;
@@ -1579,6 +1600,7 @@ export default function App() {
                 onPasswordChange={setTrainingHubPassword}
                 onRememberChange={setTrainingHubRemember}
                 onLogin={handleTrainingHubLogin}
+                onReconnect={handleTrainingHubReconnect}
                 onLogout={handleTrainingHubLogout}
                 onRefresh={handleTrainingHubRefresh}
                 onLoadDetail={handleTrainingHubActivityDetail}

--- a/src/coroslink-api.ts
+++ b/src/coroslink-api.ts
@@ -154,6 +154,7 @@ export interface CorosLinkApi {
     remember: boolean
   ) => Promise<TrainingHubStatus>;
   logoutTrainingHub: () => Promise<TrainingHubStatus>;
+  reconnectTrainingHub: () => Promise<TrainingHubStatus>;
   listTrainingHubActivities: (
     page: number,
     size: number

--- a/src/styles.css
+++ b/src/styles.css
@@ -4537,6 +4537,38 @@ td span {
   line-height: 1.45;
 }
 
+.training-login-reconnect {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(120, 170, 255, 0.35);
+  background: rgba(80, 130, 240, 0.14);
+}
+
+.training-login-reconnect-text {
+  display: grid;
+  gap: 2px;
+}
+
+.training-login-reconnect-text strong {
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 14px;
+  font-weight: 800;
+}
+
+.training-login-reconnect-text small {
+  color: rgba(245, 245, 247, 0.66);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.training-login-reconnect .primary-button {
+  flex-shrink: 0;
+}
+
 .training-login-fields {
   display: grid;
   gap: 17px;

--- a/src/training/TrainingHubView.tsx
+++ b/src/training/TrainingHubView.tsx
@@ -49,12 +49,16 @@ export function TrainingHubView({
   onPasswordChange,
   onRememberChange,
   onLogin,
+  onReconnect,
   onLogout,
   onRefresh,
   onLoadDetail,
   onExportFile
 }: TrainingHubViewProps) {
   const connected = Boolean(status?.authenticated);
+  const canReconnect =
+    !connected && Boolean(status?.rememberCredentials) && Boolean(status?.email);
+  const reconnecting = busy === "training-reconnect";
   const [showConnectionDetails, setShowConnectionDetails] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const signInBackgroundStyle = connected
@@ -225,6 +229,31 @@ export function TrainingHubView({
                 <strong>Welcome back</strong>
                 <p>Sign in to access your COROS Training Hub data</p>
               </div>
+
+              {canReconnect ? (
+                <div className="training-login-reconnect">
+                  <div className="training-login-reconnect-text">
+                    <strong>Signed in as {status?.email}</strong>
+                    <small>
+                      Your session expired. Reconnect using your saved
+                      credentials — no password needed.
+                    </small>
+                  </div>
+                  <button
+                    className="primary-button"
+                    type="button"
+                    onClick={onReconnect}
+                    disabled={reconnecting}
+                  >
+                    {reconnecting ? (
+                      <Loader2 className="spin" size={17} aria-hidden="true" />
+                    ) : (
+                      <RefreshCw size={17} aria-hidden="true" />
+                    )}
+                    Reconnect
+                  </button>
+                </div>
+              ) : null}
 
               <div className="training-login-fields">
                 <label className="field training-login-field">

--- a/src/training/types.ts
+++ b/src/training/types.ts
@@ -85,6 +85,7 @@ export interface TrainingHubViewProps {
   onPasswordChange: (value: string) => void;
   onRememberChange: (value: boolean) => void;
   onLogin: (event: FormEvent<HTMLFormElement>) => void;
+  onReconnect: () => void;
   onLogout: () => void;
   onRefresh: () => void;
   onLoadDetail: (activity: TrainingHubActivity) => void;


### PR DESCRIPTION
When the COROS access token expired, every parallel Training Hub request independently triggered a full re-login. COROS invalidates the previous token whenever a new one is minted, so the concurrent logins cannibalised each other and the retried requests failed with a raw InvalidTrainingHubTokenError.

- De-duplicate concurrent re-authentication behind a single in-flight promise so all callers reuse the same fresh token.
- Guard the retried request after re-auth: if the fresh token is still rejected, clear the session and surface a clean "log in again" message instead of leaking the raw token error.
- Warn when credentials cannot be stored (safeStorage unavailable / encrypt failure) or when re-auth cannot run, so silent no-ops are visible.
- Add a one-click "Reconnect" action (service + IPC + preload + UI banner) that re-establishes the session from stored credentials without retyping the password.

## Description
<!-- Briefly describe what this PR does and why -->


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement / enhancement
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [ ] Breaking change

## How to Test
<!-- Steps to verify your changes work correctly -->
1. 
2. 

## Checklist
- [x] I have tested my changes
- [ ] My changes do not break existing functionality
- [ ] I have added comments where necessary
