### PR TITLE
Fix load-heatmap streak resetting to 0 on an untrained today

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:sleep-data-parser": "npm run build:electron && node scripts/test-sleep-data-parser.mjs",
     "test:daily-health-data-parser": "npm run build:electron && node scripts/test-daily-health-data-parser.mjs",
     "test:training-formatters": "npm run build:electron && node --experimental-strip-types scripts/test-training-formatters.mjs",
+    "test:heatmap-summary": "node --experimental-strip-types --import ./scripts/register-ts-ext.mjs scripts/test-heatmap-summary.mjs",
     "test:exercise-names": "node --experimental-strip-types scripts/test-exercise-names.mjs",
     "test:strength-detail": "node --experimental-strip-types scripts/test-strength-detail.mjs",
     "test:chat-workout-tools": "npm run build:electron && node scripts/test-chat-workout-tools.mjs",

--- a/scripts/register-ts-ext.mjs
+++ b/scripts/register-ts-ext.mjs
@@ -1,0 +1,4 @@
+// Registers the ts-ext resolve hook via the non-deprecated module API so test
+// scripts can import extensionless `.ts` source modules under strip-types.
+import { register } from "node:module";
+register("./ts-ext-loader.mjs", import.meta.url);

--- a/scripts/test-heatmap-summary.mjs
+++ b/scripts/test-heatmap-summary.mjs
@@ -8,50 +8,65 @@ const modUrl = pathToFileURL(
 );
 const { buildHeatmapSummary } = await import(`${modUrl.href}?c=${Date.now()}`);
 
