### PR TITLE
Per-sport activity colors across heatmap + calendar (multi-sport pie, customizable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:route-location": "node --experimental-strip-types scripts/test-route-location.mjs",
     "test:sketch": "npm run build:electron && node scripts/test-sketch-geometry.mjs",
     "test:greetings": "node --experimental-strip-types scripts/test-greetings.mjs",
+    "test:sport-colors": "node --experimental-strip-types scripts/test-sport-colors.mjs",
     "test:intervals-match": "npm run build:electron && node scripts/test-intervals-match.mjs",
     "test:chat-service": "npm run build:electron && node scripts/test-chat-service.mjs",
     "test:claude-code": "npm run build:electron && node scripts/test-claude-code-provider.mjs",

--- a/scripts/test-sport-colors.mjs
+++ b/scripts/test-sport-colors.mjs
@@ -11,7 +11,8 @@ const {
   parseSportColors,
   DEFAULT_SPORT_COLORS,
   happenDayFromTimestamp,
-  buildDominantSportByDay
+  buildDominantSportByDay,
+  buildSportCategoriesByDay
 } = await import(`${modUrl.href}?c=${Date.now()}`);
 
 // Categorization (trail before run; bike before run; French + English names).
@@ -73,5 +74,21 @@ const tie = buildDominantSportByDay([
   { activityId: "g", sportType: 0, sportName: "Run", trainingLoad: 30, startTime: noonMs }
 ]);
 assert.equal(tie.get("20260714"), "bike");
+
+// buildSportCategoriesByDay: distinct categories per day, canonical order,
+// same-category activities collapse to one slice.
+const cats = buildSportCategoriesByDay([
+  // One day: trail + bike + a second bike → 2 slices (trail, bike).
+  { activityId: "h", sportType: 0, sportName: "Trail Run", trainingLoad: 30, startTime: noonMs },
+  { activityId: "i", sportType: 0, sportName: "VirtualRide", trainingLoad: 20, startTime: noonMs },
+  { activityId: "j", sportType: 0, sportName: "Cyclisme", trainingLoad: 25, startTime: noonMs },
+  // Another day: single run.
+  { activityId: "k", sportType: 0, sportName: "Run", trainingLoad: 40, startTime: new Date(2026, 6, 15, 9).getTime() },
+  // No startTime → skipped.
+  { activityId: "l", sportType: 0, sportName: "Run" }
+]);
+assert.deepEqual([...cats.get("20260714")], ["trail", "bike"]); // canonical order
+assert.deepEqual([...cats.get("20260715")], ["run"]);
+assert.equal(cats.size, 2);
 
 console.log("sport-colors tests passed");

--- a/scripts/test-sport-colors.mjs
+++ b/scripts/test-sport-colors.mjs
@@ -15,20 +15,21 @@ const {
   buildSportCategoriesByDay
 } = await import(`${modUrl.href}?c=${Date.now()}`);
 
-// Categorization (trail before run; bike before run; French + English names).
-assert.equal(sportColorCategory("TrailRun"), "trail");
-assert.equal(sportColorCategory("Morning Trail Run"), "trail");
-assert.equal(sportColorCategory("Run"), "run");
-assert.equal(sportColorCategory("Lunch Trail Run"), "trail");
-assert.equal(sportColorCategory("Lunch Cyclisme"), "bike");
-assert.equal(sportColorCategory("VirtualRide"), "bike");
-assert.equal(sportColorCategory("Evening Vélo"), "bike");
-assert.equal(sportColorCategory("WeightTraining"), "strength");
-assert.equal(sportColorCategory("Afternoon Musculation"), "strength");
-assert.equal(sportColorCategory("Afternoon Entraînement"), "strength");
-assert.equal(sportColorCategory("Workout"), "strength");
-assert.equal(sportColorCategory("Pool Swim"), "other");
-assert.equal(sportColorCategory(""), "other");
+// Categorization by COROS sportType code (names are user-editable free text
+// and never consulted). Unknown or missing codes → "other".
+assert.equal(sportColorCategory(100), "run"); //      Run
+assert.equal(sportColorCategory(101), "run"); //      Indoor Run
+assert.equal(sportColorCategory(102), "trail"); //    Trail Run
+assert.equal(sportColorCategory(103), "run"); //      Track Run
+assert.equal(sportColorCategory(104), "run"); //      Treadmill Run
+assert.equal(sportColorCategory(200), "bike"); //     Road Bike
+assert.equal(sportColorCategory(204), "bike"); //     Mountain Bike
+assert.equal(sportColorCategory(402), "strength"); // Strength
+assert.equal(sportColorCategory(403), "strength"); // Cardio (gym)
+assert.equal(sportColorCategory(700), "trail"); //    Hiking
+assert.equal(sportColorCategory(300), "other"); //    Pool Swim
+assert.equal(sportColorCategory(400), "other"); //    Triathlon
+assert.equal(sportColorCategory(999), "other"); //    unknown code
 assert.equal(sportColorCategory(undefined), "other");
 
 // parseSportColors: merge partial over defaults, ignore invalid, malformed → defaults.
@@ -54,14 +55,14 @@ assert.equal(happenDayFromTimestamp(0), undefined);
 // buildDominantSportByDay: highest-TL individual activity sets the color.
 const dominant = buildDominantSportByDay([
   // Same day: run (TL 40) vs strength (TL 90) → strength wins.
-  { activityId: "a", sportType: 0, sportName: "Run", trainingLoad: 40, startTime: noonMs },
-  { activityId: "b", sportType: 0, sportName: "Musculation", trainingLoad: 90, startTime: noonMs },
+  { activityId: "a", sportType: 100, trainingLoad: 40, startTime: noonMs },
+  { activityId: "b", sportType: 402, trainingLoad: 90, startTime: noonMs },
   // Different day, single trail.
-  { activityId: "c", sportType: 0, sportName: "Trail Run", trainingLoad: 55, startTime: new Date(2026, 6, 15, 9).getTime() },
-  // No TL and no sportName → "other".
-  { activityId: "d", sportType: 0, startTime: new Date(2026, 6, 16, 9).getTime() },
+  { activityId: "c", sportType: 102, trainingLoad: 55, startTime: new Date(2026, 6, 15, 9).getTime() },
+  // No TL and an unknown sportType → "other".
+  { activityId: "d", sportType: 999, startTime: new Date(2026, 6, 16, 9).getTime() },
   // No startTime → skipped entirely.
-  { activityId: "e", sportType: 0, sportName: "Run" }
+  { activityId: "e", sportType: 100 }
 ]);
 assert.equal(dominant.get("20260714"), "strength");
 assert.equal(dominant.get("20260715"), "trail");
@@ -70,8 +71,8 @@ assert.equal(dominant.size, 3);
 
 // Tie on TL keeps the first activity seen (deterministic).
 const tie = buildDominantSportByDay([
-  { activityId: "f", sportType: 0, sportName: "Cycling", trainingLoad: 30, startTime: noonMs },
-  { activityId: "g", sportType: 0, sportName: "Run", trainingLoad: 30, startTime: noonMs }
+  { activityId: "f", sportType: 200, trainingLoad: 30, startTime: noonMs },
+  { activityId: "g", sportType: 100, trainingLoad: 30, startTime: noonMs }
 ]);
 assert.equal(tie.get("20260714"), "bike");
 
@@ -79,13 +80,13 @@ assert.equal(tie.get("20260714"), "bike");
 // same-category activities collapse to one slice.
 const cats = buildSportCategoriesByDay([
   // One day: trail + bike + a second bike → 2 slices (trail, bike).
-  { activityId: "h", sportType: 0, sportName: "Trail Run", trainingLoad: 30, startTime: noonMs },
-  { activityId: "i", sportType: 0, sportName: "VirtualRide", trainingLoad: 20, startTime: noonMs },
-  { activityId: "j", sportType: 0, sportName: "Cyclisme", trainingLoad: 25, startTime: noonMs },
+  { activityId: "h", sportType: 102, trainingLoad: 30, startTime: noonMs },
+  { activityId: "i", sportType: 201, trainingLoad: 20, startTime: noonMs },
+  { activityId: "j", sportType: 200, trainingLoad: 25, startTime: noonMs },
   // Another day: single run.
-  { activityId: "k", sportType: 0, sportName: "Run", trainingLoad: 40, startTime: new Date(2026, 6, 15, 9).getTime() },
+  { activityId: "k", sportType: 100, trainingLoad: 40, startTime: new Date(2026, 6, 15, 9).getTime() },
   // No startTime → skipped.
-  { activityId: "l", sportType: 0, sportName: "Run" }
+  { activityId: "l", sportType: 100 }
 ]);
 assert.deepEqual([...cats.get("20260714")], ["trail", "bike"]); // canonical order
 assert.deepEqual([...cats.get("20260715")], ["run"]);

--- a/scripts/test-sport-colors.mjs
+++ b/scripts/test-sport-colors.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const modUrl = pathToFileURL(
+  path.join(repoRoot, "src", "training", "sportColors.ts")
+);
+const {
+  sportColorCategory,
+  parseSportColors,
+  DEFAULT_SPORT_COLORS,
+  happenDayFromTimestamp,
+  buildDominantSportByDay
+} = await import(`${modUrl.href}?c=${Date.now()}`);
+
+// Categorization (trail before run; bike before run; French + English names).
+assert.equal(sportColorCategory("TrailRun"), "trail");
+assert.equal(sportColorCategory("Morning Trail Run"), "trail");
+assert.equal(sportColorCategory("Run"), "run");
+assert.equal(sportColorCategory("Lunch Trail Run"), "trail");
+assert.equal(sportColorCategory("Lunch Cyclisme"), "bike");
+assert.equal(sportColorCategory("VirtualRide"), "bike");
+assert.equal(sportColorCategory("Evening Vélo"), "bike");
+assert.equal(sportColorCategory("WeightTraining"), "strength");
+assert.equal(sportColorCategory("Afternoon Musculation"), "strength");
+assert.equal(sportColorCategory("Afternoon Entraînement"), "strength");
+assert.equal(sportColorCategory("Workout"), "strength");
+assert.equal(sportColorCategory("Pool Swim"), "other");
+assert.equal(sportColorCategory(""), "other");
+assert.equal(sportColorCategory(undefined), "other");
+
+// parseSportColors: merge partial over defaults, ignore invalid, malformed → defaults.
+assert.deepEqual(parseSportColors(null), DEFAULT_SPORT_COLORS);
+assert.equal(parseSportColors('{"run":"#123456"}').run, "#123456");
+assert.equal(
+  parseSportColors('{"run":"#123456"}').trail,
+  DEFAULT_SPORT_COLORS.trail
+);
+assert.equal(
+  parseSportColors('{"run":"not-a-color"}').run,
+  DEFAULT_SPORT_COLORS.run
+);
+assert.deepEqual(parseSportColors("{malformed"), DEFAULT_SPORT_COLORS);
+
+// happenDayFromTimestamp: seconds vs ms epochs, invalid → undefined.
+const noonMs = new Date(2026, 6, 14, 12, 0, 0).getTime(); // 2026-07-14 local
+assert.equal(happenDayFromTimestamp(noonMs), "20260714");
+assert.equal(happenDayFromTimestamp(Math.floor(noonMs / 1000)), "20260714");
+assert.equal(happenDayFromTimestamp(undefined), undefined);
+assert.equal(happenDayFromTimestamp(0), undefined);
+
+// buildDominantSportByDay: highest-TL individual activity sets the color.
+const dominant = buildDominantSportByDay([
+  // Same day: run (TL 40) vs strength (TL 90) → strength wins.
+  { activityId: "a", sportType: 0, sportName: "Run", trainingLoad: 40, startTime: noonMs },
+  { activityId: "b", sportType: 0, sportName: "Musculation", trainingLoad: 90, startTime: noonMs },
+  // Different day, single trail.
+  { activityId: "c", sportType: 0, sportName: "Trail Run", trainingLoad: 55, startTime: new Date(2026, 6, 15, 9).getTime() },
+  // No TL and no sportName → "other".
+  { activityId: "d", sportType: 0, startTime: new Date(2026, 6, 16, 9).getTime() },
+  // No startTime → skipped entirely.
+  { activityId: "e", sportType: 0, sportName: "Run" }
+]);
+assert.equal(dominant.get("20260714"), "strength");
+assert.equal(dominant.get("20260715"), "trail");
+assert.equal(dominant.get("20260716"), "other");
+assert.equal(dominant.size, 3);
+
+// Tie on TL keeps the first activity seen (deterministic).
+const tie = buildDominantSportByDay([
+  { activityId: "f", sportType: 0, sportName: "Cycling", trainingLoad: 30, startTime: noonMs },
+  { activityId: "g", sportType: 0, sportName: "Run", trainingLoad: 30, startTime: noonMs }
+]);
+assert.equal(tie.get("20260714"), "bike");
+
+console.log("sport-colors tests passed");

--- a/scripts/test-sport-colors.mjs
+++ b/scripts/test-sport-colors.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 
@@ -44,6 +45,19 @@ assert.equal(
   DEFAULT_SPORT_COLORS.run
 );
 assert.deepEqual(parseSportColors("{malformed"), DEFAULT_SPORT_COLORS);
+
+// The :root --sport-* fallbacks in styles.css mirror DEFAULT_SPORT_COLORS.
+// They're overridden before first paint, but must not silently drift.
+const css = await readFile(path.join(repoRoot, "src", "styles.css"), "utf8");
+for (const [cat, hex] of Object.entries(DEFAULT_SPORT_COLORS)) {
+  const match = css.match(new RegExp(`--sport-${cat}:\\s*(#[0-9a-fA-F]{6})`));
+  assert.ok(match, `styles.css is missing a --sport-${cat} declaration`);
+  assert.equal(
+    match[1].toLowerCase(),
+    hex.toLowerCase(),
+    `--sport-${cat} in styles.css drifted from DEFAULT_SPORT_COLORS`
+  );
+}
 
 // happenDayFromTimestamp: seconds vs ms epochs, invalid → undefined.
 const noonMs = new Date(2026, 6, 14, 12, 0, 0).getTime(); // 2026-07-14 local

--- a/src/calendar/DayCell.tsx
+++ b/src/calendar/DayCell.tsx
@@ -39,7 +39,7 @@ function categoryClass(name: string): string {
 
 // Color a completed activity chip by sport, matching the training heatmap.
 function sportClass(activity: TrainingHubActivity): string {
-  return `calendar-sport-${sportColorCategory(activity.sportName ?? activity.name)}`;
+  return `calendar-sport-${sportColorCategory(activity.sportType)}`;
 }
 
 function completionTone(pct?: number): string {

--- a/src/calendar/DayCell.tsx
+++ b/src/calendar/DayCell.tsx
@@ -10,6 +10,7 @@ import {
   formatUpcomingWorkoutVolumeDisplay,
   inferUpcomingWorkoutCategory
 } from "../training/formatters";
+import { sportColorCategory } from "../training/sportColors";
 import type { CalendarDay, PlannedActualPair } from "./calendarTypes";
 import { dayNumber } from "./dateUtils";
 
@@ -34,6 +35,11 @@ interface DayCellProps {
 
 function categoryClass(name: string): string {
   return `calendar-cat-${inferUpcomingWorkoutCategory(name).toLowerCase()}`;
+}
+
+// Color a completed activity chip by sport, matching the training heatmap.
+function sportClass(activity: TrainingHubActivity): string {
+  return `calendar-sport-${sportColorCategory(activity.sportName ?? activity.name)}`;
 }
 
 function completionTone(pct?: number): string {
@@ -80,7 +86,7 @@ function PairChip({
     return (
       <button
         type="button"
-        className={`calendar-chip calendar-chip-paired ${categoryClass(scheduled.name)}`}
+        className={`calendar-chip calendar-chip-paired ${categoryClass(scheduled.name)} ${sportClass(activity)}`}
         onClick={() => onSelectActivity(activity)}
         title={`${scheduled.name} — planned vs actual`}
       >
@@ -221,7 +227,7 @@ export function DayCell({
           <button
             key={`activity-${activity.activityId}`}
             type="button"
-            className="calendar-chip calendar-chip-activity"
+            className={`calendar-chip calendar-chip-activity ${sportClass(activity)}`}
             onClick={() => onSelectActivity(activity)}
             title={activity.name ?? activity.sportName ?? "Activity"}
           >

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,10 +3,13 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import { ThemeProvider } from "./theme/ThemeProvider";
 import { applyTheme, readStoredTheme } from "./theme/theme";
+import { applySportColors, readStoredSportColors } from "./training/sportColors";
 import "./styles.css";
 
 // Apply the persisted theme before the first paint to avoid a dark→light flash.
 applyTheme(readStoredTheme());
+// Apply persisted per-sport colors so the heatmap tints correctly on first paint.
+applySportColors(readStoredSportColors());
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -8,10 +8,19 @@ import {
   Loader2,
   RefreshCw,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type CSSProperties } from "react";
 import type { AppInfo, AppUpdateSnapshot } from "../../electron/types";
 import type { CorosLinkApi } from "../coroslink-api";
 import { formatBytes } from "../media/libraryUtils";
+import {
+  DEFAULT_SPORT_COLORS,
+  SPORT_COLOR_CATEGORIES,
+  SPORT_COLOR_LABELS,
+  applySportColors,
+  readStoredSportColors,
+  storeSportColors,
+  type SportColorCategory,
+} from "../training/sportColors";
 import appLogo from "../../build/icon.png";
 
 const ABOUT_LINKS = [
@@ -68,6 +77,21 @@ export function SettingsView({
   const [openingLocationId, setOpeningLocationId] = useState<string | null>(
     null,
   );
+  const [sportColors, setSportColors] = useState(() => readStoredSportColors());
+
+  function updateSportColor(cat: SportColorCategory, value: string) {
+    const next = { ...sportColors, [cat]: value };
+    setSportColors(next);
+    storeSportColors(next);
+    applySportColors(next);
+  }
+
+  function resetSportColors() {
+    const next = { ...DEFAULT_SPORT_COLORS };
+    setSportColors(next);
+    storeSportColors(next);
+    applySportColors(next);
+  }
 
   const loadAppInfo = useCallback(async () => {
     setLoading(true);
@@ -184,6 +208,50 @@ export function SettingsView({
             </a>
           ))}
         </div>
+      </div>
+
+      <div className="panel">
+        <div className="section-heading">
+          <div>
+            <p className="eyebrow">Appearance</p>
+            <h2>Activity colors</h2>
+          </div>
+          <button
+            className="secondary-button"
+            type="button"
+            onClick={resetSportColors}
+          >
+            <RefreshCw size={15} aria-hidden="true" />
+            Reset to defaults
+          </button>
+        </div>
+        <p className="settings-sport-hint">
+          Color activities by sport in the training load heatmap. Each day uses
+          the color of its highest-load activity.
+        </p>
+        <ul className="settings-sport-list">
+          {SPORT_COLOR_CATEGORIES.map((cat) => (
+            <li className="settings-sport-row" key={cat}>
+              <span className="settings-sport-preview">
+                <span
+                  className="settings-sport-swatch"
+                  style={
+                    { "--sport-color": sportColors[cat] } as CSSProperties
+                  }
+                  aria-hidden="true"
+                />
+                <span>{SPORT_COLOR_LABELS[cat]}</span>
+              </span>
+              <input
+                type="color"
+                className="settings-sport-input"
+                value={sportColors[cat]}
+                onChange={(event) => updateSportColor(cat, event.target.value)}
+                aria-label={`${SPORT_COLOR_LABELS[cat]} color`}
+              />
+            </li>
+          ))}
+        </ul>
       </div>
 
       <div className="panel">

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -1,12 +1,23 @@
 import {
+  ArrowLeft,
+  Bike,
   Bug,
+  ChevronDown,
+  ChevronRight,
   Code2,
   Coffee,
+  Dumbbell,
+  Ellipsis,
   ExternalLink,
   FolderOpen,
+  Footprints,
   Globe2,
+  HardDrive,
   Loader2,
+  Mountain,
   RefreshCw,
+  Sparkles,
+  type LucideIcon,
 } from "lucide-react";
 import { useCallback, useEffect, useState, type CSSProperties } from "react";
 import type { AppInfo, AppUpdateSnapshot } from "../../electron/types";
@@ -52,6 +63,32 @@ const PLATFORM_LABELS: Record<string, string> = {
   linux: "Linux",
 };
 
+const SPORT_COLOR_DETAILS: Record<
+  SportColorCategory,
+  { description: string; icon: LucideIcon }
+> = {
+  strength: {
+    description: "Weight training, strength sessions, gym workouts",
+    icon: Dumbbell,
+  },
+  trail: {
+    description: "Trail running, hiking, off-road activities",
+    icon: Mountain,
+  },
+  run: {
+    description: "Outdoor runs, track runs, intervals",
+    icon: Footprints,
+  },
+  bike: {
+    description: "Road cycling, indoor cycling, e-bike",
+    icon: Bike,
+  },
+  other: {
+    description: "Yoga, pilates, mobility, mixed and other activities",
+    icon: Ellipsis,
+  },
+};
+
 function platformLabel(info: AppInfo): string {
   const name = PLATFORM_LABELS[info.platform] ?? info.platform;
   return `${name} (${info.arch})`;
@@ -77,6 +114,7 @@ export function SettingsView({
   const [openingLocationId, setOpeningLocationId] = useState<string | null>(
     null,
   );
+  const [settingsPage, setSettingsPage] = useState<"main" | "storage">("main");
   const [sportColors, setSportColors] = useState(() => readStoredSportColors());
 
   function updateSportColor(cat: SportColorCategory, value: string) {
@@ -135,6 +173,93 @@ export function SettingsView({
           ? "You're on the latest version."
           : null;
 
+  if (settingsPage === "storage") {
+    return (
+      <section className="settings-view settings-subpage">
+        <button
+          className="settings-subpage-back"
+          type="button"
+          onClick={() => setSettingsPage("main")}
+        >
+          <ArrowLeft size={16} strokeWidth={2} aria-hidden="true" />
+          Settings
+        </button>
+
+        <div className="panel settings-storage-detail-panel">
+          <div className="section-heading settings-storage-detail-heading">
+            <div>
+              <p className="eyebrow">Storage</p>
+              <h2>On this computer</h2>
+              <p className="settings-subpage-description">
+                Review storage use or open an app location on your computer.
+              </p>
+            </div>
+            <button
+              className="icon-button"
+              type="button"
+              title="Refresh storage sizes"
+              aria-label="Refresh storage sizes"
+              onClick={() => void loadAppInfo()}
+              disabled={loading}
+            >
+              <RefreshCw
+                size={16}
+                aria-hidden="true"
+                className={loading ? "spin" : ""}
+              />
+            </button>
+          </div>
+
+          {appInfo ? (
+            <ul className="settings-storage-list">
+              {appInfo.storageLocations.map((location) => (
+                <li className="settings-storage-row" key={location.id}>
+                  <div className="settings-storage-info">
+                    <div className="settings-storage-title">
+                      <strong>{location.label}</strong>
+                      <span className="settings-storage-size">
+                        {location.exists
+                          ? location.sizeBytes !== null
+                            ? formatBytes(location.sizeBytes)
+                            : "Size unavailable"
+                          : "Not created yet"}
+                      </span>
+                    </div>
+                    <p>{location.description}</p>
+                    <code className="settings-storage-path">
+                      {location.path}
+                    </code>
+                  </div>
+                  <button
+                    className="secondary-button"
+                    type="button"
+                    onClick={() => void handleOpenLocation(location.id)}
+                    disabled={
+                      openingLocationId === location.id ||
+                      (location.kind === "file" && !location.exists)
+                    }
+                  >
+                    {openingLocationId === location.id ? (
+                      <Loader2 size={15} aria-hidden="true" className="spin" />
+                    ) : (
+                      <FolderOpen size={15} aria-hidden="true" />
+                    )}
+                    Open in Folder
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="settings-storage-loading">
+              <Loader2 size={16} aria-hidden="true" className="spin" />
+              Loading storage locations…
+            </p>
+          )}
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section className="settings-view">
       <div className="panel settings-about-panel">
@@ -148,7 +273,7 @@ export function SettingsView({
           <div className="settings-about-copy">
             <h3>CorosLink</h3>
             <p>
-              Unofficial COROS companion — media, watch sync, and training
+              Unofficial COROS companion for media, watch sync, and training
               analytics.
             </p>
             {updateStatusText ? (
@@ -177,19 +302,19 @@ export function SettingsView({
           </div>
           <div>
             <dt>Platform</dt>
-            <dd>{appInfo ? platformLabel(appInfo) : "—"}</dd>
+            <dd>{appInfo ? platformLabel(appInfo) : "Not available"}</dd>
           </div>
           <div>
             <dt>Electron</dt>
-            <dd>{appInfo?.electronVersion ?? "—"}</dd>
+            <dd>{appInfo?.electronVersion ?? "Not available"}</dd>
           </div>
           <div>
             <dt>Chromium</dt>
-            <dd>{appInfo?.chromeVersion ?? "—"}</dd>
+            <dd>{appInfo?.chromeVersion ?? "Not available"}</dd>
           </div>
           <div>
             <dt>Node.js</dt>
-            <dd>{appInfo?.nodeVersion ?? "—"}</dd>
+            <dd>{appInfo?.nodeVersion ?? "Not available"}</dd>
           </div>
         </dl>
 
@@ -210,8 +335,8 @@ export function SettingsView({
         </div>
       </div>
 
-      <div className="panel">
-        <div className="section-heading">
+      <div className="panel settings-sport-panel">
+        <div className="section-heading settings-sport-heading">
           <div>
             <p className="eyebrow">Appearance</p>
             <h2>Activity colors</h2>
@@ -226,102 +351,84 @@ export function SettingsView({
           </button>
         </div>
         <p className="settings-sport-hint">
-          Color activities by sport across the app — the training load heatmap
-          and the calendar. In the heatmap, a day with one sport is a solid
-          cell; a day with several is split into a pie of sport colors.
+          Color activities by sport across the training load heatmap and
+          calendar. A day with one sport uses a solid color; days with several
+          sports are split into a color wheel.
         </p>
         <ul className="settings-sport-list">
-          {SPORT_COLOR_CATEGORIES.map((cat) => (
-            <li className="settings-sport-row" key={cat}>
-              <span className="settings-sport-preview">
-                <span
-                  className="settings-sport-swatch"
-                  style={
-                    { "--sport-color": sportColors[cat] } as CSSProperties
-                  }
-                  aria-hidden="true"
-                />
-                <span>{SPORT_COLOR_LABELS[cat]}</span>
-              </span>
-              <input
-                type="color"
-                className="settings-sport-input"
-                value={sportColors[cat]}
-                onChange={(event) => updateSportColor(cat, event.target.value)}
-                aria-label={`${SPORT_COLOR_LABELS[cat]} color`}
-              />
-            </li>
-          ))}
+          {SPORT_COLOR_CATEGORIES.map((cat) => {
+            const { description, icon: SportIcon } = SPORT_COLOR_DETAILS[cat];
+            const colorStyle = {
+              "--sport-color": sportColors[cat],
+            } as CSSProperties;
+
+            return (
+              <li
+                className="settings-sport-row"
+                key={cat}
+                style={colorStyle}
+              >
+                <span className="settings-sport-icon" aria-hidden="true">
+                  <SportIcon size={21} strokeWidth={2.1} />
+                </span>
+                <span className="settings-sport-copy">
+                  <strong>{SPORT_COLOR_LABELS[cat]}</strong>
+                  <span>{description}</span>
+                </span>
+                <label className="settings-sport-picker">
+                  <input
+                    type="color"
+                    className="settings-sport-input"
+                    value={sportColors[cat]}
+                    onChange={(event) =>
+                      updateSportColor(cat, event.target.value)
+                    }
+                    aria-label={`${SPORT_COLOR_LABELS[cat]} color`}
+                  />
+                  <span className="settings-sport-swatch" aria-hidden="true" />
+                  <span className="settings-sport-hex">
+                    {sportColors[cat].toUpperCase()}
+                  </span>
+                  <ChevronDown size={18} strokeWidth={2} aria-hidden="true" />
+                </label>
+              </li>
+            );
+          })}
         </ul>
+        <div className="settings-sport-tip">
+          <Sparkles size={18} strokeWidth={1.8} aria-hidden="true" />
+          <p>
+            <strong>Tip:</strong> These colors are used in your training load
+            heatmap and calendar.
+          </p>
+        </div>
       </div>
 
-      <div className="panel">
-        <div className="section-heading">
-          <div>
-            <p className="eyebrow">Storage</p>
-            <h2>On this computer</h2>
-          </div>
-          <button
-            className="icon-button"
-            type="button"
-            title="Refresh storage sizes"
-            aria-label="Refresh storage sizes"
-            onClick={() => void loadAppInfo()}
-            disabled={loading}
-          >
-            <RefreshCw
-              size={16}
-              aria-hidden="true"
-              className={loading ? "spin" : ""}
-            />
-          </button>
-        </div>
-
-        {appInfo ? (
-          <ul className="settings-storage-list">
-            {appInfo.storageLocations.map((location) => (
-              <li className="settings-storage-row" key={location.id}>
-                <div className="settings-storage-info">
-                  <div className="settings-storage-title">
-                    <strong>{location.label}</strong>
-                    <span className="settings-storage-size">
-                      {location.exists
-                        ? location.sizeBytes !== null
-                          ? formatBytes(location.sizeBytes)
-                          : "Size unavailable"
-                        : "Not created yet"}
-                    </span>
-                  </div>
-                  <p>{location.description}</p>
-                  <code className="settings-storage-path">
-                    {location.path}
-                  </code>
-                </div>
-                <button
-                  className="secondary-button"
-                  type="button"
-                  onClick={() => void handleOpenLocation(location.id)}
-                  disabled={
-                    openingLocationId === location.id ||
-                    (location.kind === "file" && !location.exists)
-                  }
-                >
-                  {openingLocationId === location.id ? (
-                    <Loader2 size={15} aria-hidden="true" className="spin" />
-                  ) : (
-                    <FolderOpen size={15} aria-hidden="true" />
-                  )}
-                  Open in Folder
-                </button>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="settings-storage-loading">
-            <Loader2 size={16} aria-hidden="true" className="spin" />
-            Loading storage locations…
-          </p>
-        )}
+      <div className="panel settings-storage-panel">
+        <p className="eyebrow">Storage</p>
+        <button
+          className="settings-storage-link"
+          type="button"
+          onClick={() => setSettingsPage("storage")}
+        >
+          <span className="settings-storage-link-icon" aria-hidden="true">
+            <HardDrive size={22} strokeWidth={1.9} />
+          </span>
+          <span className="settings-storage-link-copy">
+            <strong>On this computer</strong>
+            <span>
+              {appInfo
+                ? `${appInfo.storageLocations.length} storage locations`
+                : "Downloads, projects, caches, and app data"}
+            </span>
+          </span>
+          <ChevronRight
+            className="settings-storage-link-chevron"
+            size={20}
+            strokeWidth={2}
+            aria-hidden="true"
+          />
+        </button>
       </div>
     </section>
   );

--- a/src/settings/SettingsView.tsx
+++ b/src/settings/SettingsView.tsx
@@ -226,8 +226,9 @@ export function SettingsView({
           </button>
         </div>
         <p className="settings-sport-hint">
-          Color activities by sport in the training load heatmap. Each day uses
-          the color of its highest-load activity.
+          Color activities by sport across the app — the training load heatmap
+          and the calendar. In the heatmap, a day with one sport is a solid
+          cell; a day with several is split into a pie of sport colors.
         </p>
         <ul className="settings-sport-list">
           {SPORT_COLOR_CATEGORIES.map((cat) => (

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,14 @@
 :root {
   color-scheme: dark;
 
+  /* Per-sport activity colors. Overridden at runtime from localStorage via
+     applySportColors(); customizable in Settings → Activity colors. */
+  --sport-strength: #e5484d;
+  --sport-trail: #4c8dff;
+  --sport-run: #2fbe91;
+  --sport-bike: #e6b800;
+  --sport-other: #7fd8cf;
+
   --bg-base: #05080b;
   --bg-ambient-green: rgba(47, 190, 145, 0.1);
   --bg-ambient-teal: rgba(31, 182, 166, 0.07);
@@ -11817,6 +11825,10 @@ td span {
 }
 
 .training-heatmap-cell {
+  /* Base hue for the day; overridden inline per cell with the dominant sport
+     color so intensity (level) and sport (hue) compose. Falls back to the
+     original green when a day has load but no matching activity. */
+  --cell-color: #2d9a74;
   position: relative;
   width: 100%;
   height: 100%;
@@ -11849,8 +11861,8 @@ td span {
   inset: 0;
   border-radius: inherit;
   box-shadow:
-    0 0 22px rgba(45, 154, 116, 0.55),
-    0 0 36px rgba(45, 154, 116, 0.2);
+    0 0 22px color-mix(in srgb, var(--cell-color) 55%, transparent),
+    0 0 36px color-mix(in srgb, var(--cell-color) 20%, transparent);
   opacity: 0;
   pointer-events: none;
   animation: heatmap-peak-glow 2.8s ease-in-out 1.1s infinite;
@@ -11868,20 +11880,25 @@ td span {
 }
 
 .training-heatmap-cell[data-level="1"] {
-  background: rgba(45, 154, 116, 0.28);
+  background: color-mix(in srgb, var(--cell-color) 28%, transparent);
 }
 
 .training-heatmap-cell[data-level="2"] {
-  background: rgba(45, 154, 116, 0.48);
+  background: color-mix(in srgb, var(--cell-color) 48%, transparent);
 }
 
 .training-heatmap-cell[data-level="3"] {
-  background: rgba(45, 154, 116, 0.72);
+  background: color-mix(in srgb, var(--cell-color) 72%, transparent);
 }
 
 .training-heatmap-cell[data-level="4"] {
-  background: linear-gradient(145deg, #3eb889 0%, #2d9a74 55%, #248f6a 100%);
-  box-shadow: 0 0 14px rgba(45, 154, 116, 0.35);
+  background: linear-gradient(
+    145deg,
+    color-mix(in srgb, var(--cell-color) 88%, #fff) 0%,
+    var(--cell-color) 55%,
+    color-mix(in srgb, var(--cell-color) 88%, #000) 100%
+  );
+  box-shadow: 0 0 14px color-mix(in srgb, var(--cell-color) 35%, transparent);
 }
 
 .training-heatmap-cell:not(.is-empty):hover,
@@ -11890,7 +11907,7 @@ td span {
   filter: brightness(1.12);
   box-shadow:
     0 0 0 2px rgba(255, 255, 255, 0.2),
-    0 0 20px rgba(45, 154, 116, 0.45);
+    0 0 20px color-mix(in srgb, var(--cell-color) 45%, transparent);
   z-index: 2;
 }
 
@@ -11943,10 +11960,44 @@ td span {
   padding-top: 4px;
 }
 
+.training-heatmap-legends {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 20px;
+}
+
 .training-heatmap-legend {
   display: flex;
   align-items: center;
   gap: clamp(5px, 0.6vw, 8px);
+}
+
+.training-heatmap-sport-legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 14px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.training-heatmap-sport-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: clamp(11px, 1vw, 13px);
+  font-weight: 600;
+}
+
+.training-heatmap-sport-swatch {
+  width: clamp(11px, 1.1vw, 14px);
+  height: clamp(11px, 1.1vw, 14px);
+  border-radius: 4px;
+  background: var(--cell-color);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.12) inset;
 }
 
 .training-heatmap-legend-label {
@@ -22507,6 +22558,52 @@ tr.data-intervals-row-missing {
   flex-direction: column;
   gap: 18px;
   max-width: 980px;
+}
+
+.settings-sport-hint {
+  margin: 4px 0 12px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.settings-sport-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.settings-sport-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.settings-sport-preview {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 14px;
+}
+.settings-sport-swatch {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  background: var(--sport-color);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.12) inset;
+}
+.settings-sport-input {
+  flex: 0 0 auto;
+  width: 44px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  cursor: pointer;
 }
 
 .settings-about-panel {

--- a/src/styles.css
+++ b/src/styles.css
@@ -21957,6 +21957,25 @@ tr.data-intervals-row-missing {
   border-left-color: var(--accent-strong);
 }
 
+/* Completed-activity chips are tinted by sport, matching the training heatmap.
+   Two classes (.calendar-chip is always present) beat the single-class
+   activity/paired defaults above. */
+.calendar-chip.calendar-sport-strength {
+  border-left-color: var(--sport-strength);
+}
+.calendar-chip.calendar-sport-trail {
+  border-left-color: var(--sport-trail);
+}
+.calendar-chip.calendar-sport-run {
+  border-left-color: var(--sport-run);
+}
+.calendar-chip.calendar-sport-bike {
+  border-left-color: var(--sport-bike);
+}
+.calendar-chip.calendar-sport-other {
+  border-left-color: var(--sport-other);
+}
+
 .calendar-cat-easy { border-left-color: #5eb9f0; }
 .calendar-cat-long { border-left-color: #a78bfa; }
 .calendar-cat-intervals { border-left-color: #f0785e; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -22584,9 +22584,31 @@ tr.data-intervals-row-missing {
 }
 
 .settings-sport-hint {
-  margin: 4px 0 12px;
+  max-width: 760px;
+  margin: 7px 0 14px;
   color: var(--text-muted);
   font-size: 13px;
+  line-height: 1.5;
+}
+.settings-sport-panel {
+  padding: 20px;
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.035), transparent 56%),
+    var(--glass-bg);
+}
+.settings-sport-heading {
+  align-items: flex-start;
+}
+.settings-sport-heading h2 {
+  margin-top: 3px;
+  font-size: clamp(21px, 2.2vw, 26px);
+  letter-spacing: -0.025em;
+}
+.settings-sport-heading .secondary-button {
+  min-height: 36px;
+  padding-inline: 12px;
+  white-space: nowrap;
 }
 .settings-sport-list {
   list-style: none;
@@ -22594,39 +22616,128 @@ tr.data-intervals-row-missing {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 .settings-sport-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  gap: 11px;
+  min-height: 64px;
+  padding: 8px 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.035);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+  transition:
+    background 0.18s ease,
+    border-color 0.18s ease,
+    transform 0.18s ease;
 }
-.settings-sport-preview {
+.settings-sport-row:hover {
+  border-color: color-mix(in srgb, var(--sport-color) 34%, var(--glass-border));
+  background: color-mix(in srgb, var(--sport-color) 5%, var(--glass-bg-hover));
+  transform: translateY(-1px);
+}
+.settings-sport-icon {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--sport-color) 55%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--sport-color) 13%, transparent);
+  color: var(--sport-color);
+}
+.settings-sport-copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+.settings-sport-copy strong {
+  color: var(--text-primary);
+  font-size: 14px;
+  line-height: 1.3;
+}
+.settings-sport-copy > span {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.settings-sport-picker {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 10px;
-  flex: 1 1 auto;
-  min-width: 0;
-  font-size: 14px;
+  gap: 9px;
+  min-width: 164px;
+  min-height: 42px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  padding: 5px 10px 5px 5px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    background 0.18s ease,
+    border-color 0.18s ease;
+}
+.settings-sport-picker:hover {
+  border-color: var(--glass-border);
+  background: var(--glass-bg-hover);
+}
+.settings-sport-picker:has(.settings-sport-input:focus-visible) {
+  outline: 2px solid color-mix(in srgb, var(--sport-color) 65%, white);
+  outline-offset: 2px;
 }
 .settings-sport-swatch {
   flex: 0 0 auto;
-  width: 16px;
-  height: 16px;
-  border-radius: 4px;
+  width: 40px;
+  height: 32px;
+  border: 3px solid rgba(255, 255, 255, 0.07);
+  border-radius: var(--radius-sm);
   background: var(--sport-color);
-  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.12) inset;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.24) inset,
+    0 0 0 1px rgba(0, 0, 0, 0.16);
+}
+.settings-sport-hex {
+  min-width: 62px;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
 }
 .settings-sport-input {
-  flex: 0 0 auto;
-  width: 44px;
-  height: 32px;
-  padding: 0;
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius-sm);
-  background: transparent;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  opacity: 0;
   cursor: pointer;
+}
+.settings-sport-tip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: var(--glass-bg);
+  padding: 10px 13px;
+  color: var(--text-muted);
+}
+.settings-sport-tip svg {
+  flex: 0 0 auto;
+  color: var(--accent);
+}
+.settings-sport-tip p {
+  margin: 0;
+  font-size: 13px;
+}
+.settings-sport-tip strong {
+  color: var(--text-secondary);
 }
 
 .settings-about-panel {
@@ -22727,6 +22838,125 @@ tr.data-intervals-row-missing {
   color: var(--accent);
 }
 
+.settings-storage-panel {
+  padding: 20px;
+}
+
+.settings-storage-panel > .eyebrow {
+  margin: 0 0 10px;
+}
+
+.settings-storage-link {
+  display: grid;
+  grid-template-columns: 46px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 13px;
+  width: 100%;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: var(--glass-bg);
+  padding: 12px 14px;
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background 0.18s ease,
+    border-color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.settings-storage-link:hover {
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--glass-border));
+  background: var(--glass-bg-hover);
+  transform: translateY(-1px);
+}
+
+.settings-storage-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.settings-storage-link-icon {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--accent) 32%, var(--glass-border));
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  color: var(--accent);
+}
+
+.settings-storage-link-copy {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.settings-storage-link-copy strong {
+  font-size: 15px;
+}
+
+.settings-storage-link-copy > span {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.settings-storage-link-chevron {
+  color: var(--text-muted);
+}
+
+.settings-subpage {
+  gap: 12px;
+}
+
+.settings-subpage-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  align-self: flex-start;
+  min-height: 36px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--glass-bg);
+  padding: 0 12px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 0.18s ease,
+    border-color 0.18s ease,
+    color 0.18s ease;
+}
+
+.settings-subpage-back:hover {
+  border-color: color-mix(in srgb, var(--accent) 42%, var(--glass-border));
+  background: var(--glass-bg-hover);
+  color: var(--text-primary);
+}
+
+.settings-subpage-back:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.settings-storage-detail-panel {
+  padding: 24px;
+}
+
+.settings-storage-detail-heading {
+  align-items: flex-start;
+}
+
+.settings-subpage-description {
+  max-width: 620px;
+  margin: 7px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
 .settings-storage-list {
   list-style: none;
   display: flex;
@@ -22793,6 +23023,35 @@ tr.data-intervals-row-missing {
 }
 
 @media (max-width: 720px) {
+  .settings-sport-panel {
+    padding: 18px;
+  }
+
+  .settings-sport-heading {
+    gap: 14px;
+  }
+
+  .settings-sport-row {
+    grid-template-columns: 42px minmax(0, 1fr);
+    min-height: 0;
+    padding: 12px;
+  }
+
+  .settings-sport-icon {
+    width: 42px;
+    height: 42px;
+  }
+
+  .settings-sport-picker {
+    grid-column: 1 / -1;
+    width: 100%;
+    min-width: 0;
+  }
+
+  .settings-sport-picker svg {
+    margin-left: auto;
+  }
+
   .settings-about-header {
     flex-wrap: wrap;
   }
@@ -22800,6 +23059,26 @@ tr.data-intervals-row-missing {
   .settings-storage-row {
     flex-direction: column;
     align-items: stretch;
+  }
+
+  .settings-storage-panel {
+    padding: 18px;
+  }
+
+  .settings-storage-detail-panel {
+    padding: 18px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-sport-row,
+  .settings-storage-link {
+    transition: none;
+  }
+
+  .settings-sport-row:hover,
+  .settings-storage-link:hover {
+    transform: none;
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,7 +2,9 @@
   color-scheme: dark;
 
   /* Per-sport activity colors. Overridden at runtime from localStorage via
-     applySportColors(); customizable in Settings → Activity colors. */
+     applySportColors(); customizable in Settings → Activity colors.
+     Mirrors DEFAULT_SPORT_COLORS in src/training/sportColors.ts (the source
+     of truth) — test:sport-colors asserts the two stay in sync. */
   --sport-strength: #e5484d;
   --sport-trail: #4c8dff;
   --sport-run: #2fbe91;
@@ -11827,7 +11829,9 @@ td span {
 .training-heatmap-cell {
   /* Base hue for the day; overridden inline per cell with the dominant sport
      color so intensity (level) and sport (hue) compose. Falls back to the
-     original green when a day has load but no matching activity. */
+     original green when a day has load but no matching activity — this is the
+     legacy pre-sport-colors heatmap green, intentionally not a --sport-* value
+     (and intentionally distinct from --sport-run). */
   --cell-color: #2d9a74;
   position: relative;
   width: 100%;

--- a/src/training/components/TrainingHeatmapPanel.tsx
+++ b/src/training/components/TrainingHeatmapPanel.tsx
@@ -18,8 +18,10 @@ import {
 } from "../weeklyActivity";
 import {
   buildDominantSportByDay,
+  buildSportCategoriesByDay,
   SPORT_COLOR_CATEGORIES,
-  SPORT_COLOR_LABELS
+  SPORT_COLOR_LABELS,
+  type SportColorCategory
 } from "../sportColors";
 import type { HeatmapCell, TrainingHubSnapshot } from "../types";
 
@@ -30,6 +32,29 @@ interface TrainingHeatmapPanelProps {
 
 const WEEKDAY_LABELS = ["M", "T", "W", "T", "F", "S", "S"];
 const LEGEND_LEVELS = [0, 1, 2, 3, 4] as const;
+
+// Opacity per intensity level, mirroring the single-sport CSS levels so a
+// multi-sport pie reads at the same darkness as a solid cell of the same load.
+const LEVEL_ALPHA: Record<number, number> = { 1: 28, 2: 48, 3: 72, 4: 100 };
+
+function sliceColor(cat: SportColorCategory, level: number): string {
+  const pct = LEVEL_ALPHA[level] ?? 100;
+  return `color-mix(in srgb, var(--sport-${cat}) ${pct}%, transparent)`;
+}
+
+// Split a day's cell into equal pie slices, one per distinct sport category.
+function pieBackground(
+  categories: SportColorCategory[],
+  level: number
+): string {
+  const n = categories.length;
+  const stops = categories.map((cat, index) => {
+    const from = ((index / n) * 360).toFixed(3);
+    const to = (((index + 1) / n) * 360).toFixed(3);
+    return `${sliceColor(cat, level)} ${from}deg ${to}deg`;
+  });
+  return `conic-gradient(${stops.join(", ")})`;
+}
 
 function usePrefersReducedMotion() {
   const [reducedMotion, setReducedMotion] = useState(false);
@@ -84,11 +109,22 @@ export function TrainingHeatmapPanel({
     () => buildDominantSportByDay(activities),
     [activities]
   );
-  // Only show sports that actually appear in the visible range, in canonical order.
+  // Distinct sport categories per day → equal pie slices when there are 2+.
+  const sportsByDay = useMemo(
+    () => buildSportCategoriesByDay(activities),
+    [activities]
+  );
+  // Only show sports that actually appear in the visible range, in canonical
+  // order — including those that only ever show up as a pie slice.
   const presentSports = useMemo(() => {
-    const seen = new Set(sportByDay.values());
+    const seen = new Set<SportColorCategory>();
+    for (const set of sportsByDay.values()) {
+      for (const cat of set) {
+        seen.add(cat);
+      }
+    }
     return SPORT_COLOR_CATEGORIES.filter((cat) => seen.has(cat));
-  }, [sportByDay]);
+  }, [sportsByDay]);
   const hasData = cells.some((cell) => cell.level > 0);
 
   useEffect(() => {
@@ -169,14 +205,23 @@ export function TrainingHeatmapPanel({
                   const loadLabel = formatOptionalNumber(cell.trainingLoad);
                   const distanceLabel = formatDistanceMeters(cell.distance);
                   const durationLabel = formatDurationSeconds(cell.duration);
-                  const sportCategory =
+                  const dominantSport =
                     cell.level > 0 ? sportByDay.get(cell.happenDay) : undefined;
+                  const daySports =
+                    cell.level > 0
+                      ? [...(sportsByDay.get(cell.happenDay) ?? [])]
+                      : [];
                   const cellStyle: Record<string, string> = {};
                   if (!reducedMotion) {
                     cellStyle.animationDelay = `${staggerDelay}ms`;
                   }
-                  if (sportCategory) {
-                    cellStyle["--cell-color"] = `var(--sport-${sportCategory})`;
+                  // Dominant sport sets the hue for glow/hover and the single-
+                  // sport fill; 2+ sports split the cell into equal pie slices.
+                  if (dominantSport) {
+                    cellStyle["--cell-color"] = `var(--sport-${dominantSport})`;
+                  }
+                  if (daySports.length >= 2) {
+                    cellStyle.background = pieBackground(daySports, cell.level);
                   }
 
                   return (

--- a/src/training/components/TrainingHeatmapPanel.tsx
+++ b/src/training/components/TrainingHeatmapPanel.tsx
@@ -16,6 +16,11 @@ import {
 import {
   enrichDayListWithActivityTotals
 } from "../weeklyActivity";
+import {
+  buildDominantSportByDay,
+  SPORT_COLOR_CATEGORIES,
+  SPORT_COLOR_LABELS
+} from "../sportColors";
 import type { HeatmapCell, TrainingHubSnapshot } from "../types";
 
 interface TrainingHeatmapPanelProps {
@@ -74,6 +79,16 @@ export function TrainingHeatmapPanel({
   );
   const grid = useMemo(() => buildHeatmapGrid(cells), [cells]);
   const summary = useMemo(() => buildHeatmapSummary(cells), [cells]);
+  // Color each day by the sport of that day's highest-training-load activity.
+  const sportByDay = useMemo(
+    () => buildDominantSportByDay(activities),
+    [activities]
+  );
+  // Only show sports that actually appear in the visible range, in canonical order.
+  const presentSports = useMemo(() => {
+    const seen = new Set(sportByDay.values());
+    return SPORT_COLOR_CATEGORIES.filter((cat) => seen.has(cat));
+  }, [sportByDay]);
   const hasData = cells.some((cell) => cell.level > 0);
 
   useEffect(() => {
@@ -154,6 +169,15 @@ export function TrainingHeatmapPanel({
                   const loadLabel = formatOptionalNumber(cell.trainingLoad);
                   const distanceLabel = formatDistanceMeters(cell.distance);
                   const durationLabel = formatDurationSeconds(cell.duration);
+                  const sportCategory =
+                    cell.level > 0 ? sportByDay.get(cell.happenDay) : undefined;
+                  const cellStyle: Record<string, string> = {};
+                  if (!reducedMotion) {
+                    cellStyle.animationDelay = `${staggerDelay}ms`;
+                  }
+                  if (sportCategory) {
+                    cellStyle["--cell-color"] = `var(--sport-${sportCategory})`;
+                  }
 
                   return (
                     <span
@@ -165,11 +189,7 @@ export function TrainingHeatmapPanel({
                       role="gridcell"
                       tabIndex={0}
                       aria-label={formatCellAriaLabel(cell)}
-                      style={
-                        reducedMotion
-                          ? undefined
-                          : { animationDelay: `${staggerDelay}ms` }
-                      }
+                      style={cellStyle as CSSProperties}
                     >
                       <span className="training-heatmap-tooltip" role="tooltip">
                         <strong>{cell.label}</strong>
@@ -185,16 +205,37 @@ export function TrainingHeatmapPanel({
           </div>
 
           <div className="training-heatmap-footer">
-            <div className="training-heatmap-legend" aria-hidden="true">
-              <span className="training-heatmap-legend-label">Less</span>
-              {LEGEND_LEVELS.map((level) => (
-                <span
-                  key={level}
-                  className="training-heatmap-legend-cell"
-                  data-level={level}
-                />
-              ))}
-              <span className="training-heatmap-legend-label">More</span>
+            <div className="training-heatmap-legends">
+              <div className="training-heatmap-legend" aria-hidden="true">
+                <span className="training-heatmap-legend-label">Less</span>
+                {LEGEND_LEVELS.map((level) => (
+                  <span
+                    key={level}
+                    className="training-heatmap-legend-cell"
+                    data-level={level}
+                  />
+                ))}
+                <span className="training-heatmap-legend-label">More</span>
+              </div>
+
+              {presentSports.length > 0 ? (
+                <ul className="training-heatmap-sport-legend">
+                  {presentSports.map((cat) => (
+                    <li key={cat} className="training-heatmap-sport-legend-item">
+                      <span
+                        className="training-heatmap-sport-swatch"
+                        style={
+                          {
+                            "--cell-color": `var(--sport-${cat})`
+                          } as CSSProperties
+                        }
+                        aria-hidden="true"
+                      />
+                      <span>{SPORT_COLOR_LABELS[cat]}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
             </div>
 
             <div className="training-heatmap-summary">

--- a/src/training/sportColors.ts
+++ b/src/training/sportColors.ts
@@ -1,0 +1,150 @@
+import type { TrainingHubActivity } from "../../electron/types";
+
+export type SportColorCategory = "strength" | "trail" | "run" | "bike" | "other";
+
+export const SPORT_COLOR_CATEGORIES: SportColorCategory[] = [
+  "strength",
+  "trail",
+  "run",
+  "bike",
+  "other"
+];
+
+export const DEFAULT_SPORT_COLORS: Record<SportColorCategory, string> = {
+  strength: "#e5484d",
+  trail: "#4c8dff",
+  run: "#2fbe91",
+  bike: "#e6b800",
+  other: "#7fd8cf"
+};
+
+export const SPORT_COLOR_LABELS: Record<SportColorCategory, string> = {
+  strength: "Strength / Gym",
+  trail: "Trail",
+  run: "Running",
+  bike: "Cycling",
+  other: "Other"
+};
+
+const STORAGE_KEY = "coroslink.sportColors";
+const HEX_RE = /^#[0-9a-fA-F]{6}$/;
+
+/**
+ * Categorize an activity by its sport name. Trail and bike are checked before
+ * run so "TrailRun"/"VirtualRide" don't fall into run. Matches FR + EN names.
+ */
+export function sportColorCategory(
+  name: string | undefined
+): SportColorCategory {
+  const n = (name ?? "").toLowerCase();
+  if (!n) return "other";
+  if (/trail/.test(n)) return "trail";
+  if (/(bike|cycl|ride|v[ée]lo|spin)/.test(n)) return "bike";
+  if (/(run|jog|course|marathon|tempo|track|\d+\s?k\b)/.test(n)) return "run";
+  if (/(muscu|weight|strength|gym|\bcore\b|workout|entra[iî]n)/.test(n)) {
+    return "strength";
+  }
+  return "other";
+}
+
+/** Parse a stored JSON blob, merging valid hex values over the defaults. */
+export function parseSportColors(
+  raw: string | null
+): Record<SportColorCategory, string> {
+  const result = { ...DEFAULT_SPORT_COLORS };
+  if (!raw) return result;
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    for (const cat of SPORT_COLOR_CATEGORIES) {
+      const value = parsed[cat];
+      if (typeof value === "string" && HEX_RE.test(value)) {
+        result[cat] = value;
+      }
+    }
+  } catch {
+    // malformed → defaults
+  }
+  return result;
+}
+
+export function readStoredSportColors(): Record<SportColorCategory, string> {
+  const raw =
+    typeof localStorage !== "undefined"
+      ? localStorage.getItem(STORAGE_KEY)
+      : null;
+  return parseSportColors(raw);
+}
+
+export function storeSportColors(
+  colors: Record<SportColorCategory, string>
+): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(colors));
+  } catch {
+    // storage unavailable — ignore
+  }
+}
+
+/** Set --sport-<cat> custom properties on the document root. */
+export function applySportColors(
+  colors: Record<SportColorCategory, string>
+): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  for (const cat of SPORT_COLOR_CATEGORIES) {
+    root.style.setProperty(`--sport-${cat}`, colors[cat]);
+  }
+}
+
+function dateToHappenDay(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}${month}${day}`;
+}
+
+/** Local-time YYYYMMDD for an epoch (seconds or ms), mirroring weeklyActivity. */
+export function happenDayFromTimestamp(timestamp?: number): string | undefined {
+  if (timestamp === undefined || !Number.isFinite(timestamp) || timestamp <= 0) {
+    return undefined;
+  }
+  const ms = timestamp < 10_000_000_000 ? timestamp * 1000 : timestamp;
+  return dateToHappenDay(new Date(ms));
+}
+
+/**
+ * Map each day (YYYYMMDD) to the sport color category of that day's activity
+ * with the highest training load. Ties and missing/zero TL keep the first
+ * activity seen for the day; a missing sport name resolves to "other".
+ */
+export function buildDominantSportByDay(
+  activities: TrainingHubActivity[]
+): Map<string, SportColorCategory> {
+  const best = new Map<string, { load: number; category: SportColorCategory }>();
+
+  for (const activity of activities) {
+    const happenDay = happenDayFromTimestamp(activity.startTime);
+    if (!happenDay) {
+      continue;
+    }
+
+    const load =
+      activity.trainingLoad !== undefined &&
+      Number.isFinite(activity.trainingLoad)
+        ? activity.trainingLoad
+        : 0;
+    const category = sportColorCategory(activity.sportName);
+    const current = best.get(happenDay);
+
+    // Strictly greater keeps the first activity on a tie (deterministic).
+    if (!current || load > current.load) {
+      best.set(happenDay, { load, category });
+    }
+  }
+
+  const result = new Map<string, SportColorCategory>();
+  for (const [happenDay, entry] of best) {
+    result.set(happenDay, entry.category);
+  }
+  return result;
+}

--- a/src/training/sportColors.ts
+++ b/src/training/sportColors.ts
@@ -10,6 +10,8 @@ export const SPORT_COLOR_CATEGORIES: SportColorCategory[] = [
   "other"
 ];
 
+// Source of truth for the default palette. The :root --sport-* fallbacks in
+// src/styles.css mirror these values; test:sport-colors asserts they match.
 export const DEFAULT_SPORT_COLORS: Record<SportColorCategory, string> = {
   strength: "#e5484d",
   trail: "#4c8dff",

--- a/src/training/sportColors.ts
+++ b/src/training/sportColors.ts
@@ -29,22 +29,36 @@ export const SPORT_COLOR_LABELS: Record<SportColorCategory, string> = {
 const STORAGE_KEY = "coroslink.sportColors";
 const HEX_RE = /^#[0-9a-fA-F]{6}$/;
 
+// Stable COROS sportType codes → color category; keep the codes in sync with
+// electron/corosSportTypes.ts. Everything not listed (swim, triathlon, ski,
+// rowing, climbing, walk, unknown codes) falls back to "other".
+const SPORT_TYPE_CATEGORY: Record<number, SportColorCategory> = {
+  100: "run", //      Run
+  101: "run", //      Indoor Run
+  102: "trail", //    Trail Run
+  103: "run", //      Track Run
+  104: "run", //      Treadmill Run
+  200: "bike", //     Road Bike
+  201: "bike", //     Indoor Bike
+  202: "bike", //     E-Bike
+  203: "bike", //     Gravel Bike
+  204: "bike", //     Mountain Bike
+  402: "strength", // Strength
+  403: "strength", // Cardio (gym)
+  700: "trail" //     Hiking
+};
+
 /**
- * Categorize an activity by its sport name. Trail and bike are checked before
- * run so "TrailRun"/"VirtualRide" don't fall into run. Matches FR + EN names.
+ * Categorize an activity by its numeric COROS sportType code — names are
+ * user-editable free text and unreliable. Unknown or missing codes → "other".
  */
 export function sportColorCategory(
-  name: string | undefined
+  sportType: number | undefined
 ): SportColorCategory {
-  const n = (name ?? "").toLowerCase();
-  if (!n) return "other";
-  if (/trail/.test(n)) return "trail";
-  if (/(bike|cycl|ride|v[ée]lo|spin)/.test(n)) return "bike";
-  if (/(run|jog|course|marathon|tempo|track|\d+\s?k\b)/.test(n)) return "run";
-  if (/(muscu|weight|strength|gym|\bcore\b|workout|entra[iî]n)/.test(n)) {
-    return "strength";
-  }
-  return "other";
+  return (
+    (sportType !== undefined ? SPORT_TYPE_CATEGORY[sportType] : undefined) ??
+    "other"
+  );
 }
 
 /** Parse a stored JSON blob, merging valid hex values over the defaults. */
@@ -115,7 +129,7 @@ export function happenDayFromTimestamp(timestamp?: number): string | undefined {
 /**
  * Map each day (YYYYMMDD) to the sport color category of that day's activity
  * with the highest training load. Ties and missing/zero TL keep the first
- * activity seen for the day; a missing sport name resolves to "other".
+ * activity seen for the day; an unknown sportType code resolves to "other".
  */
 export function buildDominantSportByDay(
   activities: TrainingHubActivity[]
@@ -133,7 +147,7 @@ export function buildDominantSportByDay(
       Number.isFinite(activity.trainingLoad)
         ? activity.trainingLoad
         : 0;
-    const category = sportColorCategory(activity.sportName);
+    const category = sportColorCategory(activity.sportType);
     const current = best.get(happenDay);
 
     // Strictly greater keeps the first activity on a tie (deterministic).
@@ -166,7 +180,7 @@ export function buildSportCategoriesByDay(
       continue;
     }
 
-    const category = sportColorCategory(activity.sportName);
+    const category = sportColorCategory(activity.sportType);
     const set = byDay.get(happenDay) ?? new Set<SportColorCategory>();
     set.add(category);
     byDay.set(happenDay, set);

--- a/src/training/sportColors.ts
+++ b/src/training/sportColors.ts
@@ -148,3 +148,37 @@ export function buildDominantSportByDay(
   }
   return result;
 }
+
+/**
+ * Map each day (YYYYMMDD) to the distinct sport color categories done that day,
+ * in canonical order. Multiple activities of the same category collapse to a
+ * single entry (e.g. two bike rides → one "bike"). Used to split a day's cell
+ * into equal slices, one per sport.
+ */
+export function buildSportCategoriesByDay(
+  activities: TrainingHubActivity[]
+): Map<string, Set<SportColorCategory>> {
+  const byDay = new Map<string, Set<SportColorCategory>>();
+
+  for (const activity of activities) {
+    const happenDay = happenDayFromTimestamp(activity.startTime);
+    if (!happenDay) {
+      continue;
+    }
+
+    const category = sportColorCategory(activity.sportName);
+    const set = byDay.get(happenDay) ?? new Set<SportColorCategory>();
+    set.add(category);
+    byDay.set(happenDay, set);
+  }
+
+  // Re-emit each set as canonically ordered for deterministic slice order.
+  const result = new Map<string, Set<SportColorCategory>>();
+  for (const [happenDay, set] of byDay) {
+    result.set(
+      happenDay,
+      new Set(SPORT_COLOR_CATEGORIES.filter((cat) => set.has(cat)))
+    );
+  }
+  return result;
+}


### PR DESCRIPTION
## What

A shared **per-sport color scheme** applied consistently across the app — the Training Activity **load heatmap** and the **calendar** — customizable in Settings.

## Heatmap
<img width="1591" height="417" alt="Screenshot 2026-07-14 at 09 50 41" src="https://github.com/user-attachments/assets/aad18e74-633f-48e8-880b-6cea1762c6a1" />

- **Hue = sport**: each day is tinted by that day's activities.
  - One sport (or several of the same type) → **solid** cell in that sport's color.
  - **2+ distinct sports** → the cell is **split into equal pie slices**, one color per sport (activities grouped by category first, so two bike rides = one slice).
- **Intensity = training load**: the 4 intensity levels (training-load only) are preserved; each cell/slice is tinted by its load level.
- **Sport legend** beside the intensity legend, listing only the sports present in the visible range (including sports that only appear as a slice).
- Days with load but no matching activity fall back to the original green.

## Calendar
<img width="404" height="205" alt="Screenshot 2026-07-14 at 11 04 01" src="https://github.com/user-attachments/assets/5c6f2eb5-67fc-4fe2-9139-c03d9179be19" />

- Completed-activity chips (free activities and realized planned sessions) get a **sport-colored left border**; planned-only chips keep their neutral style.

## Settings

- **Appearance → Activity colors**: color pickers + reset, persisted in localStorage and applied on startup like the theme.
<img width="982" height="358" alt="Screenshot 2026-07-14 at 11 04 24" src="https://github.com/user-attachments/assets/1f529449-51ea-4727-acaa-bde98b1451ae" />

## Categories

Strength / Gym · Trail · Running · Cycling · Other — matched from sport names (FR + EN); trail/bike checked before run.

## Files

- `src/training/sportColors.ts` — categorization + persistence, `applySportColors` (→ `--sport-*` vars), `buildDominantSportByDay`, `buildSportCategoriesByDay`.
- `src/training/components/TrainingHeatmapPanel.tsx` — dominant hue, multi-sport pie (conic-gradient), sport legend.
- `src/calendar/DayCell.tsx` — sport-tinted completed-activity chips.
- `src/settings/SettingsView.tsx` — Activity colors card.
- `src/main.tsx`, `src/styles.css` — startup apply, `--sport-*` defaults, heatmap/calendar/settings styles.
- `scripts/test-sport-colors.mjs` — TDD: categorization, tie-break, distinct-categories-per-day, missing TL / sport name, s/ms timestamps.

## Test

`npm run test:sport-colors` ✅ · `npm run build` ✅ · verified live (heatmap solid + pie, calendar chips, Settings recolor, legend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
