### PR TITLE
Fix watchface login for EU/CN accounts (region selector)

### DIFF
--- a/electron/corosWatchfaceService.ts
+++ b/electron/corosWatchfaceService.ts
@@ -16,6 +16,7 @@ import type {
   CorosWatchfaceProject,
   CorosWatchfaceProjectSaveInput,
   CorosWatchfaceProjectSummary,
+  CorosWatchfaceRegion,
   CorosWatchfaceResolutionDetails,
   CorosWatchfaceShareLink,
   CorosWatchfaceSpriteFile,
@@ -35,7 +36,53 @@ import type {
   CorosPairedDevice
 } from "./types";
 
-const API_BASE_URL = "https://api.coros.com/coros";
+// COROS accounts are region-bound: a mobile session is only valid on the host
+// its account was registered on. Hitting the wrong host returns "Account is not
+// registered", so the region is chosen at login and persisted with the session.
+const MOBILE_API_BASE_URLS: Record<CorosWatchfaceRegion, string> = {
+  eu: "https://apieu.coros.com/coros",
+  us: "https://api.coros.com/coros",
+  cn: "https://apicn.coros.com/coros"
+};
+const MOBILE_API_HOSTNAMES: Record<CorosWatchfaceRegion, string> = {
+  eu: "apieu.coros.com",
+  us: "api.coros.com",
+  cn: "apicn.coros.com"
+};
+const DEFAULT_WATCHFACE_REGION: CorosWatchfaceRegion = "us";
+
+function normalizeWatchfaceRegion(value: unknown): CorosWatchfaceRegion {
+  return value === "eu" || value === "us" || value === "cn"
+    ? value
+    : DEFAULT_WATCHFACE_REGION;
+}
+
+function mobileApiBaseUrl(region: CorosWatchfaceRegion | undefined): string {
+  return MOBILE_API_BASE_URLS[region ?? DEFAULT_WATCHFACE_REGION];
+}
+
+/** Best-guess region for the login form, from the Training Hub session or locale. */
+function suggestWatchfaceRegion(): CorosWatchfaceRegion {
+  const trainingHubBaseUrl = getSetting("trainingHub.baseUrl") ?? "";
+  if (trainingHubBaseUrl.includes("teameuapi")) {
+    return "eu";
+  }
+  if (trainingHubBaseUrl.includes("teamcnapi")) {
+    return "cn";
+  }
+  if (trainingHubBaseUrl.includes("teamapi")) {
+    return "us";
+  }
+  const country =
+    Intl.DateTimeFormat().resolvedOptions().locale.match(/[-_]([A-Z]{2})\b/)?.[1] ?? "";
+  if (["CN", "HK", "MO", "TW"].includes(country)) {
+    return "cn";
+  }
+  if (country && !["US", "CA", "MX"].includes(country)) {
+    return "eu";
+  }
+  return DEFAULT_WATCHFACE_REGION;
+}
 const MOBILE_APP_KEY = "3475792298363620";
 const MOBILE_LOGIN_IV = "weloop3_2015_03#";
 const MOBILE_VERSION_CODE = "407081000";
@@ -86,6 +133,8 @@ interface StoredMobileSession {
   accessToken: string;
   /** Kept as text because COROS user IDs exceed Number.MAX_SAFE_INTEGER. */
   userId?: string;
+  /** Regional mobile host the session was created on. */
+  region?: CorosWatchfaceRegion;
 }
 
 interface MobileApiEnvelope<T> {
@@ -149,25 +198,32 @@ export function encryptMobileLoginField(value: string): string {
 }
 
 export function getCorosWatchfaceStatus(): CorosWatchfaceStatus {
+  const session = readStoredSession();
   return {
-    authenticated: Boolean(readStoredSession()),
-    secureStorageAvailable: safeStorage.isEncryptionAvailable()
+    authenticated: Boolean(session),
+    secureStorageAvailable: safeStorage.isEncryptionAvailable(),
+    region: session?.region,
+    suggestedRegion: session?.region ?? suggestWatchfaceRegion()
   };
 }
 
 export async function loginCorosWatchfaces(
   email: string,
-  password: string
+  password: string,
+  region?: CorosWatchfaceRegion
 ): Promise<CorosWatchfaceStatus> {
   const account = email.trim();
   if (!account || !password) {
     throw new Error("Enter your COROS email and password.");
   }
+  const resolvedRegion = normalizeWatchfaceRegion(region);
+  const baseUrl = mobileApiBaseUrl(resolvedRegion);
 
   let envelope = await mobileRequest<{ accessToken?: string }>(
     "/user/login",
     {
       method: "POST",
+      baseUrl,
       body: JSON.stringify(buildMobileLoginPayload(account, password, 1)),
       allowedResultCodes: ["1115"]
     }
@@ -179,6 +235,7 @@ export async function loginCorosWatchfaces(
   if (mobileApiResult(envelope) === "1115") {
     envelope = await mobileRequest<{ accessToken?: string }>("/user/login", {
       method: "POST",
+      baseUrl,
       body: JSON.stringify(buildMobileLoginPayload(account, password, 0))
     });
   }
@@ -190,7 +247,8 @@ export async function loginCorosWatchfaces(
 
   writeStoredSession({
     accessToken,
-    userId: extractDecimalProperty(envelope.raw, "userId")
+    userId: extractDecimalProperty(envelope.raw, "userId"),
+    region: resolvedRegion
   });
   return getCorosWatchfaceStatus();
 }
@@ -366,8 +424,9 @@ async function fetchThemeResource(
 
 function withAccessTokenParam(url: string, session: StoredMobileSession): string {
   const parsed = new URL(url);
+  const regionalHosts = Object.values(MOBILE_API_HOSTNAMES);
   if (
-    parsed.hostname === "api.coros.com" &&
+    regionalHosts.includes(parsed.hostname) &&
     !parsed.searchParams.has("accessToken")
   ) {
     parsed.searchParams.set("accessToken", session.accessToken);
@@ -1766,6 +1825,8 @@ async function mobileRequest<T>(
     includeAccessTokenInQuery?: boolean;
     userId?: string;
     allowedResultCodes?: string[];
+    /** Override the regional host (used by login, before a session exists). */
+    baseUrl?: string;
   }
 ): Promise<MobileApiEnvelope<T> & { raw: string }> {
   const query = options.accessToken && options.includeAccessTokenInQuery !== false
@@ -1775,7 +1836,8 @@ async function mobileRequest<T>(
   if (typeof options.body === "string") {
     headers["Content-Type"] = "application/json";
   }
-  const response = await fetch(`${API_BASE_URL}${endpoint}${query}`, {
+  const baseUrl = options.baseUrl ?? mobileApiBaseUrl(readStoredSession()?.region);
+  const response = await fetch(`${baseUrl}${endpoint}${query}`, {
     method: options.method,
     headers,
     body: options.body

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -139,6 +139,7 @@ import type {
 import type {
   CorosWatchfaceCreatorInput,
   CorosWatchfacePublishInput,
+  CorosWatchfaceRegion,
   CorosWatchfaceThemeDownloadInput,
   CorosWatchfaceThemeListInput,
   CorosBatteryQueryInput
@@ -565,8 +566,8 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle(
     "watchfaces:login",
-    (_event, email: string, password: string) =>
-      loginCorosWatchfaces(email, password)
+    (_event, email: string, password: string, region?: CorosWatchfaceRegion) =>
+      loginCorosWatchfaces(email, password, region)
   );
 
   ipcMain.handle("watchfaces:logout", () => logoutCorosWatchfaces());

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -93,6 +93,7 @@ import type {
   CorosWatchfaceProjectSaveInput,
   CorosWatchfaceProjectSummary,
   CorosWatchfacePublishInput,
+  CorosWatchfaceRegion,
   CorosWatchfaceShareLink,
   CorosWatchfaceStatus,
   CorosWatchfaceTemplateAsset,
@@ -115,9 +116,10 @@ const api = {
     ipcRenderer.invoke("watchfaces:getStatus"),
   loginCorosWatchfaces: (
     email: string,
-    password: string
+    password: string,
+    region: CorosWatchfaceRegion
   ): Promise<CorosWatchfaceStatus> =>
-    ipcRenderer.invoke("watchfaces:login", email, password),
+    ipcRenderer.invoke("watchfaces:login", email, password, region),
   logoutCorosWatchfaces: (): Promise<CorosWatchfaceStatus> =>
     ipcRenderer.invoke("watchfaces:logout"),
   listCorosPairedDevices: (): Promise<CorosPairedDevice[]> =>

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -85,10 +85,17 @@ export interface WatchStatus {
   error?: string;
 }
 
+/** COROS account region, selecting the regional mobile API host. */
+export type CorosWatchfaceRegion = "eu" | "us" | "cn";
+
 /** A separate COROS mobile-app session used only for custom-watchface sharing. */
 export interface CorosWatchfaceStatus {
   authenticated: boolean;
   secureStorageAvailable: boolean;
+  /** Region of the active mobile session, when signed in. */
+  region?: CorosWatchfaceRegion;
+  /** Best-guess region to preselect in the login form. */
+  suggestedRegion: CorosWatchfaceRegion;
 }
 
 /** Parameters required by COROS's official editable-template catalog request. */

--- a/src/coroslink-api.ts
+++ b/src/coroslink-api.ts
@@ -92,6 +92,7 @@ import type {
   CorosWatchfaceProjectSaveInput,
   CorosWatchfaceProjectSummary,
   CorosWatchfacePublishInput,
+  CorosWatchfaceRegion,
   CorosWatchfaceShareLink,
   CorosWatchfaceStatus,
   CorosWatchfaceTemplateAsset,
@@ -111,7 +112,8 @@ export interface CorosLinkApi {
   getCorosWatchfaceStatus: () => Promise<CorosWatchfaceStatus>;
   loginCorosWatchfaces: (
     email: string,
-    password: string
+    password: string,
+    region: CorosWatchfaceRegion
   ) => Promise<CorosWatchfaceStatus>;
   logoutCorosWatchfaces: () => Promise<CorosWatchfaceStatus>;
   listCorosPairedDevices: () => Promise<CorosPairedDevice[]>;

--- a/src/watchfaces/WatchfacesView.tsx
+++ b/src/watchfaces/WatchfacesView.tsx
@@ -21,10 +21,17 @@ import type {
   CorosWatchfaceArchive,
   CorosWatchfaceProject,
   CorosWatchfaceProjectSummary,
+  CorosWatchfaceRegion,
   CorosWatchfaceShareLink,
   CorosWatchfaceStatus,
   CorosWatchfaceTheme
 } from "../../electron/types";
+
+const REGION_OPTIONS: { value: CorosWatchfaceRegion; label: string }[] = [
+  { value: "eu", label: "Europe" },
+  { value: "us", label: "United States" },
+  { value: "cn", label: "China / Asia-Pacific" }
+];
 import type { CorosLinkApi } from "../coroslink-api";
 import { WatchfaceCreator } from "./WatchfaceCreator";
 import { BatteryHistoryPanel } from "./BatteryHistoryPanel";
@@ -39,6 +46,8 @@ export function WatchfacesView({ api }: WatchfacesViewProps) {
   const [status, setStatus] = useState<CorosWatchfaceStatus | null>(null);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [region, setRegion] = useState<CorosWatchfaceRegion>("us");
+  const [regionTouched, setRegionTouched] = useState(false);
   const [archive, setArchive] = useState<CorosWatchfaceArchive | null>(null);
   const [starterArchive, setStarterArchive] =
     useState<CorosWatchfaceArchive | null>(null);
@@ -69,9 +78,14 @@ export function WatchfacesView({ api }: WatchfacesViewProps) {
   useEffect(() => {
     void api
       .getCorosWatchfaceStatus()
-      .then(setStatus)
+      .then((nextStatus) => {
+        setStatus(nextStatus);
+        if (!regionTouched) {
+          setRegion(nextStatus.region ?? nextStatus.suggestedRegion);
+        }
+      })
       .catch((caught) => setError(toErrorMessage(caught)));
-  }, [api]);
+  }, [api, regionTouched]);
 
   useEffect(() => {
     void api
@@ -97,7 +111,7 @@ export function WatchfacesView({ api }: WatchfacesViewProps) {
     setError(null);
     setNotice(null);
     try {
-      const nextStatus = await api.loginCorosWatchfaces(email, password);
+      const nextStatus = await api.loginCorosWatchfaces(email, password, region);
       setStatus(nextStatus);
       setPassword("");
       setNotice("COROS mobile session connected.");
@@ -320,6 +334,22 @@ export function WatchfacesView({ api }: WatchfacesViewProps) {
             session is kept in encrypted OS storage; CorosLink does not save the password.
           </p>
           <form className="watchfaces-form" onSubmit={handleLogin}>
+            <label className="field">
+              COROS account region
+              <select
+                value={region}
+                onChange={(event) => {
+                  setRegion(event.target.value as CorosWatchfaceRegion);
+                  setRegionTouched(true);
+                }}
+              >
+                {REGION_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
             <label className="field">
               COROS email
               <input


### PR DESCRIPTION
## Fix: region-aware watchface mobile login

### Problem
Signing in on the watchface panel failed for non-US accounts with:

```
Error invoking remote method 'watchfaces:login': Error: Account is not registered
```

COROS accounts are region-bound — a mobile session is only valid on the host its account was registered on. The watchface client hardcoded the US host (`https://api.coros.com/coros`) for every mobile call, and `buildMobileLoginRegion()` only set a region *string* in the payload, not the request host. So an EU (or CN) account is genuinely "not registered" on the US server, and login fails. (This account signs in fine on the Training Hub, which is already EU-routed via `teameuapi.coros.com`.)

### Fix
Route the mobile API host by region, chosen at login:

- **Region selector in the login form** — Europe / United States / China · Asia-Pacific.
- **Regional hosts**: `eu → apieu.coros.com`, `us → api.coros.com`, `cn → apicn.coros.com` (path prefix `/coros`).
- **Region persisted with the session**, so every later mobile call (themes, battery, publish, share-link, downloads) hits the same correct host — not just login.
- **Smart default**: the selector preselects the account's region, inferred from the existing Training Hub session base URL (`teameuapi → eu`, `teamcnapi → cn`, else `us`), falling back to a locale guess. Fully overridable by the user.
- **Theme package URLs** on regional hosts now also receive the access token (`withAccessTokenParam` previously only matched `api.coros.com`).

### Files
- `electron/corosWatchfaceService.ts` — regional host map + resolver, `suggestWatchfaceRegion()`, `region` threaded through `loginCorosWatchfaces` / `mobileRequest` / the stored session, regional-host token param.
- `electron/types.ts` — `CorosWatchfaceRegion`; `region` + `suggestedRegion` on `CorosWatchfaceStatus`.
- `electron/main.ts`, `electron/preload.ts`, `src/coroslink-api.ts` — thread the region argument through IPC.
- `src/watchfaces/WatchfacesView.tsx` — region `<select>`, default from status, passed to login.

### Testing
- `npm run build` — clean (electron `tsc` + renderer `tsc --noEmit` + vite).
- Verified live: with **Europe** selected, the EU account signs in successfully and the "Account is not registered" error is gone; the theme browser and session then operate against the EU host.

No new runtime dependencies. No change to US-account behavior (US is still selectable and remains the fallback default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
