### PR TITLE
Add update changelog prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- One-time update prompt with release notes, explicit update confirmation, and per-version dismissal when choosing **Not now**
+- Full in-app changelog covering every newer release when updating across multiple versions
+- Development-only **Test update** control for previewing the complete update prompt without downloading or restarting
+
 ## [0.1.17] - 2026-07-13
 
 ### Added

--- a/electron/updaterService.ts
+++ b/electron/updaterService.ts
@@ -135,7 +135,13 @@ function registerAutoUpdaterListeners(): void {
   }
 
   listenersRegistered = true;
-  autoUpdater.autoInstallOnAppQuit = true;
+  // Applying an update is always an explicit choice from the update prompt or
+  // update controls. In particular, choosing "Not now" must not silently
+  // install the already-downloaded update when the app later quits.
+  autoUpdater.autoInstallOnAppQuit = false;
+  // Include notes for every release newer than the installed version so users
+  // who skip one or more versions still see the complete changelog.
+  autoUpdater.fullChangelog = true;
 
   autoUpdater.on("checking-for-update", () => {
     setSnapshot({ status: "checking", error: undefined });
@@ -304,7 +310,11 @@ export async function quitAndInstallUpdate(): Promise<{
 }
 
 function formatReleaseNotes(
-  releaseNotes: string | Array<{ note?: string | null }> | null | undefined
+  releaseNotes:
+    | string
+    | Array<{ version?: string; note?: string | null }>
+    | null
+    | undefined
 ): string | undefined {
   if (!releaseNotes) {
     return undefined;
@@ -314,8 +324,16 @@ function formatReleaseNotes(
     return releaseNotes;
   }
 
-  return releaseNotes
-    .map((entry) => entry.note?.trim())
-    .filter(Boolean)
-    .join("\n\n");
+  const sections = releaseNotes.flatMap((entry) => {
+    const note = entry.note?.trim();
+    if (!note) {
+      return [];
+    }
+
+    return entry.version
+      ? [`## Version ${entry.version}\n\n${note}`]
+      : [note];
+  });
+
+  return sections.length > 0 ? sections.join("\n\n") : undefined;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,7 @@ import { TrainingHubView } from "./training/TrainingHubView";
 import type { TrainingHubSnapshot } from "./training/types";
 import type { CorosLinkApi } from "./coroslink-api";
 import { AppUpdateControls } from "./components/AppUpdateControls";
+import { UpdateAvailablePrompt } from "./components/UpdateAvailablePrompt";
 import {
   AppSidebar,
   createInitialSidebarExpanded,
@@ -130,6 +131,22 @@ const YOUTUBE_DOWNLOAD_CONSOLE_PREFIX = "__COROSLINK_YOUTUBE_DOWNLOAD__";
 const APPLE_MUSIC_SELECTED_PLAYLIST_STORAGE_KEY =
   "coroslink.appleMusic.selectedPlaylistId";
 const IS_DEVELOPMENT_BUILD = import.meta.env.DEV;
+const DEV_UPDATE_PREVIEW_VERSION = "0.1.18-dev-preview";
+const DEV_UPDATE_PREVIEW_NOTES = `## Version 0.1.18
+
+### Added
+
+- A one-time update window with the complete release changelog
+- An explicit choice to update now or dismiss this version
+- A development preview so the update experience can be reviewed before release
+
+### Improved
+
+- Update notes now include every missed version when upgrading across multiple releases
+
+### Fixed
+
+- Choosing **Not now** no longer allows the downloaded update to install silently when CorosLink quits`;
 const TRAINING_HISTORY_PAGE_SIZE = 100;
 const TRAINING_HISTORY_MAX_PAGES = 100;
 
@@ -168,6 +185,10 @@ export default function App() {
   const [showDevelopmentTools, setShowDevelopmentTools] = useState(
     IS_DEVELOPMENT_BUILD,
   );
+  const [devUpdatePreviewKey, setDevUpdatePreviewKey] = useState<
+    number | undefined
+  >(undefined);
+  const devUpdatePreviewSequenceRef = useRef(0);
   const [sidebarOverlayOpen, setSidebarOverlayOpen] = useState(() => {
     if (typeof window === "undefined") {
       return false;
@@ -257,6 +278,7 @@ export default function App() {
       autoDownload: true,
     },
   );
+  const installAcceptedVersionRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!api) {
@@ -266,6 +288,33 @@ export default function App() {
     void api.getAppUpdateStatus().then(setAppUpdateSnapshot);
     return api.onAppUpdateStatus(setAppUpdateSnapshot);
   }, [api]);
+
+  useEffect(() => {
+    const acceptedVersion = installAcceptedVersionRef.current;
+    if (!acceptedVersion) {
+      return;
+    }
+
+    if (
+      appUpdateSnapshot.status === "downloaded" &&
+      appUpdateSnapshot.availableVersion === acceptedVersion
+    ) {
+      installAcceptedVersionRef.current = null;
+      handleInstallUpdate();
+      return;
+    }
+
+    if (appUpdateSnapshot.status === "error") {
+      installAcceptedVersionRef.current = null;
+      setError(
+        appUpdateSnapshot.error ?? "Could not download the update.",
+      );
+    }
+  }, [
+    appUpdateSnapshot.availableVersion,
+    appUpdateSnapshot.error,
+    appUpdateSnapshot.status,
+  ]);
 
   // Tag the document with the host OS so the header can clear the macOS
   // traffic lights that overlay it.
@@ -780,6 +829,67 @@ export default function App() {
       setError(toErrorMessage(caught));
     } finally {
       setBusy(null);
+    }
+  }
+
+  function handleAcceptAvailableUpdate(version: string) {
+    if (IS_DEVELOPMENT_BUILD && devUpdatePreviewKey !== undefined) {
+      restoreUpdateSnapshotAfterPreview();
+      setMessage(
+        `Test update ${version} accepted. No files were downloaded in the development build.`,
+      );
+      return;
+    }
+
+    installAcceptedVersionRef.current = version;
+
+    if (
+      appUpdateSnapshot.status === "downloaded" &&
+      appUpdateSnapshot.availableVersion === version
+    ) {
+      installAcceptedVersionRef.current = null;
+      handleInstallUpdate();
+      return;
+    }
+
+    // electron-updater starts this itself when auto-download is enabled.
+    // Otherwise the explicit acceptance starts the download here.
+    if (
+      appUpdateSnapshot.status !== "downloading" &&
+      !(
+        appUpdateSnapshot.status === "available" &&
+        appUpdateSnapshot.autoDownload
+      )
+    ) {
+      void handleDownloadUpdate();
+    }
+  }
+
+  function showDevUpdatePreview() {
+    if (!IS_DEVELOPMENT_BUILD) {
+      return;
+    }
+
+    devUpdatePreviewSequenceRef.current += 1;
+    setDevUpdatePreviewKey(devUpdatePreviewSequenceRef.current);
+    setAppUpdateSnapshot((current) => ({
+      supported: true,
+      currentVersion:
+        current.currentVersion === "0.0.0" ? "0.1.17" : current.currentVersion,
+      status: "available",
+      availableVersion: DEV_UPDATE_PREVIEW_VERSION,
+      releaseNotes: DEV_UPDATE_PREVIEW_NOTES,
+      autoCheck: current.autoCheck,
+      autoDownload: false,
+    }));
+  }
+
+  function restoreUpdateSnapshotAfterPreview() {
+    setDevUpdatePreviewKey(undefined);
+    if (api) {
+      void api.getAppUpdateStatus().then(setAppUpdateSnapshot).catch((caught) => {
+        setError(toErrorMessage(caught));
+      });
     }
   }
 
@@ -1543,6 +1653,17 @@ export default function App() {
             </button>
           ) : null}
           {IS_DEVELOPMENT_BUILD && showDevelopmentTools ? (
+            <button
+              className="app-dev-view-toggle app-dev-update-test"
+              type="button"
+              title="Preview the update changelog prompt"
+              onClick={showDevUpdatePreview}
+            >
+              <Sparkles size={13} aria-hidden="true" />
+              Test update
+            </button>
+          ) : null}
+          {IS_DEVELOPMENT_BUILD && showDevelopmentTools ? (
             <WatchConnectionSmokeControls
               api={api}
               onWatchStatusChange={setWatchStatus}
@@ -1805,6 +1926,16 @@ export default function App() {
       </main>
       </div>
 
+      <UpdateAvailablePrompt
+        snapshot={appUpdateSnapshot}
+        onAccept={handleAcceptAvailableUpdate}
+        onDecline={
+          devUpdatePreviewKey === undefined
+            ? undefined
+            : restoreUpdateSnapshotAfterPreview
+        }
+        previewKey={devUpdatePreviewKey}
+      />
       <Toaster toasts={toasts} onDismiss={dismissToast} />
     </div>
   );

--- a/src/components/UpdateAvailablePrompt.tsx
+++ b/src/components/UpdateAvailablePrompt.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useRef, useState } from "react";
+import { Download, Sparkles } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { AppUpdateSnapshot } from "../../electron/types";
+
+const DISMISSED_UPDATE_VERSION_KEY =
+  "coroslink.updatePrompt.dismissedVersion";
+
+interface UpdateAvailablePromptProps {
+  snapshot: AppUpdateSnapshot;
+  onAccept: (version: string) => void;
+  onDecline?: (version: string) => void;
+  /** Forces a fresh, non-persistent preview whenever this value changes. */
+  previewKey?: number;
+}
+
+function readDismissedVersion(): string | null {
+  try {
+    return window.localStorage.getItem(DISMISSED_UPDATE_VERSION_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function rememberDismissedVersion(version: string): void {
+  try {
+    window.localStorage.setItem(DISMISSED_UPDATE_VERSION_KEY, version);
+  } catch {
+    // The in-memory guard still prevents the prompt from repeating this run.
+  }
+}
+
+function canPromptForUpdate(snapshot: AppUpdateSnapshot): boolean {
+  return (
+    snapshot.supported &&
+    Boolean(snapshot.availableVersion) &&
+    (snapshot.status === "available" ||
+      snapshot.status === "downloading" ||
+      snapshot.status === "downloaded")
+  );
+}
+
+export function UpdateAvailablePrompt({
+  snapshot,
+  onAccept,
+  onDecline,
+  previewKey,
+}: UpdateAvailablePromptProps) {
+  const [visibleVersion, setVisibleVersion] = useState<string | null>(null);
+  const promptedVersions = useRef(new Set<string>());
+  const handledPreviewKey = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (!canPromptForUpdate(snapshot) || !snapshot.availableVersion) {
+      return;
+    }
+
+    const version = snapshot.availableVersion;
+    if (
+      previewKey !== undefined &&
+      handledPreviewKey.current !== previewKey
+    ) {
+      handledPreviewKey.current = previewKey;
+      promptedVersions.current.add(version);
+      setVisibleVersion(version);
+      return;
+    }
+
+    if (promptedVersions.current.has(version)) {
+      return;
+    }
+
+    promptedVersions.current.add(version);
+    if (readDismissedVersion() !== version) {
+      setVisibleVersion(version);
+    }
+  }, [
+    previewKey,
+    snapshot.availableVersion,
+    snapshot.status,
+    snapshot.supported,
+  ]);
+
+  useEffect(() => {
+    if (!visibleVersion) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        if (previewKey === undefined) {
+          rememberDismissedVersion(visibleVersion);
+        }
+        setVisibleVersion(null);
+        onDecline?.(visibleVersion);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onDecline, previewKey, visibleVersion]);
+
+  if (!visibleVersion) {
+    return null;
+  }
+
+  const releaseNotes = snapshot.releaseNotes?.trim();
+  const isDownloaded = snapshot.status === "downloaded";
+  const isManualInstall =
+    isDownloaded && snapshot.installMethod === "manual";
+  const actionLabel = isManualInstall
+    ? "Open download"
+    : isDownloaded
+      ? "Restart and update"
+      : "Update now";
+  const progress = Math.round(snapshot.downloadPercent ?? 0);
+  const statusText =
+    snapshot.status === "downloading"
+      ? `Downloading ${progress}% — CorosLink will restart when it is ready.`
+      : isManualInstall
+        ? "The installer will open in your browser."
+        : isDownloaded
+          ? "The update is downloaded and ready to install."
+          : "CorosLink will download the update and restart to finish installing it.";
+
+  const decline = () => {
+    if (previewKey === undefined) {
+      rememberDismissedVersion(visibleVersion);
+    }
+    setVisibleVersion(null);
+    onDecline?.(visibleVersion);
+  };
+
+  const accept = () => {
+    const version = visibleVersion;
+    setVisibleVersion(null);
+    onAccept(version);
+  };
+
+  return (
+    <div className="update-prompt-backdrop" role="presentation">
+      <section
+        className="update-prompt"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="update-prompt-title"
+        aria-describedby="update-prompt-description"
+      >
+        <header className="update-prompt-header">
+          <span className="update-prompt-icon" aria-hidden="true">
+            <Sparkles size={22} />
+          </span>
+          <div>
+            <p className="update-prompt-eyebrow">Update available</p>
+            <h2 id="update-prompt-title">CorosLink {visibleVersion}</h2>
+            <p id="update-prompt-description">
+              Everything new since CorosLink {snapshot.currentVersion}.
+            </p>
+          </div>
+        </header>
+
+        <div className="update-prompt-changelog" tabIndex={0}>
+          {releaseNotes ? (
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={{
+                a: ({ children, ...props }) => (
+                  <a {...props} target="_blank" rel="noreferrer">
+                    {children}
+                  </a>
+                ),
+              }}
+            >
+              {releaseNotes}
+            </ReactMarkdown>
+          ) : (
+            <p>
+              This release includes the latest improvements and bug fixes.
+            </p>
+          )}
+        </div>
+
+        <footer className="update-prompt-footer">
+          <p>{statusText}</p>
+          <div className="update-prompt-actions">
+            <button
+              className="secondary-button"
+              type="button"
+              onClick={decline}
+            >
+              Not now
+            </button>
+            <button
+              className="primary-button"
+              type="button"
+              autoFocus
+              onClick={accept}
+            >
+              {isDownloaded ? (
+                <Sparkles size={16} aria-hidden="true" />
+              ) : (
+                <Download size={16} aria-hidden="true" />
+              )}
+              {actionLabel}
+            </button>
+          </div>
+        </footer>
+      </section>
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -344,6 +344,19 @@ input::placeholder {
   color: var(--text-secondary);
 }
 
+.app-dev-update-test {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-color: color-mix(in srgb, var(--accent-gold) 48%, var(--glass-border));
+  background: color-mix(in srgb, var(--accent-gold) 13%, var(--glass-bg));
+}
+
+.app-dev-update-test:hover {
+  border-color: color-mix(in srgb, var(--accent-gold) 72%, var(--glass-border));
+  background: color-mix(in srgb, var(--accent-gold) 20%, var(--glass-bg));
+}
+
 .app-body {
   display: flex;
   flex: 1;
@@ -1103,6 +1116,214 @@ input::placeholder {
   font-size: 12px;
   line-height: 1.35;
   color: var(--text-secondary);
+}
+
+.update-prompt-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 28px;
+  background: rgba(2, 5, 8, 0.68);
+  -webkit-backdrop-filter: blur(12px) saturate(125%);
+  backdrop-filter: blur(12px) saturate(125%);
+}
+
+.update-prompt {
+  width: min(620px, 100%);
+  max-height: min(720px, calc(100vh - 56px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--glass-border));
+  border-radius: var(--radius-xl);
+  background:
+    radial-gradient(circle at 12% 0%, var(--accent-soft), transparent 34%),
+    color-mix(in srgb, var(--bg-base) 94%, var(--glass-bg-elevated));
+  box-shadow:
+    0 34px 90px rgba(0, 0, 0, 0.58),
+    var(--glass-inset);
+}
+
+.update-prompt-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 26px 28px 20px;
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.update-prompt-icon {
+  width: 46px;
+  height: 46px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border: 1px solid color-mix(in srgb, var(--accent) 38%, transparent);
+  border-radius: 15px;
+  background: var(--accent-gradient);
+  color: #ffffff;
+  box-shadow: 0 12px 28px var(--accent-glow);
+}
+
+.update-prompt-eyebrow {
+  margin: 0 0 3px;
+  color: var(--accent-strong);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.update-prompt-header h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: clamp(22px, 3vw, 28px);
+  line-height: 1.15;
+}
+
+.update-prompt-header div > p:last-child {
+  margin: 7px 0 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.update-prompt-changelog {
+  min-height: 120px;
+  max-height: 360px;
+  overflow-y: auto;
+  margin: 20px 28px;
+  padding: 18px 20px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--glass-bg) 72%, transparent);
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.6;
+  scrollbar-color: var(--glass-border) transparent;
+}
+
+.update-prompt-changelog:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.update-prompt-changelog > :first-child {
+  margin-top: 0;
+}
+
+.update-prompt-changelog > :last-child {
+  margin-bottom: 0;
+}
+
+.update-prompt-changelog h1,
+.update-prompt-changelog h2,
+.update-prompt-changelog h3 {
+  margin: 18px 0 8px;
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: 15px;
+  line-height: 1.35;
+}
+
+.update-prompt-changelog p,
+.update-prompt-changelog ul,
+.update-prompt-changelog ol {
+  margin: 0 0 10px;
+}
+
+.update-prompt-changelog ul,
+.update-prompt-changelog ol {
+  padding-left: 20px;
+}
+
+.update-prompt-changelog li + li {
+  margin-top: 5px;
+}
+
+.update-prompt-changelog a {
+  color: var(--accent-strong);
+}
+
+.update-prompt-changelog code {
+  border-radius: 5px;
+  background: var(--glass-bg-elevated);
+  color: var(--text-primary);
+  padding: 1px 5px;
+  font-size: 0.92em;
+}
+
+.update-prompt-changelog pre {
+  overflow-x: auto;
+  border-radius: var(--radius-sm);
+  background: rgba(0, 0, 0, 0.24);
+  padding: 12px;
+}
+
+.update-prompt-changelog pre code {
+  background: transparent;
+  padding: 0;
+}
+
+.update-prompt-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 0 28px 26px;
+}
+
+.update-prompt-footer > p {
+  max-width: 300px;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.update-prompt-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  flex: 0 0 auto;
+}
+
+.update-prompt-actions .primary-button,
+.update-prompt-actions .secondary-button {
+  min-height: 40px;
+}
+
+@media (max-width: 600px) {
+  .update-prompt-backdrop {
+    padding: 14px;
+  }
+
+  .update-prompt-header {
+    padding: 22px 20px 18px;
+  }
+
+  .update-prompt-changelog {
+    margin: 16px 20px;
+  }
+
+  .update-prompt-footer {
+    align-items: stretch;
+    flex-direction: column;
+    padding: 0 20px 20px;
+  }
+
+  .update-prompt-footer > p {
+    max-width: none;
+  }
+
+  .update-prompt-actions > button {
+    flex: 1;
+  }
 }
 
 .resources-menu {


### PR DESCRIPTION
## What changed

- add a one-time update prompt with release notes and per-version dismissal
- show the full changelog when users skip multiple versions
- require explicit confirmation before installing an update
- add a development-only update prompt preview
- document the update experience in the changelog

## Impact

Users can review everything included in an available update and choose when to install it. Choosing **Not now** no longer installs the downloaded update when the app exits.

## Validation

- `npm run build`