### PR TITLE
Calendar: per-sport activity colors, customizable in Settings

### DIFF
--- a/docs/superpowers/plans/2026-07-10-calendar-activity-colors.md
+++ b/docs/superpowers/plans/2026-07-10-calendar-activity-colors.md
@@ -1,0 +1,353 @@
+# Per-sport Activity Colors — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Color each Calendar activity chip by sport via a semi-transparent right-side liseré, with the five colors user-customizable in Settings and persisted in localStorage.
+
+**Architecture:** A pure `sportColors` module owns categorization, defaults, localStorage read/write, and CSS-variable application. The renderer applies the stored colors as `--sport-*` custom properties at boot; DayCell tags each activity chip with a `calendar-sport-<cat>` class; CSS draws the right liseré via `color-mix`. A Settings card edits the colors and re-applies them live.
+
+**Tech Stack:** React 19 renderer, TypeScript, CSS custom properties + `color-mix`, `localStorage`. No new dependencies.
+
+## Global Constraints
+
+- **No new runtime dependencies.**
+- **Renderer UI preference persistence via `localStorage`** (key `coroslink.sportColors`) applied as CSS vars on `document.documentElement`, mirroring the theme — NOT backend/SQLite/IPC.
+- **Do not touch** the existing planned-workout left-border categories (`calendar-cat-*` / `inferUpcomingWorkoutCategory`) — that is workout-type coloring on the LEFT border and is unrelated.
+- **Five categories, fixed keys:** `strength`, `trail`, `run`, `bike`, `other`. Defaults: `#e5484d`, `#4c8dff`, `#2fbe91`, `#e6b800`, `#7fd8cf`.
+- **Visual:** keep the existing left gray border; add a RIGHT border liseré at ~60% opacity via `color-mix(in srgb, var(--sport-<cat>) 60%, transparent)`.
+- **Renderer test convention:** `.ts` source is imported directly by a `scripts/test-<name>.mjs` run with `node --experimental-strip-types` (see `scripts/test-greetings.mjs` / `package.json` `test:greetings`) — no build step needed for a self-contained src module. Use `node:assert/strict`, print `<name> tests passed`.
+
+---
+
+### Task 1: `sportColors` module
+
+**Files:**
+- Create: `src/calendar/sportColors.ts`
+- Test: `scripts/test-sport-colors.mjs`
+- Modify: `package.json` (add `test:sport-colors`)
+
+**Interfaces:**
+- Produces: `SportColorCategory`, `SPORT_COLOR_CATEGORIES`, `DEFAULT_SPORT_COLORS`, `SPORT_COLOR_LABELS`, `sportColorCategory(name)`, `parseSportColors(raw)`, `readStoredSportColors()`, `storeSportColors(colors)`, `applySportColors(colors)`.
+
+- [ ] **Step 1: Write the failing test.** Create `scripts/test-sport-colors.mjs`:
+
+```js
+import assert from "node:assert/strict";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const modUrl = pathToFileURL(
+  path.join(repoRoot, "src", "calendar", "sportColors.ts")
+);
+const { sportColorCategory, parseSportColors, DEFAULT_SPORT_COLORS } =
+  await import(`${modUrl.href}?c=${Date.now()}`);
+
+// Categorization (trail before run; bike before run; French + English names).
+assert.equal(sportColorCategory("TrailRun"), "trail");
+assert.equal(sportColorCategory("Morning Trail Run"), "trail");
+assert.equal(sportColorCategory("Run"), "run");
+assert.equal(sportColorCategory("Lunch Trail Run"), "trail");
+assert.equal(sportColorCategory("Lunch Cyclisme"), "bike");
+assert.equal(sportColorCategory("VirtualRide"), "bike");
+assert.equal(sportColorCategory("Evening Vélo"), "bike");
+assert.equal(sportColorCategory("WeightTraining"), "strength");
+assert.equal(sportColorCategory("Afternoon Musculation"), "strength");
+assert.equal(sportColorCategory("Afternoon Entraînement"), "strength");
+assert.equal(sportColorCategory("Workout"), "strength");
+assert.equal(sportColorCategory("Pool Swim"), "other");
+assert.equal(sportColorCategory(""), "other");
+assert.equal(sportColorCategory(undefined), "other");
+
+// parseSportColors: merge partial over defaults, ignore invalid, malformed → defaults.
+assert.deepEqual(parseSportColors(null), DEFAULT_SPORT_COLORS);
+assert.equal(parseSportColors('{"run":"#123456"}').run, "#123456");
+assert.equal(
+  parseSportColors('{"run":"#123456"}').trail,
+  DEFAULT_SPORT_COLORS.trail
+);
+assert.equal(
+  parseSportColors('{"run":"not-a-color"}').run,
+  DEFAULT_SPORT_COLORS.run
+);
+assert.deepEqual(parseSportColors("{malformed"), DEFAULT_SPORT_COLORS);
+
+console.log("sport-colors tests passed");
+```
+
+- [ ] **Step 2: Add the script to package.json:**
+```json
+"test:sport-colors": "node --experimental-strip-types scripts/test-sport-colors.mjs",
+```
+
+- [ ] **Step 3: Run test to verify it fails.** `npm run test:sport-colors` → module not found (`src/calendar/sportColors.ts` missing).
+
+- [ ] **Step 4: Implement.** Create `src/calendar/sportColors.ts`:
+
+```ts
+export type SportColorCategory = "strength" | "trail" | "run" | "bike" | "other";
+
+export const SPORT_COLOR_CATEGORIES: SportColorCategory[] = [
+  "strength",
+  "trail",
+  "run",
+  "bike",
+  "other"
+];
+
+export const DEFAULT_SPORT_COLORS: Record<SportColorCategory, string> = {
+  strength: "#e5484d",
+  trail: "#4c8dff",
+  run: "#2fbe91",
+  bike: "#e6b800",
+  other: "#7fd8cf"
+};
+
+export const SPORT_COLOR_LABELS: Record<SportColorCategory, string> = {
+  strength: "Strength / Gym",
+  trail: "Trail",
+  run: "Running",
+  bike: "Cycling",
+  other: "Other"
+};
+
+const STORAGE_KEY = "coroslink.sportColors";
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+/** Categorize an activity by sport name. Trail and bike are checked before run
+ *  so "TrailRun"/"VirtualRide" don't fall into run. Matches FR + EN names. */
+export function sportColorCategory(
+  name: string | undefined
+): SportColorCategory {
+  const n = (name ?? "").toLowerCase();
+  if (!n) return "other";
+  if (/trail/.test(n)) return "trail";
+  if (/(bike|cycl|ride|v[ée]lo|spin)/.test(n)) return "bike";
+  if (/(run|jog|course|marathon|tempo|track|\d+\s?k\b)/.test(n)) return "run";
+  if (/(muscu|weight|strength|gym|\bcore\b|workout|entra[iî]n)/.test(n)) {
+    return "strength";
+  }
+  return "other";
+}
+
+/** Parse a stored JSON blob, merging valid hex values over the defaults. */
+export function parseSportColors(
+  raw: string | null
+): Record<SportColorCategory, string> {
+  const result = { ...DEFAULT_SPORT_COLORS };
+  if (!raw) return result;
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    for (const cat of SPORT_COLOR_CATEGORIES) {
+      const value = parsed[cat];
+      if (typeof value === "string" && HEX_RE.test(value)) {
+        result[cat] = value;
+      }
+    }
+  } catch {
+    // malformed → defaults
+  }
+  return result;
+}
+
+export function readStoredSportColors(): Record<SportColorCategory, string> {
+  const raw =
+    typeof localStorage !== "undefined"
+      ? localStorage.getItem(STORAGE_KEY)
+      : null;
+  return parseSportColors(raw);
+}
+
+export function storeSportColors(
+  colors: Record<SportColorCategory, string>
+): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(colors));
+  } catch {
+    // storage unavailable — ignore
+  }
+}
+
+/** Set --sport-<cat> custom properties on the document root. */
+export function applySportColors(
+  colors: Record<SportColorCategory, string>
+): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  for (const cat of SPORT_COLOR_CATEGORIES) {
+    root.style.setProperty(`--sport-${cat}`, colors[cat]);
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes.** `npm run test:sport-colors` → `sport-colors tests passed`
+
+- [ ] **Step 6: Commit.**
+```bash
+git add src/calendar/sportColors.ts scripts/test-sport-colors.mjs package.json
+git commit -m "feat: add sportColors module (categorization + persistence)"
+```
+
+---
+
+### Task 2: Apply colors to Calendar chips (boot + DayCell + CSS)
+
+**Files:**
+- Modify: `src/main.tsx` (apply stored colors at boot)
+- Modify: `src/calendar/DayCell.tsx` (tag activity chips with `calendar-sport-<cat>`)
+- Modify: `src/styles.css` (`:root` defaults + right liseré rules)
+
+**Interfaces:**
+- Consumes: `sportColorCategory`, `readStoredSportColors`, `applySportColors` (Task 1).
+
+- [ ] **Step 1: Apply colors at boot in `src/main.tsx`.** Near the top-level render (before `createRoot(...).render(...)`), add:
+
+```ts
+import { applySportColors, readStoredSportColors } from "./calendar/sportColors";
+
+applySportColors(readStoredSportColors());
+```
+(Place the call after imports, before the render call so the `--sport-*` vars exist on first paint. If the theme is applied here too, colocate with it.)
+
+- [ ] **Step 2: Tag activity chips in `src/calendar/DayCell.tsx`.**
+  - Add the import: `import { sportColorCategory } from "./sportColors";`
+  - Add a helper near the existing `categoryClass`:
+    ```ts
+    function sportChipClass(name: string | undefined): string {
+      return `calendar-sport-${sportColorCategory(name)}`;
+    }
+    ```
+  - On the **unplanned activity** chip, change:
+    ```tsx
+    className="calendar-chip calendar-chip-activity"
+    ```
+    to:
+    ```tsx
+    className={`calendar-chip calendar-chip-activity ${sportChipClass(
+      activity.sportName ?? activity.name
+    )}`}
+    ```
+  - On the **PairChip completed-activity** branch (the `if (activity) { ... }` button, currently `className={`calendar-chip calendar-chip-paired ${categoryClass(scheduled.name)}`}`), append the sport class from the ACTUAL activity:
+    ```tsx
+    className={`calendar-chip calendar-chip-paired ${categoryClass(
+      scheduled.name
+    )} ${sportChipClass(activity.sportName ?? activity.name)}`}
+    ```
+  Leave the planned-only chip (`calendar-chip-planned`) untouched.
+
+- [ ] **Step 3: Add CSS in `src/styles.css`.** Add the defaults to the existing `:root` block (near the other color tokens, e.g. after `--accent-gold`):
+
+```css
+  --sport-strength: #e5484d;
+  --sport-trail: #4c8dff;
+  --sport-run: #2fbe91;
+  --sport-bike: #e6b800;
+  --sport-other: #7fd8cf;
+```
+
+Then add, next to the existing `.calendar-cat-*` rules (near the end of the calendar styles):
+
+```css
+.calendar-chip-activity,
+.calendar-chip-paired {
+  border-right: 3px solid transparent;
+}
+.calendar-sport-strength { border-right-color: color-mix(in srgb, var(--sport-strength) 60%, transparent); }
+.calendar-sport-trail    { border-right-color: color-mix(in srgb, var(--sport-trail) 60%, transparent); }
+.calendar-sport-run      { border-right-color: color-mix(in srgb, var(--sport-run) 60%, transparent); }
+.calendar-sport-bike     { border-right-color: color-mix(in srgb, var(--sport-bike) 60%, transparent); }
+.calendar-sport-other    { border-right-color: color-mix(in srgb, var(--sport-other) 60%, transparent); }
+```
+
+- [ ] **Step 4: Build the renderer to verify it compiles.** `npm run build:renderer` → no TypeScript errors.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add src/main.tsx src/calendar/DayCell.tsx src/styles.css
+git commit -m "feat: render per-sport right liseré on calendar activity chips"
+```
+
+---
+
+### Task 3: "Activity colors" card in Settings
+
+**Files:**
+- Modify: `src/settings/SettingsView.tsx`
+- Modify: `src/styles.css` (small styles for the color rows/preview, reusing existing settings-card classes where possible)
+
+**Interfaces:**
+- Consumes: `SPORT_COLOR_CATEGORIES`, `SPORT_COLOR_LABELS`, `DEFAULT_SPORT_COLORS`, `readStoredSportColors`, `storeSportColors`, `applySportColors`, `SportColorCategory` (Task 1).
+
+- [ ] **Step 1: Read the existing SettingsView card structure** so the new card matches the sibling cards' markup/classNames (headings, card container, layout). It renders a list of cards (About, app info, updates).
+
+- [ ] **Step 2: Add the "Activity colors" card.** In `src/settings/SettingsView.tsx`:
+  - Import: `import { SPORT_COLOR_CATEGORIES, SPORT_COLOR_LABELS, DEFAULT_SPORT_COLORS, readStoredSportColors, storeSportColors, applySportColors, type SportColorCategory } from "../calendar/sportColors";`
+  - State: `const [sportColors, setSportColors] = useState(() => readStoredSportColors());`
+  - Handler:
+    ```tsx
+    function updateSportColor(cat: SportColorCategory, value: string) {
+      const next = { ...sportColors, [cat]: value };
+      setSportColors(next);
+      storeSportColors(next);
+      applySportColors(next);
+    }
+    function resetSportColors() {
+      const next = { ...DEFAULT_SPORT_COLORS };
+      setSportColors(next);
+      storeSportColors(next);
+      applySportColors(next);
+    }
+    ```
+  - Render a card (matching the sibling cards) titled "Activity colors" with one row per `SPORT_COLOR_CATEGORIES`:
+    ```tsx
+    <div className="settings-card">
+      <h3>Activity colors</h3>
+      <p className="settings-card-hint">
+        Colors of the right edge of each activity in the calendar, by sport.
+      </p>
+      <div className="sport-color-rows">
+        {SPORT_COLOR_CATEGORIES.map((cat) => (
+          <label key={cat} className="sport-color-row">
+            <span
+              className={`calendar-chip calendar-chip-activity calendar-sport-${cat} sport-color-preview`}
+              aria-hidden="true"
+            >
+              <span className="calendar-chip-title">
+                <span className="calendar-chip-name">{SPORT_COLOR_LABELS[cat]}</span>
+              </span>
+            </span>
+            <input
+              type="color"
+              value={sportColors[cat]}
+              onChange={(e) => updateSportColor(cat, e.target.value)}
+              aria-label={`${SPORT_COLOR_LABELS[cat]} color`}
+            />
+          </label>
+        ))}
+      </div>
+      <button type="button" className="settings-secondary-button" onClick={resetSportColors}>
+        Reset to defaults
+      </button>
+    </div>
+    ```
+  Match the real card container class and button class used by the sibling cards (read them in Step 1 — the snippet's `settings-card`/`settings-secondary-button` names may differ; use the file's actual conventions).
+
+- [ ] **Step 3: Add minimal CSS in `src/styles.css`** for `.sport-color-rows` (vertical stack, gap), `.sport-color-row` (flex, space-between, align center), and `.sport-color-preview` (fixed small width, `cursor: default`). Reuse existing tokens (`--radius-sm`, spacing) and follow nearby settings styles.
+
+- [ ] **Step 4: Build the renderer.** `npm run build:renderer` → no TypeScript errors.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add src/settings/SettingsView.tsx src/styles.css
+git commit -m "feat: add Activity colors settings card"
+```
+
+---
+
+## Final validation gate (with user) then PR
+
+- [ ] `npm run test:sport-colors` passes; all previously-added `test:*` suites still pass.
+- [ ] `npm run build` (electron + renderer) clean.
+- [ ] Live (`npm run dev`): calendar activity chips show the right-side colored liseré per sport (spot-check a trail=blue, run=green, ride=yellow, strength=red, other=turquoise); the left gray/planned borders are unchanged.
+- [ ] In Settings → Activity colors: change a color → matching chips update live; **Reset** restores defaults; colors persist across an app restart.
+- [ ] Then fork is already set up (`fork` remote → GitjoPowershell); push `feat/calendar-activity-colors` and open the PR to `JunAkerBuilds/CorosLink`.

--- a/docs/superpowers/specs/2026-07-10-calendar-activity-colors-design.md
+++ b/docs/superpowers/specs/2026-07-10-calendar-activity-colors-design.md
@@ -1,0 +1,136 @@
+# Design — Per-sport activity colors in the Calendar
+
+**Date:** 2026-07-10
+**Status:** Approved (design phase). Branch `feat/calendar-activity-colors`.
+
+## Problem
+
+In the Calendar view (week/month), completed activities render as gray chips with a single green accent stripe on the left. There's no way to tell a run from a ride from a gym session at a glance. Add a **per-sport color** to each activity chip, shown as a **right-side colored liseré** (semi-transparent), with the colors **user-customizable in Settings**.
+
+## Scope (from brainstorming)
+
+- **Five sport categories, all user-customizable**, with these defaults:
+  | Category | Matches (sportName / name) | Default color |
+  |----------|----------------------------|---------------|
+  | `strength` | Musculation, Weight Training, Workout, Entraînement, gym, core | red `#e5484d` |
+  | `trail` | Trail (matched **before** run) | blue `#4c8dff` |
+  | `run` | Course, Run, jog, marathon, 5k/10k, tempo, track (non-trail) | green `#2fbe91` |
+  | `bike` | Vélo, Cyclisme, Ride, VirtualRide, bike, cycl, spin | yellow `#e6b800` |
+  | `other` | everything else | pastel turquoise `#7fd8cf` |
+- **Visual:** keep the existing left gray border unchanged; ADD a right-side colored liseré, ~60% opacity, in the sport color.
+- **Where editable:** a new "Activity colors" card in the existing Settings view (`src/settings/SettingsView.tsx`), with five `<input type="color">` swatches (label + a live preview chip) and a **Reset to defaults** button.
+- **Persistence:** `localStorage` (`coroslink.sportColors`), applied as CSS custom properties on `document.documentElement` (same approach as the theme). One color set, valid in both light and dark themes.
+- **Feature scope:** the Calendar view only — the completed-activity chips (unplanned activities and the actual activity inside planned/actual pairs). The existing planned-workout categories (`calendar-cat-*` on the LEFT border, based on workout *type* — Race/Long/Easy/Intervals) are unrelated and left untouched.
+
+## Non-goals
+
+- No change to the planned-workout left-border category coloring.
+- No backend/SQLite/IPC persistence — this is a renderer UI preference, stored client-side like the theme.
+- No per-theme color sets; no color for swim/walk as separate categories (folded into `other`).
+- No new runtime dependencies.
+
+## Architecture
+
+### `src/calendar/sportColors.ts` (new, pure + side-effecting apply)
+The single source of truth for categories, defaults, storage, and CSS application.
+
+```ts
+export type SportColorCategory = "strength" | "trail" | "run" | "bike" | "other";
+
+export const SPORT_COLOR_CATEGORIES: SportColorCategory[] =
+  ["strength", "trail", "run", "bike", "other"];
+
+export const DEFAULT_SPORT_COLORS: Record<SportColorCategory, string> = {
+  strength: "#e5484d",
+  trail: "#4c8dff",
+  run: "#2fbe91",
+  bike: "#e6b800",
+  other: "#7fd8cf"
+};
+
+export const SPORT_COLOR_LABELS: Record<SportColorCategory, string> = {
+  strength: "Strength / Gym",
+  trail: "Trail",
+  run: "Running",
+  bike: "Cycling",
+  other: "Other"
+};
+
+/** Categorize an activity by its sport name (trail checked before run). Pure. */
+export function sportColorCategory(name: string | undefined): SportColorCategory;
+
+/** localStorage read (merges stored over defaults; ignores malformed). */
+export function readStoredSportColors(): Record<SportColorCategory, string>;
+
+/** localStorage write. */
+export function storeSportColors(colors: Record<SportColorCategory, string>): void;
+
+/** Set --sport-<cat> custom properties on document.documentElement. */
+export function applySportColors(colors: Record<SportColorCategory, string>): void;
+```
+
+Categorization order (first match wins), against `(sportName ?? name ?? "").toLowerCase()`:
+1. `trail` — `/trail/`
+2. `bike` — `/(bike|cycl|ride|v[ée]lo|spin)/`
+3. `run` — `/(run|jog|course|marathon|tempo|track|\d+\s?k\b)/`
+4. `strength` — `/(muscu|weight|strength|gym|\bcore\b|workout|entra[iî]n)/`
+5. `other` — default
+
+(Order note: `trail` before `run` so "TrailRun" → trail; `bike` before `run` so nothing cross-matches; `strength` matches French "Musculation"/"Entraînement" and English "Weight Training"/"Workout".)
+
+### Boot application
+On app start (renderer entry `src/main.tsx`, or the top-level `App`), call `applySportColors(readStoredSportColors())` once so the CSS vars exist before the Calendar renders. The theme already applies at boot the same way — colocate.
+
+### `DayCell.tsx`
+Add a helper `sportChipClass(activity)` → `calendar-sport-${sportColorCategory(activity.sportName ?? activity.name)}` and append it to the className of:
+- the unplanned activity chip (`.calendar-chip-activity`), and
+- the completed-activity `PairChip` (the branch where `pair.activity` exists).
+
+### `styles.css`
+- Define defaults in `:root` (and they get overridden at runtime by `applySportColors`):
+  ```css
+  :root {
+    --sport-strength: #e5484d;
+    --sport-trail: #4c8dff;
+    --sport-run: #2fbe91;
+    --sport-bike: #e6b800;
+    --sport-other: #7fd8cf;
+  }
+  ```
+- Right-side liseré (kept transparent by default; colored per sport class):
+  ```css
+  .calendar-chip-activity { border-right: 3px solid transparent; }
+  .calendar-sport-strength { border-right-color: color-mix(in srgb, var(--sport-strength) 60%, transparent); }
+  .calendar-sport-trail    { border-right-color: color-mix(in srgb, var(--sport-trail) 60%, transparent); }
+  .calendar-sport-run      { border-right-color: color-mix(in srgb, var(--sport-run) 60%, transparent); }
+  .calendar-sport-bike     { border-right-color: color-mix(in srgb, var(--sport-bike) 60%, transparent); }
+  .calendar-sport-other    { border-right-color: color-mix(in srgb, var(--sport-other) 60%, transparent); }
+  ```
+  (`color-mix` is supported by the app's Chromium/Electron 42 runtime.)
+
+### `SettingsView.tsx`
+New "Activity colors" card: five rows, each a color `<input type="color">` bound to the category, its label, and a small preview chip using the live value. Editing updates React state → `storeSportColors` + `applySportColors` immediately (Calendar reflects it on next render / via the CSS vars). A **Reset to defaults** button restores `DEFAULT_SPORT_COLORS`.
+
+## Data flow
+
+```
+localStorage[coroslink.sportColors]
+      │ read at boot + on Settings mount
+      ▼
+applySportColors → :root { --sport-* }
+      │                         ▲
+      ▼                         │ Settings color pickers write + re-apply
+.calendar-sport-<cat> chips ────┘ (border-right color-mix)
+sportColorCategory(name) picks the class
+```
+
+## Error handling / edge cases
+
+- Malformed/missing localStorage → fall back to `DEFAULT_SPORT_COLORS` (merge per-key so a partial/old blob still yields all five).
+- Unknown/empty sport name → `other`.
+- Invalid hex from a color input can't occur (`<input type="color">` always yields `#rrggbb`); still, `applySportColors` only sets known keys.
+
+## Testing
+
+- **Unit** (`sportColors`): `sportColorCategory` mapping — TrailRun→trail, Run→run, Ride/VirtualRide/Cyclisme→bike, WeightTraining/Musculation/Entraînement/Workout→strength, Swim/unknown→other, empty→other; `readStoredSportColors` merges partial stored over defaults and ignores malformed JSON.
+- **Manual (UI):** change each color in Settings → the matching calendar chips' right liseré updates and persists across app restart; Reset restores defaults; existing left-border planned-workout colors unchanged.

--- a/docs/superpowers/specs/2026-07-10-calendar-activity-colors-design.md
+++ b/docs/superpowers/specs/2026-07-10-calendar-activity-colors-design.md
@@ -17,7 +17,7 @@ In the Calendar view (week/month), completed activities render as gray chips wit
   | `run` | Course, Run, jog, marathon, 5k/10k, tempo, track (non-trail) | green `#2fbe91` |
   | `bike` | Vélo, Cyclisme, Ride, VirtualRide, bike, cycl, spin | yellow `#e6b800` |
   | `other` | everything else | pastel turquoise `#7fd8cf` |
-- **Visual:** keep the existing left gray border unchanged; ADD a right-side colored liseré, ~60% opacity, in the sport color.
+- **Visual (revised after live review):** color the **left** border of the activity chip with the sport color, replacing the default green accent. (An earlier iteration added a semi-transparent right-side liseré; the user preferred moving the color to the existing left border instead and dropping the right stripe.) Applies to **unplanned** activity chips (the ones that showed the accent); planned/actual pair chips keep their existing workout-type left-border color.
 - **Where editable:** a new "Activity colors" card in the existing Settings view (`src/settings/SettingsView.tsx`), with five `<input type="color">` swatches (label + a live preview chip) and a **Reset to defaults** button.
 - **Persistence:** `localStorage` (`coroslink.sportColors`), applied as CSS custom properties on `document.documentElement` (same approach as the theme). One color set, valid in both light and dark themes.
 - **Feature scope:** the Calendar view only — the completed-activity chips (unplanned activities and the actual activity inside planned/actual pairs). The existing planned-workout categories (`calendar-cat-*` on the LEFT border, based on workout *type* — Race/Long/Easy/Intervals) are unrelated and left untouched.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:route-location": "node --experimental-strip-types scripts/test-route-location.mjs",
     "test:sketch": "npm run build:electron && node scripts/test-sketch-geometry.mjs",
     "test:greetings": "node --experimental-strip-types scripts/test-greetings.mjs",
+    "test:sport-colors": "node --experimental-strip-types scripts/test-sport-colors.mjs",
     "test:intervals-match": "npm run build:electron && node scripts/test-intervals-match.mjs",
     "test:chat-service": "npm run build:electron && node scripts/test-chat-service.mjs",
     "test:chat-history-store": "npm run build:electron && node scripts/test-chat-history-store.mjs",

--- a/scripts/test-sport-colors.mjs
+++ b/scripts/test-sport-colors.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const modUrl = pathToFileURL(
+  path.join(repoRoot, "src", "calendar", "sportColors.ts")
+);
+const { sportColorCategory, parseSportColors, DEFAULT_SPORT_COLORS } =
+  await import(`${modUrl.href}?c=${Date.now()}`);
+
+// Categorization (trail before run; bike before run; French + English names).
+assert.equal(sportColorCategory("TrailRun"), "trail");
+assert.equal(sportColorCategory("Morning Trail Run"), "trail");
+assert.equal(sportColorCategory("Run"), "run");
+assert.equal(sportColorCategory("Lunch Trail Run"), "trail");
+assert.equal(sportColorCategory("Lunch Cyclisme"), "bike");
+assert.equal(sportColorCategory("VirtualRide"), "bike");
+assert.equal(sportColorCategory("Evening Vélo"), "bike");
+assert.equal(sportColorCategory("WeightTraining"), "strength");
+assert.equal(sportColorCategory("Afternoon Musculation"), "strength");
+assert.equal(sportColorCategory("Afternoon Entraînement"), "strength");
+assert.equal(sportColorCategory("Workout"), "strength");
+assert.equal(sportColorCategory("Pool Swim"), "other");
+assert.equal(sportColorCategory(""), "other");
+assert.equal(sportColorCategory(undefined), "other");
+
+// parseSportColors: merge partial over defaults, ignore invalid, malformed → defaults.
+assert.deepEqual(parseSportColors(null), DEFAULT_SPORT_COLORS);
+assert.equal(parseSportColors('{"run":"#123456"}').run, "#123456");
+assert.equal(
+  parseSportColors('{"run":"#123456"}').trail,
+  DEFAULT_SPORT_COLORS.trail
+);
+assert.equal(
+  parseSportColors('{"run":"not-a-color"}').run,
+  DEFAULT_SPORT_COLORS.run
+);
+assert.deepEqual(parseSportColors("{malformed"), DEFAULT_SPORT_COLORS);
+
+console.log("sport-colors tests passed");

--- a/src/calendar/DayCell.tsx
+++ b/src/calendar/DayCell.tsx
@@ -86,7 +86,7 @@ function PairChip({
     return (
       <button
         type="button"
-        className={`calendar-chip calendar-chip-paired ${categoryClass(scheduled.name)} ${sportChipClass(activity.sportName ?? activity.name)}`}
+        className={`calendar-chip calendar-chip-paired ${categoryClass(scheduled.name)}`}
         onClick={() => onSelectActivity(activity)}
         title={`${scheduled.name} — planned vs actual`}
       >

--- a/src/calendar/DayCell.tsx
+++ b/src/calendar/DayCell.tsx
@@ -12,6 +12,7 @@ import {
 } from "../training/formatters";
 import type { CalendarDay, PlannedActualPair } from "./calendarTypes";
 import { dayNumber } from "./dateUtils";
+import { sportColorCategory } from "./sportColors";
 
 export const CALENDAR_DRAG_MIME = "application/x-coroslink-scheduled-workout";
 
@@ -34,6 +35,11 @@ interface DayCellProps {
 
 function categoryClass(name: string): string {
   return `calendar-cat-${inferUpcomingWorkoutCategory(name).toLowerCase()}`;
+}
+
+// Per-sport color class for the right-side liseré on completed-activity chips.
+function sportChipClass(name: string | undefined): string {
+  return `calendar-sport-${sportColorCategory(name)}`;
 }
 
 function completionTone(pct?: number): string {
@@ -80,7 +86,7 @@ function PairChip({
     return (
       <button
         type="button"
-        className={`calendar-chip calendar-chip-paired ${categoryClass(scheduled.name)}`}
+        className={`calendar-chip calendar-chip-paired ${categoryClass(scheduled.name)} ${sportChipClass(activity.sportName ?? activity.name)}`}
         onClick={() => onSelectActivity(activity)}
         title={`${scheduled.name} — planned vs actual`}
       >
@@ -221,7 +227,7 @@ export function DayCell({
           <button
             key={`activity-${activity.activityId}`}
             type="button"
-            className="calendar-chip calendar-chip-activity"
+            className={`calendar-chip calendar-chip-activity ${sportChipClass(activity.sportName ?? activity.name)}`}
             onClick={() => onSelectActivity(activity)}
             title={activity.name ?? activity.sportName ?? "Activity"}
           >

--- a/src/calendar/sportColors.ts
+++ b/src/calendar/sportColors.ts
@@ -1,0 +1,95 @@
+export type SportColorCategory = "strength" | "trail" | "run" | "bike" | "other";
+
+export const SPORT_COLOR_CATEGORIES: SportColorCategory[] = [
+  "strength",
+  "trail",
+  "run",
+  "bike",
+  "other"
+];
+
+export const DEFAULT_SPORT_COLORS: Record<SportColorCategory, string> = {
+  strength: "#e5484d",
+  trail: "#4c8dff",
+  run: "#2fbe91",
+  bike: "#e6b800",
+  other: "#7fd8cf"
+};
+
+export const SPORT_COLOR_LABELS: Record<SportColorCategory, string> = {
+  strength: "Strength / Gym",
+  trail: "Trail",
+  run: "Running",
+  bike: "Cycling",
+  other: "Other"
+};
+
+const STORAGE_KEY = "coroslink.sportColors";
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+/**
+ * Categorize an activity by its sport name. Trail and bike are checked before
+ * run so "TrailRun"/"VirtualRide" don't fall into run. Matches FR + EN names.
+ */
+export function sportColorCategory(
+  name: string | undefined
+): SportColorCategory {
+  const n = (name ?? "").toLowerCase();
+  if (!n) return "other";
+  if (/trail/.test(n)) return "trail";
+  if (/(bike|cycl|ride|v[ée]lo|spin)/.test(n)) return "bike";
+  if (/(run|jog|course|marathon|tempo|track|\d+\s?k\b)/.test(n)) return "run";
+  if (/(muscu|weight|strength|gym|\bcore\b|workout|entra[iî]n)/.test(n)) {
+    return "strength";
+  }
+  return "other";
+}
+
+/** Parse a stored JSON blob, merging valid hex values over the defaults. */
+export function parseSportColors(
+  raw: string | null
+): Record<SportColorCategory, string> {
+  const result = { ...DEFAULT_SPORT_COLORS };
+  if (!raw) return result;
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    for (const cat of SPORT_COLOR_CATEGORIES) {
+      const value = parsed[cat];
+      if (typeof value === "string" && HEX_RE.test(value)) {
+        result[cat] = value;
+      }
+    }
+  } catch {
+    // malformed → defaults
+  }
+  return result;
+}
+
+export function readStoredSportColors(): Record<SportColorCategory, string> {
+  const raw =
+    typeof localStorage !== "undefined"
+      ? localStorage.getItem(STORAGE_KEY)
+      : null;
+  return parseSportColors(raw);
+}
+
+export function storeSportColors(
+  colors: Record<SportColorCategory, string>
+): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(colors));
+  } catch {
+    // storage unavailable — ignore
+  }
+}
+
+/** Set --sport-<cat> custom properties on the document root. */
+export function applySportColors(
+  colors: Record<SportColorCategory, string>
+): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  for (const cat of SPORT_COLOR_CATEGORIES) {
+    root.style.setProperty(`--sport-${cat}`, colors[cat]);
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,10 +3,16 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import { ThemeProvider } from "./theme/ThemeProvider";
 import { applyTheme, readStoredTheme } from "./theme/theme";
+import {
+  applySportColors,
+  readStoredSportColors
+} from "./calendar/sportColors";
 import "./styles.css";
 
 // Apply the persisted theme before the first paint to avoid a dark→light flash.
 applyTheme(readStoredTheme());
+// Apply the persisted per-sport activity colors so the calendar liserés paint correctly.
+applySportColors(readStoredSportColors());
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -12,6 +12,15 @@ import { useCallback, useEffect, useState } from "react";
 import type { AppInfo, AppUpdateSnapshot } from "../../electron/types";
 import type { CorosLinkApi } from "../coroslink-api";
 import { formatBytes } from "../media/libraryUtils";
+import {
+  SPORT_COLOR_CATEGORIES,
+  SPORT_COLOR_LABELS,
+  DEFAULT_SPORT_COLORS,
+  readStoredSportColors,
+  storeSportColors,
+  applySportColors,
+  type SportColorCategory
+} from "../calendar/sportColors";
 import appLogo from "../../build/icon.png";
 
 const ABOUT_LINKS = [
@@ -68,6 +77,21 @@ export function SettingsView({
   const [openingLocationId, setOpeningLocationId] = useState<string | null>(
     null,
   );
+  const [sportColors, setSportColors] = useState(() => readStoredSportColors());
+
+  function updateSportColor(cat: SportColorCategory, value: string) {
+    const next = { ...sportColors, [cat]: value };
+    setSportColors(next);
+    storeSportColors(next);
+    applySportColors(next);
+  }
+
+  function resetSportColors() {
+    const next = { ...DEFAULT_SPORT_COLORS };
+    setSportColors(next);
+    storeSportColors(next);
+    applySportColors(next);
+  }
 
   const loadAppInfo = useCallback(async () => {
     setLoading(true);
@@ -253,6 +277,49 @@ export function SettingsView({
             Loading storage locations…
           </p>
         )}
+      </div>
+
+      <div className="panel">
+        <div className="section-heading">
+          <div>
+            <p className="eyebrow">Calendar</p>
+            <h2>Activity colors</h2>
+          </div>
+          <button
+            className="secondary-button"
+            type="button"
+            onClick={resetSportColors}
+          >
+            <RefreshCw size={15} aria-hidden="true" />
+            Reset to defaults
+          </button>
+        </div>
+        <p className="settings-sport-hint">
+          Color of the right edge of each activity in the calendar, by sport.
+        </p>
+        <ul className="settings-sport-list">
+          {SPORT_COLOR_CATEGORIES.map((cat) => (
+            <li className="settings-sport-row" key={cat}>
+              <span
+                className={`calendar-chip calendar-chip-activity calendar-sport-${cat} settings-sport-preview`}
+                aria-hidden="true"
+              >
+                <span className="calendar-chip-title">
+                  <span className="calendar-chip-name">
+                    {SPORT_COLOR_LABELS[cat]}
+                  </span>
+                </span>
+              </span>
+              <input
+                type="color"
+                className="settings-sport-input"
+                value={sportColors[cat]}
+                onChange={(event) => updateSportColor(cat, event.target.value)}
+                aria-label={`${SPORT_COLOR_LABELS[cat]} color`}
+              />
+            </li>
+          ))}
+        </ul>
       </div>
     </section>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -18847,17 +18847,13 @@ tr.data-intervals-row-missing {
 .calendar-cat-race { border-left-color: #ef5da8; }
 .calendar-cat-run { border-left-color: var(--accent); }
 
-/* Per-sport colored liseré on the RIGHT edge of completed-activity chips.
-   Semi-transparent so it stays subtle alongside the left category border. */
-.calendar-chip-activity,
-.calendar-chip-paired {
-  border-right: 3px solid transparent;
-}
-.calendar-sport-strength { border-right-color: color-mix(in srgb, var(--sport-strength) 60%, transparent); }
-.calendar-sport-trail { border-right-color: color-mix(in srgb, var(--sport-trail) 60%, transparent); }
-.calendar-sport-run { border-right-color: color-mix(in srgb, var(--sport-run) 60%, transparent); }
-.calendar-sport-bike { border-right-color: color-mix(in srgb, var(--sport-bike) 60%, transparent); }
-.calendar-sport-other { border-right-color: color-mix(in srgb, var(--sport-other) 60%, transparent); }
+/* Per-sport color on the LEFT border of completed-activity chips — replaces
+   the default green accent so each activity reads by its sport at a glance. */
+.calendar-chip-activity.calendar-sport-strength { border-left-color: var(--sport-strength); }
+.calendar-chip-activity.calendar-sport-trail { border-left-color: var(--sport-trail); }
+.calendar-chip-activity.calendar-sport-run { border-left-color: var(--sport-run); }
+.calendar-chip-activity.calendar-sport-bike { border-left-color: var(--sport-bike); }
+.calendar-chip-activity.calendar-sport-other { border-left-color: var(--sport-other); }
 
 /* Settings → Activity colors card. */
 .settings-sport-hint {

--- a/src/styles.css
+++ b/src/styles.css
@@ -35,6 +35,14 @@
   --accent-gradient: linear-gradient(135deg, #2fbe91 0%, #1fb6a6 100%);
   --accent-gold: #d89b22;
 
+  /* Per-sport activity colors (calendar right liseré). Overridden at runtime
+     from localStorage via applySportColors(). */
+  --sport-strength: #e5484d;
+  --sport-trail: #4c8dff;
+  --sport-run: #2fbe91;
+  --sport-bike: #e6b800;
+  --sport-other: #7fd8cf;
+
   --success-bg: rgba(47, 190, 145, 0.15);
   --success-border: rgba(110, 231, 168, 0.28);
   --success-text: #6ee7a8;
@@ -18838,6 +18846,18 @@ tr.data-intervals-row-missing {
 .calendar-cat-speed { border-left-color: var(--accent-gold); }
 .calendar-cat-race { border-left-color: #ef5da8; }
 .calendar-cat-run { border-left-color: var(--accent); }
+
+/* Per-sport colored liseré on the RIGHT edge of completed-activity chips.
+   Semi-transparent so it stays subtle alongside the left category border. */
+.calendar-chip-activity,
+.calendar-chip-paired {
+  border-right: 3px solid transparent;
+}
+.calendar-sport-strength { border-right-color: color-mix(in srgb, var(--sport-strength) 60%, transparent); }
+.calendar-sport-trail { border-right-color: color-mix(in srgb, var(--sport-trail) 60%, transparent); }
+.calendar-sport-run { border-right-color: color-mix(in srgb, var(--sport-run) 60%, transparent); }
+.calendar-sport-bike { border-right-color: color-mix(in srgb, var(--sport-bike) 60%, transparent); }
+.calendar-sport-other { border-right-color: color-mix(in srgb, var(--sport-other) 60%, transparent); }
 
 .calendar-chip-title {
   display: flex;

--- a/src/styles.css
+++ b/src/styles.css
@@ -18859,6 +18859,42 @@ tr.data-intervals-row-missing {
 .calendar-sport-bike { border-right-color: color-mix(in srgb, var(--sport-bike) 60%, transparent); }
 .calendar-sport-other { border-right-color: color-mix(in srgb, var(--sport-other) 60%, transparent); }
 
+/* Settings → Activity colors card. */
+.settings-sport-hint {
+  margin: 4px 0 12px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.settings-sport-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.settings-sport-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.settings-sport-preview {
+  flex: 1 1 auto;
+  min-width: 0;
+  cursor: default;
+}
+.settings-sport-input {
+  flex: 0 0 auto;
+  width: 44px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  cursor: pointer;
+}
+
 .calendar-chip-title {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What this adds

Per-sport **colors for completed activities in the Calendar**, customizable in Settings.

Each activity chip's **left border** is colored by its sport (replacing the default green accent), so you can tell a run from a ride from a gym session at a glance:

| Category | Matches | Default |
|----------|---------|---------|
| Strength / Gym | Musculation, Weight Training, Workout, Entraînement | red `#e5484d` |
| Trail | Trail (matched before run) | blue `#4c8dff` |
| Running | Course, Run, non-trail | green `#2fbe91` |
| Cycling | Vélo, Cyclisme, Ride, VirtualRide | yellow `#e6b800` |
| Other | everything else | pastel turquoise `#7fd8cf` |

A new **"Activity colors"** card in Settings lets the user change all five colors (with a live preview chip) and reset to defaults. Colors persist in `localStorage` and are applied as CSS custom properties on the document root at boot — the same approach the theme uses.

## Notes

- **No new runtime dependencies.**
- Scope is the Calendar's completed **activity** chips. The existing planned-workout left-border colors (workout *type*: Easy/Long/Intervals…) on planned/actual pair chips are left untouched.
- Categorization is name-based and pure (`src/calendar/sportColors.ts`), unit-tested via `npm run test:sport-colors` (trail-before-run ordering, FR + EN sport names, localStorage parse/merge with malformed-input fallback).
- `npm run build` (electron + renderer) is clean.

Design/plan docs are under `docs/superpowers/` — happy to drop them if you'd prefer code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