-// Cells are ordered oldest → newest; the last cell is "today".
-function cell(load) {
-  return {
-    happenDay: "20260101",
-    trainingLoad: load,
-    level: load && load > 0 ? 2 : 0,
-    label: "day"
-  };
+// Cells are ordered oldest → newest; the last cell is "today". Each cell gets
+// a distinct consecutive happenDay ending at TODAY.
+const TODAY_UTC = Date.UTC(2026, 0, 10);
+function cells(loads) {
+  return loads.map((load, index) => {
+    const date = new Date(
+      TODAY_UTC - (loads.length - 1 - index) * 24 * 60 * 60 * 1000
+    );
+    return {
+      happenDay: date.toISOString().slice(0, 10).replace(/-/g, ""),
+      trainingLoad: load,
+      level: load && load > 0 ? 2 : 0,
+      label: "day"
+    };
+  });
 }
 
 // A rest day *today* (day still in progress) must NOT break the streak:
 // the streak is broken only when both yesterday AND today have no activity.
-const restTodayActiveYesterday = buildHeatmapSummary([
-  cell(50), // day -3
-  cell(50), // day -2
-  cell(50), // yesterday (active)
-  cell(0) //  today (rest, in progress)
-]);
+const restTodayActiveYesterday = buildHeatmapSummary(
+  cells([
+    50, // day -3
+    50, // day -2
+    50, // yesterday (active)
+    0 //   today (rest, in progress)
+  ])
+);
 assert.equal(restTodayActiveYesterday.currentStreak, 3);
 
 // Active today counts today plus the preceding consecutive active days.
-const activeToday = buildHeatmapSummary([
-  cell(50), // day -2
-  cell(50), // yesterday
-  cell(50) //  today
-]);
+const activeToday = buildHeatmapSummary(
+  cells([
+    50, // day -2
+    50, // yesterday
+    50 //  today
+  ])
+);
 assert.equal(activeToday.currentStreak, 3);
 
 // No activity yesterday AND today → streak broken (0).
-const restTwoDays = buildHeatmapSummary([
-  cell(50), // day -2 (active)
-  cell(0), //  yesterday (rest)
-  cell(0) //   today (rest)
-]);
+const restTwoDays = buildHeatmapSummary(
+  cells([
+    50, // day -2 (active)
+    0, //  yesterday (rest)
+    0 //   today (rest)
+  ])
+);
 assert.equal(restTwoDays.currentStreak, 0);
 
 // A gap earlier in the window doesn't affect the current streak.
-const gapEarlier = buildHeatmapSummary([
-  cell(50),
-  cell(0), // gap
-  cell(50),
-  cell(50),
-  cell(0) // today rest → streak = last two active days
-]);
+const gapEarlier = buildHeatmapSummary(
+  cells([
+    50,
+    0, // gap
+    50,
+    50,
+    0 // today rest → streak = last two active days
+  ])
+);
 assert.equal(gapEarlier.currentStreak, 2);
 
 // Sanity: activeDays / totalLoad unchanged by the streak fix.

--- a/scripts/test-heatmap-summary.mjs
+++ b/scripts/test-heatmap-summary.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const modUrl = pathToFileURL(
+  path.join(repoRoot, "src", "training", "parsers.ts")
+);
+const { buildHeatmapSummary } = await import(`${modUrl.href}?c=${Date.now()}`);
+
+// Cells are ordered oldest → newest; the last cell is "today".
+function cell(load) {
+  return {
+    happenDay: "20260101",
+    trainingLoad: load,
+    level: load && load > 0 ? 2 : 0,
+    label: "day"
+  };
+}
+
+// A rest day *today* (day still in progress) must NOT break the streak:
+// the streak is broken only when both yesterday AND today have no activity.
+const restTodayActiveYesterday = buildHeatmapSummary([
+  cell(50), // day -3
+  cell(50), // day -2
+  cell(50), // yesterday (active)
+  cell(0) //  today (rest, in progress)
+]);
+assert.equal(restTodayActiveYesterday.currentStreak, 3);
+
+// Active today counts today plus the preceding consecutive active days.
+const activeToday = buildHeatmapSummary([
+  cell(50), // day -2
+  cell(50), // yesterday
+  cell(50) //  today
+]);
+assert.equal(activeToday.currentStreak, 3);
+
+// No activity yesterday AND today → streak broken (0).
+const restTwoDays = buildHeatmapSummary([
+  cell(50), // day -2 (active)
+  cell(0), //  yesterday (rest)
+  cell(0) //   today (rest)
+]);
+assert.equal(restTwoDays.currentStreak, 0);
+
+// A gap earlier in the window doesn't affect the current streak.
+const gapEarlier = buildHeatmapSummary([
+  cell(50),
+  cell(0), // gap
+  cell(50),
+  cell(50),
+  cell(0) // today rest → streak = last two active days
+]);
+assert.equal(gapEarlier.currentStreak, 2);
+
+// Sanity: activeDays / totalLoad unchanged by the streak fix.
+assert.equal(restTodayActiveYesterday.activeDays, 3);
+assert.equal(restTodayActiveYesterday.totalLoad, 150);
+assert.equal(restTodayActiveYesterday.longestStreak, 3);
+
+console.log("heatmap-summary tests passed");

--- a/scripts/ts-ext-loader.mjs
+++ b/scripts/ts-ext-loader.mjs
@@ -1,0 +1,21 @@
+// Minimal ESM resolve hook so test scripts can import source `.ts` modules that
+// use TypeScript-style extensionless relative imports (which Node does not
+// resolve on its own). Pairs with node --experimental-strip-types.
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export async function resolve(specifier, context, nextResolve) {
+  try {
+    return await nextResolve(specifier, context);
+  } catch (err) {
+    const isRelative =
+      specifier.startsWith("./") || specifier.startsWith("../");
+    if (isRelative && context.parentURL) {
+      const candidate = new URL(`${specifier}.ts`, context.parentURL);
+      if (existsSync(fileURLToPath(candidate))) {
+        return nextResolve(`${specifier}.ts`, context);
+      }
+    }
+    throw err;
+  }
+}

--- a/src/training/parsers.ts
+++ b/src/training/parsers.ts
@@ -101,8 +101,16 @@ export function buildHeatmapSummary(cells: HeatmapCell[]): HeatmapSummary {
     0
   );
 
+  // Current streak counts consecutive active days ending at the most recent
+  // day. Today is still in progress, so an empty *today* does not break the
+  // streak — only a full rest day (yesterday) does. In other words the streak
+  // breaks only when both yesterday and today have no activity.
   let currentStreak = 0;
-  for (let index = cells.length - 1; index >= 0; index -= 1) {
+  let index = cells.length - 1;
+  if (index >= 0 && (cells[index].trainingLoad ?? 0) <= 0) {
+    index -= 1; // skip an empty, in-progress "today"
+  }
+  for (; index >= 0; index -= 1) {
     if ((cells[index].trainingLoad ?? 0) > 0) {
       currentStreak += 1;
     } else {


### PR DESCRIPTION
## Problem

The Training Activity load heatmap showed **`0-day streak`** despite a long, dense training history (e.g. *222 active days · 26 241 total load · 0-day streak*).
<img width="1609" height="417" alt="Screenshot 2026-07-14 at 10 03 45" src="https://github.com/user-attachments/assets/3e30618d-f921-4cce-953c-a63f68621a90" />

## Root cause

`buildHeatmapSummary` computed the current streak by walking back from the most recent day (today) and breaking at the first day with no training load. Since **today is still in progress**, an as-yet-untrained today reset the streak to 0 — so unless you had already logged an activity *today*, the streak was almost always 0.

## Fix

A streak should break only when **both yesterday and today** have no activity. The fix skips an empty, in-progress *today* before counting, so the streak reflects the run of consecutive active days ending yesterday, until a real rest day breaks it.

## Changes

- `src/training/parsers.ts` — skip an empty trailing today in `buildHeatmapSummary`.
- `scripts/test-heatmap-summary.mjs` — TDD: empty-today, active-today, two rest days, earlier gap, and `activeDays`/`totalLoad`/`longestStreak` unchanged.
- `scripts/ts-ext-loader.mjs` + `scripts/register-ts-ext.mjs` — small ESM resolve hook so tests can import extensionless `.ts` source modules under `--experimental-strip-types` (`parsers.ts` pulls in value imports the previous test helpers didn't).

## Test

`npm run test:heatmap-summary` ✅ · `npm run build` ✅ · verified live: the streak now shows the real consecutive-day count instead of 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
