### PR TITLE
Support auto-aligned watchface time

### DIFF
--- a/electron/corosWatchfaceService.ts
+++ b/electron/corosWatchfaceService.ts
@@ -1261,7 +1261,16 @@ export function applyCorosWatchfaceConfigOverrides(
     "control_temperature_font",
     "control_temperature_font_color",
     "control_temperature_negative_sign_icon",
-    "control_negative_sign_icon"
+    "control_negative_sign_icon",
+    "time_hour_high_pos",
+    "time_hour_high_font",
+    "time_hour_low_pos",
+    "time_hour_low_font",
+    "time_minute_high_pos",
+    "time_minute_high_font",
+    "time_minute_low_pos",
+    "time_minute_low_font",
+    "colon_icon"
   ]);
   const appended: string[] = [];
   for (const [key, value] of pending) {

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -524,6 +524,8 @@ export interface CorosWatchfaceDesignState {
   metricStyles: Record<string, { color?: string; scale: number; fontFamily?: string }>;
   /** Per selectable-control icon offsets, independent from the slot origin/value. */
   controlIconOffsets?: Record<string, { dx: number; dy: number }>;
+  /** Converts firmware auto-aligned HH:MM into four independently positioned digits. */
+  separateAutoTime?: boolean;
   timeStyles: Record<string, { color?: string; scale: number; fontFamily?: string }>;
   /** Weekday/month/day scaling; absent in projects saved before resizing. */
   dateStyles?: Record<

--- a/scripts/test-watchface-studio.mjs
+++ b/scripts/test-watchface-studio.mjs
@@ -11,6 +11,7 @@ import {
   buildLayoutOverrides,
   buildMetricOverrides,
   buildMetricStyleOverrides,
+  buildSeparateTimeOverrides,
   buildStaticSeparatorOverrides,
   buildTimeStyleOverrides,
   buildTimeTrackingOverrides,
@@ -25,6 +26,7 @@ import {
   getFixedMetricCapabilities,
   getTemplateBackgroundAssetPaths,
   getWatchfaceAnalogPreviewLayers,
+  hasAutoAlignedTime,
   hasWatchfaceAod,
   inferStaticSeparators,
   listWatchfaceConfigAssets,
@@ -244,6 +246,84 @@ const details = {
   resolutions: [resolution(416, 23, 33), resolution(800, 44, 64)]
 };
 
+const autoTimeResolution = resolution(240, 12, 20);
+Object.assign(autoTimeResolution.config, {
+  watchface_time_format: "1",
+  autoalign_time_rect: "{60,80,180,120,hcenter|vcenter}",
+  autoalign_time_font: "13x19",
+  autoalign_time_font_color: "",
+  autoalign_time_colon_icon: "icon\\colon.png"
+});
+const autoTimeDetails = {
+  archiveId: "auto-time",
+  resolutions: [autoTimeResolution]
+};
+assert.equal(hasAutoAlignedTime(autoTimeResolution), true);
+assert.deepEqual(
+  computeLayoutGroupBounds(autoTimeResolution).find(({ id }) => id === "autoTime"),
+  { id: "autoTime", label: "Time", x0: 60, y0: 80, x1: 180, y1: 120 },
+  "Auto-aligned time should be one movable editor layer"
+);
+assert.deepEqual(
+  buildTimeStyleOverrides(
+    autoTimeDetails,
+    { autoTime: { color: "#12abef", scale: 1.5 } },
+    true
+  )[0],
+  {
+    path: "watchface_240x240/config.txt",
+    values: {
+      autoalign_time_rect: "{30,70,210,130,hcenter|vcenter}",
+      autoalign_time_font: "cl_auto_time"
+    }
+  },
+  "Auto-aligned time styling should scale its shared rect and use an isolated font folder"
+);
+assert.deepEqual(
+  buildLayoutOverrides(autoTimeDetails, { autoTime: { dx: 7, dy: -5 } })[0],
+  {
+    path: "watchface_240x240/config.txt",
+    values: {
+      autoalign_time_rect: "{67,75,187,115,hcenter|vcenter}"
+    }
+  },
+  "Dragging auto-aligned time should move its shared firmware rect"
+);
+assert.equal(
+  computeLayoutGroupBounds(autoTimeResolution).some(
+    ({ id }) => id === "hours" || id === "minutes"
+  ),
+  false,
+  "Inactive individually positioned time keys must not create duplicate layers"
+);
+const separateTimeOverrides = buildSeparateTimeOverrides(autoTimeDetails, true);
+assert.deepEqual(separateTimeOverrides[0], {
+  path: "watchface_240x240/config.txt",
+  values: {
+    watchface_time_format: "0",
+    time_hour_high_pos: "{91,90}",
+    time_hour_high_font: "13x19",
+    time_hour_low_pos: "{103,90}",
+    time_hour_low_font: "13x19",
+    time_minute_high_pos: "{125,90}",
+    time_minute_high_font: "13x19",
+    time_minute_low_pos: "{137,90}",
+    time_minute_low_font: "13x19",
+    colon_icon: "icon\\colon.png"
+  }
+});
+const separateTimeResolution = applyConfigOverridesToDetails(
+  autoTimeDetails,
+  separateTimeOverrides
+).resolutions[0];
+assert.equal(hasAutoAlignedTime(separateTimeResolution), false);
+assert.deepEqual(
+  computeLayoutGroupBounds(separateTimeResolution)
+    .filter(({ id }) => id === "hours" || id === "minutes")
+    .map(({ id }) => id),
+  ["hours", "minutes"],
+  "Converted time should expose independent hour and minute layers"
+);
 assert.equal(hasWatchfaceAod(details), true);
 assert.equal(
   hasWatchfaceAod({

--- a/src/watchfaces/WatchfaceEditor.tsx
+++ b/src/watchfaces/WatchfaceEditor.tsx
@@ -708,6 +708,7 @@ export function WatchfaceEditor({
       design.tintIcons,
       design.previewComplication,
       design.metricStyles,
+      design.separateAutoTime,
       design.timeStyles,
       design.dateStyles,
       design.layerColors,
@@ -738,6 +739,7 @@ export function WatchfaceEditor({
       details,
       design.metricChanges,
       design.metricStyles,
+      design.separateAutoTime,
       design.timeStyles,
       design.dateStyles,
       design.layerColors,
@@ -2893,6 +2895,41 @@ export function WatchfaceEditor({
     });
   }
 
+  function convertAutoTimeToSeparate() {
+    setDesign((prev) => {
+      const timeStyles = { ...prev.timeStyles };
+      const autoStyle = timeStyles.autoTime;
+      delete timeStyles.autoTime;
+      if (autoStyle) {
+        timeStyles.hours = { ...autoStyle };
+        timeStyles.minutes = { ...autoStyle };
+      }
+      const layoutOffsets = { ...prev.layoutOffsets };
+      const autoOffset = layoutOffsets.autoTime;
+      delete layoutOffsets.autoTime;
+      if (autoOffset) {
+        layoutOffsets.hours = { ...autoOffset };
+        layoutOffsets.minutes = { ...autoOffset };
+      }
+      const layerVisibility = { ...prev.layerVisibility };
+      const autoVisible = layerVisibility.autoTime;
+      delete layerVisibility.autoTime;
+      if (autoVisible !== undefined) {
+        layerVisibility.hours = autoVisible;
+        layerVisibility.minutes = autoVisible;
+      }
+      return {
+        ...prev,
+        separateAutoTime: true,
+        timeStyles,
+        layoutOffsets,
+        layerVisibility
+      };
+    });
+    setSelectedId("hours");
+    setSelectedIds(["hours"]);
+  }
+
   function setDateStyle(
     partId: WatchfaceDatePartId,
     patch: { scale?: number; fontFamily?: string; color?: string }
@@ -4144,6 +4181,15 @@ export function WatchfaceEditor({
       return (
         <div className="watchface-inspector-group">
           {renderLayerVisibilityToggle(layer)}
+          {layer.timePartId === "autoTime" ? (
+            <button
+              type="button"
+              className="secondary-button"
+              onClick={convertAutoTimeToSeparate}
+            >
+              Separate hours and minutes
+            </button>
+          ) : null}
           <LocalFontPicker
             api={api}
             label="Digit font"

--- a/src/watchfaces/watchfaceBackground.ts
+++ b/src/watchfaces/watchfaceBackground.ts
@@ -41,6 +41,7 @@ export function makeDefaultDesign(): CorosWatchfaceDesignState {
     metricChanges: {},
     metricStyles: {},
     controlIconOffsets: {},
+    separateAutoTime: false,
     timeStyles: {},
     dateStyles: {},
     staticSeparators: {

--- a/src/watchfaces/watchfaceCompose.ts
+++ b/src/watchfaces/watchfaceCompose.ts
@@ -23,6 +23,7 @@ import {
   buildMetricOverrides,
   buildMetricSpriteReplacements,
   buildMetricStyleOverrides,
+  buildSeparateTimeOverrides,
   buildStaticSeparatorOverrides,
   buildStudioReplacements,
   buildTimeSpriteReplacements,
@@ -51,6 +52,7 @@ import {
  * metric-toggle and component-style overrides so element bounds move correctly.
  */
 export interface DesignDetails {
+  timeFormatOverrides: CorosWatchfaceConfigOverride[];
   metricOverrides: CorosWatchfaceConfigOverride[];
   metricDetails: CorosWatchfaceTemplateDetails;
   styledMetricDetails: CorosWatchfaceTemplateDetails;
@@ -115,8 +117,22 @@ export function deriveDesignDetails(
   details: CorosWatchfaceTemplateDetails,
   design: CorosWatchfaceDesignState
 ): DesignDetails {
-  const metricOverrides = buildMetricOverrides(details, design.metricChanges ?? {});
-  const metricDetails = applyConfigOverridesToDetails(details, metricOverrides);
+  const timeFormatOverrides = buildSeparateTimeOverrides(
+    details,
+    design.separateAutoTime === true
+  );
+  const timeFormatDetails = applyConfigOverridesToDetails(
+    details,
+    timeFormatOverrides
+  );
+  const metricOverrides = buildMetricOverrides(
+    timeFormatDetails,
+    design.metricChanges ?? {}
+  );
+  const metricDetails = applyConfigOverridesToDetails(
+    timeFormatDetails,
+    metricOverrides
+  );
   const controlTemperatureStyle = metricStylesOf(design).temperature ?? {
     color: design.digitColor,
     scale: 1
@@ -148,7 +164,13 @@ export function deriveDesignDetails(
     laidOutDetails,
     buildLayerVisibilityOverrides(laidOutDetails, design.layerVisibility ?? {})
   );
-  return { metricOverrides, metricDetails, styledMetricDetails, previewDetails };
+  return {
+    timeFormatOverrides,
+    metricOverrides,
+    metricDetails,
+    styledMetricDetails,
+    previewDetails
+  };
 }
 
 function hasEntries(record: Record<string, unknown> | undefined): boolean {
@@ -171,7 +193,12 @@ export async function composeWatchfaceReplacements(
   design: CorosWatchfaceDesignState,
   loadAssets: WatchfaceAssetLoader
 ): Promise<WatchfaceComposeResult> {
-  const { metricOverrides, metricDetails, styledMetricDetails } =
+  const {
+    timeFormatOverrides,
+    metricOverrides,
+    metricDetails,
+    styledMetricDetails
+  } =
     deriveDesignDetails(details, design);
   const metricStyles = metricStylesOf(design);
   const timeStyles = timeStylesOf(design);
@@ -229,7 +256,7 @@ export async function composeWatchfaceReplacements(
       : [],
     timeStyleActive
       ? await buildTimeSpriteReplacements(
-          details,
+          metricDetails,
           timeStyles,
           design.fontFamily,
           loadAssets,
@@ -262,7 +289,7 @@ export async function composeWatchfaceReplacements(
   );
 
   const timeStyleOverrides = timeStyleActive
-    ? buildTimeStyleOverrides(details, timeStyles, true)
+    ? buildTimeStyleOverrides(metricDetails, timeStyles, true)
     : [];
   const timePositionDetails = applyConfigOverridesToDetails(
     styledMetricDetails,
@@ -284,6 +311,7 @@ export async function composeWatchfaceReplacements(
     details,
     mergeConfigOverrides(
       metricOverrides,
+      timeFormatOverrides,
       metricStyleActive ? buildMetricStyleOverrides(metricDetails, metricStyles, true) : [],
       controlTemperatureActive
         ? buildControlTemperatureOverrides(

--- a/src/watchfaces/watchfaceEditorModel.ts
+++ b/src/watchfaces/watchfaceEditorModel.ts
@@ -8,6 +8,7 @@ import {
   buildDateStyleOverrides,
   buildMetricOverrides,
   buildMetricStyleOverrides,
+  buildSeparateTimeOverrides,
   buildTimeStyleOverrides,
   computeLayoutGroupBounds,
   getFixedMetricCapabilities,
@@ -101,6 +102,7 @@ const NO_CAPABILITIES: EditorLayerCapabilities = {
 
 /** Panel order, top (front-most overlay) to bottom (background). */
 const LAYER_ORDER: string[] = [
+  "autoTime",
   "hours",
   "minutes",
   "seconds",
@@ -126,6 +128,7 @@ const METRIC_IDS = new Set<WatchfaceMetricId>([
 ]);
 
 const TIME_GROUP_PARTS: Record<string, WatchfaceTimePartId> = {
+  autoTime: "autoTime",
   hours: "hours",
   minutes: "minutes"
 };
@@ -180,9 +183,13 @@ export function deriveEditorLayers(
   details: CorosWatchfaceTemplateDetails,
   design: CorosWatchfaceDesignState
 ): EditorLayer[] {
-  const metricDetails = applyConfigOverridesToDetails(
+  const timeFormatDetails = applyConfigOverridesToDetails(
     details,
-    buildMetricOverrides(details, design.metricChanges ?? {})
+    buildSeparateTimeOverrides(details, design.separateAutoTime === true)
+  );
+  const metricDetails = applyConfigOverridesToDetails(
+    timeFormatDetails,
+    buildMetricOverrides(timeFormatDetails, design.metricChanges ?? {})
   );
   const styledDetails = applyConfigOverridesToDetails(
     metricDetails,

--- a/src/watchfaces/watchfaceStudio.ts
+++ b/src/watchfaces/watchfaceStudio.ts
@@ -1182,7 +1182,7 @@ export type WatchfaceMetricStyles = Partial<
   Record<WatchfaceMetricId, WatchfaceMetricSpriteStyle>
 >;
 
-export type WatchfaceTimePartId = "hours" | "minutes";
+export type WatchfaceTimePartId = "hours" | "minutes" | "autoTime";
 
 export type WatchfaceTimeStyles = Partial<
   Record<WatchfaceTimePartId, WatchfaceMetricSpriteStyle>
@@ -1385,7 +1385,67 @@ function timeStudioFolder(
   part: WatchfaceTimePartId,
   slot: "high" | "low"
 ): string {
+  if (part === "autoTime") return "cl_auto_time";
   return `cl_${part === "hours" ? "h" : "m"}${slot === "high" ? "h" : "l"}`;
+}
+
+/** True when firmware lays out the complete HH:MM value inside one rectangle. */
+export function hasAutoAlignedTime(
+  resolution: CorosWatchfaceResolutionDetails
+): boolean {
+  return (
+    resolution.config.watchface_time_format?.trim() === "1" &&
+    parseConfigRect(resolution.config.autoalign_time_rect) !== null &&
+    Boolean(resolution.config.autoalign_time_font?.trim())
+  );
+}
+
+/**
+ * Converts firmware's shared auto-aligned HH:MM block into the four position
+ * keys used by normal digital faces. The original font and colon artwork are
+ * reused, so conversion changes layout behavior without changing appearance.
+ */
+export function buildSeparateTimeOverrides(
+  details: CorosWatchfaceTemplateDetails,
+  enabled: boolean
+): CorosWatchfaceConfigOverride[] {
+  if (!enabled) return [];
+  const overrides: CorosWatchfaceConfigOverride[] = [];
+  for (const resolution of details.resolutions) {
+    if (!hasAutoAlignedTime(resolution)) continue;
+    const rect = parseConfigRect(resolution.config.autoalign_time_rect);
+    const font = resolution.config.autoalign_time_font?.trim();
+    const source = findSpriteFolder(resolution, font);
+    const sample = source?.files[0];
+    if (!rect || !font || !sample) continue;
+
+    const colonValue = resolution.config.autoalign_time_colon_icon?.trim();
+    const colon = colonValue
+      ? resolution.icons.find(
+          (icon) =>
+            icon.path ===
+            `${resolution.directory}/${colonValue.replace(/\\/g, "/")}`
+        )
+      : undefined;
+    const colonWidth = colon?.width ?? 0;
+    const totalWidth = sample.width * 4 + colonWidth;
+    const x = Math.round((rect.x0 + rect.x1 - totalWidth) / 2);
+    const y = Math.round((rect.y0 + rect.y1 - sample.height) / 2);
+    const values: Record<string, string> = {
+      watchface_time_format: "0",
+      time_hour_high_pos: `{${x},${y}}`,
+      time_hour_high_font: font,
+      time_hour_low_pos: `{${x + sample.width},${y}}`,
+      time_hour_low_font: font,
+      time_minute_high_pos: `{${x + sample.width * 2 + colonWidth},${y}}`,
+      time_minute_high_font: font,
+      time_minute_low_pos: `{${x + sample.width * 3 + colonWidth},${y}}`,
+      time_minute_low_font: font
+    };
+    if (colonValue) values.colon_icon = colonValue;
+    overrides.push({ path: `${resolution.directory}/config.txt`, values });
+  }
+  return overrides;
 }
 
 export const WATCHFACE_COMPLICATIONS: WatchfaceComplicationDefinition[] = [
@@ -1996,6 +2056,17 @@ export function buildTimeStyleOverrides(
   const overrides: CorosWatchfaceConfigOverride[] = [];
   for (const resolution of details.resolutions) {
     const values: Record<string, string> = {};
+    const autoStyle = styles.autoTime;
+    if (autoStyle && hasAutoAlignedTime(resolution)) {
+      const rect = scaleConfigRectValue(
+        resolution.config.autoalign_time_rect ?? "",
+        autoStyle.scale
+      );
+      if (rect) values.autoalign_time_rect = rect;
+      if (useStudioFolders) {
+        values.autoalign_time_font = timeStudioFolder("autoTime", "high");
+      }
+    }
     for (const part of WATCHFACE_TIME_PARTS) {
       const style = styles[part.id];
       if (!style) {
@@ -2096,6 +2167,30 @@ export async function buildTimeSpriteReplacements(
     rasterized: boolean;
   }[] = [];
   for (const resolution of details.resolutions) {
+    const autoStyle = styles.autoTime;
+    const autoSource = autoStyle && hasAutoAlignedTime(resolution)
+      ? findSpriteFolder(resolution, resolution.config.autoalign_time_font)
+      : null;
+    if (autoStyle && autoSource) {
+      const normalizedScale = Math.max(0.5, Math.min(2, autoStyle.scale));
+      const partFontFamily = autoStyle.fontFamily ?? fontFamily;
+      autoSource.files.slice(0, 10).forEach((file, value) => {
+        jobs.push({
+          source: file,
+          path: `${resolution.directory}/${timeStudioFolder("autoTime", "high")}/${String(value).padStart(2, "0")}.png`,
+          digit: value,
+          width: Math.max(1, Math.round(file.width * normalizedScale)),
+          height: Math.max(1, Math.round(file.height * normalizedScale)),
+          color: autoStyle.color,
+          fontFamily: partFontFamily,
+          rasterized: shouldRenderWatchfaceText(
+            String(value),
+            partFontFamily,
+            typography
+          )
+        });
+      });
+    }
     for (const part of WATCHFACE_TIME_PARTS) {
       const style = styles[part.id];
       if (!style) {
@@ -2347,6 +2442,11 @@ export function mergeAssetReplacements(
  */
 export const WATCHFACE_LAYOUT_GROUPS: WatchfaceLayoutGroup[] = [
   {
+    id: "autoTime",
+    label: "Time",
+    patterns: [/^autoalign_time_rect$/]
+  },
+  {
     id: "hours",
     label: "Hour digits",
     patterns: [/^time_hour_(high|low)_pos$/]
@@ -2444,6 +2544,13 @@ export function layoutGroupKeys(
   resolution: CorosWatchfaceResolutionDetails,
   group: WatchfaceLayoutGroup
 ): string[] {
+  const autoAligned = hasAutoAlignedTime(resolution);
+  if (
+    (group.id === "autoTime" && !autoAligned) ||
+    ((group.id === "hours" || group.id === "minutes") && autoAligned)
+  ) {
+    return [];
+  }
   return Object.keys(resolution.config).filter(
     (key) =>
       group.patterns.some((pattern) => pattern.test(key)) &&
@@ -2528,6 +2635,7 @@ export function buildLayerColorOverrides(
   colors: Record<string, string>
 ): CorosWatchfaceConfigOverride[] {
   const colorKeys: Record<string, RegExp[]> = {
+    autoTime: [/^autoalign_time_font_color$/],
     hours: [/^time_hour_(high|low)_font_color$/],
     minutes: [/^time_minute_(high|low)_font_color$/],
     seconds: [/^time_second_(high|low)_font_color$/],
@@ -2577,6 +2685,7 @@ export async function buildLayerColorSpriteReplacements(
       }
     };
     addIcon(resolution.config["colon_icon"], colors.separators);
+    addIcon(resolution.config["autoalign_time_colon_icon"], colors.separators);
     addIcon(resolution.config["arc_cut_icon"], colors.separators);
     if (colors.complication) {
       for (const [key, value] of Object.entries(resolution.config)) {
@@ -2920,16 +3029,19 @@ export async function drawStudioPreview(
     ["time_minute_high_pos", "time_minute_high_font", minute[0]!, "minutes"],
     ["time_minute_low_pos", "time_minute_low_font", minute[1]!, "minutes"]
   ];
-  for (const [posKey, fontKey, digitText, partId] of timeKeys) {
-    const source = findSpriteFolder(resolution, config[fontKey]);
-    digitPlan.push({
-      pos: parseConfigPos(config[posKey]),
-      source,
-      digit: Number(digitText),
-      partId,
-      slot: posKey.includes("_high_") ? "high" : "low",
-      componentId: partId
-    });
+  const autoAlignedTime = hasAutoAlignedTime(resolution);
+  if (!autoAlignedTime) {
+    for (const [posKey, fontKey, digitText, partId] of timeKeys) {
+      const source = findSpriteFolder(resolution, config[fontKey]);
+      digitPlan.push({
+        pos: parseConfigPos(config[posKey]),
+        source,
+        digit: Number(digitText),
+        partId,
+        slot: posKey.includes("_high_") ? "high" : "low",
+        componentId: partId
+      });
+    }
   }
   for (const [posKey, fontKey, digitText] of [
     ["time_second_high_pos", "time_second_high_font", second[0]!],
@@ -2942,7 +3054,9 @@ export async function drawStudioPreview(
       componentId: "seconds"
     });
   }
-  const colonValue = config["colon_icon"]?.replace(/\\/g, "/");
+  const colonValue = !autoAlignedTime
+    ? config["colon_icon"]?.replace(/\\/g, "/")
+    : undefined;
   const colonPath = colonValue ? `${resolution.directory}/${colonValue}` : null;
   const colonFile = colonPath
     ? resolution.icons.find((icon) => icon.path === colonPath) ?? null
@@ -3108,8 +3222,39 @@ export async function drawStudioPreview(
     value: string;
     metricId?: WatchfaceMetricId;
     datePartId?: WatchfaceDatePartId;
+    timePartId?: WatchfaceTimePartId;
     componentId?: string;
+    separator?: {
+      configKey: string;
+      file: CorosWatchfaceSpriteFile;
+    };
   }[] = [];
+  if (autoAlignedTime) {
+    const rect = parseConfigRect(config.autoalign_time_rect);
+    const source = findSpriteFolder(resolution, config.autoalign_time_font);
+    const separatorValue = config.autoalign_time_colon_icon?.replace(/\\/g, "/");
+    const separatorPath = separatorValue
+      ? `${resolution.directory}/${separatorValue}`
+      : null;
+    const separatorFile = separatorPath
+      ? resolution.icons.find((icon) => icon.path === separatorPath) ?? null
+      : null;
+    if (rect && source) {
+      numberPlans.push({
+        rect,
+        source,
+        value: `${hour}${minute}`,
+        timePartId: "autoTime",
+        componentId: "autoTime",
+        ...(separatorFile
+          ? { separator: { configKey: "autoalign_time_colon_icon", file: separatorFile } }
+          : {})
+      });
+      if (separatorFile) {
+        wantedSprites.set(separatorFile.path, { color: separatorIconColor });
+      }
+    }
+  }
   if (complication && complicationSource) {
     for (const part of relativeComplicationRects) {
       numberPlans.push({
@@ -3185,7 +3330,9 @@ export async function drawStudioPreview(
     }
   }
   for (const plan of numberPlans) {
-    const fontFamily = plan.datePartId
+    const fontFamily = plan.timePartId
+      ? options.timeStyles?.[plan.timePartId]?.fontFamily ?? options.fontFamily
+      : plan.datePartId
       ? options.dateStyles?.[plan.datePartId]?.fontFamily ?? options.fontFamily
       : plan.metricId
         ? options.metricStyles?.[plan.metricId]?.fontFamily ?? options.fontFamily
@@ -3507,11 +3654,14 @@ export async function drawStudioPreview(
     const dateStyle = plan.datePartId
       ? options.dateStyles?.[plan.datePartId]
       : undefined;
+    const timeStyle = plan.timePartId
+      ? options.timeStyles?.[plan.timePartId]
+      : undefined;
     const componentColor = plan.componentId
       ? options.layerColors?.[plan.componentId]
       : undefined;
     const glyphFontFamily =
-      metricStyle?.fontFamily ?? dateStyle?.fontFamily ?? options.fontFamily;
+      timeStyle?.fontFamily ?? metricStyle?.fontFamily ?? dateStyle?.fontFamily ?? options.fontFamily;
     const glyphs: {
       file: CorosWatchfaceSpriteFile;
       image: HTMLImageElement;
@@ -3521,7 +3671,7 @@ export async function drawStudioPreview(
       if (!file) {
         continue;
       }
-      if (!metricStyle && !dateStyle && !componentColor) {
+      if (!timeStyle && !metricStyle && !dateStyle && !componentColor) {
         const image = digitSprites.get(file.path) ?? loaded.get(file.path);
         if (image) {
           glyphs.push({ file, image });
@@ -3530,7 +3680,7 @@ export async function drawStudioPreview(
       }
       const glyphScale = Math.max(
         0.5,
-        Math.min(2, metricStyle?.scale ?? dateStyle?.scale ?? 1)
+        Math.min(2, timeStyle?.scale ?? metricStyle?.scale ?? dateStyle?.scale ?? 1)
       );
       const styledFile = {
         ...file,
@@ -3538,6 +3688,7 @@ export async function drawStudioPreview(
         height: Math.max(1, Math.round(file.height * glyphScale))
       };
       const glyphColor =
+        timeStyle?.color ??
         metricStyle?.color ??
         dateStyle?.color ??
         componentColor ??
@@ -3556,7 +3707,7 @@ export async function drawStudioPreview(
               options
             )
           );
-        } else if (metricStyle?.color || dateStyle?.color || componentColor) {
+        } else if (timeStyle?.color || metricStyle?.color || dateStyle?.color || componentColor) {
           image = await loadStudioImage(
             await resizeAndTintSprite(
               loadedAssets.get(file.path)?.dataUrl ?? "",
@@ -3579,11 +3730,31 @@ export async function drawStudioPreview(
     if (glyphs.length === 0) {
       continue;
     }
-    const totalWidth = glyphs.reduce((sum, glyph) => sum + glyph.file.width, 0);
+    const separatorImage = plan.separator
+      ? await configuredAssetImage(
+          plan.separator.configKey,
+          plan.separator.file,
+          separatorIconColor
+        )
+      : undefined;
+    const separatorWidth = separatorImage && plan.separator
+      ? plan.separator.file.width
+      : 0;
+    const totalWidth = glyphs.reduce((sum, glyph) => sum + glyph.file.width, 0) + separatorWidth;
     const centerX = (plan.rect.x0 + plan.rect.x1) / 2;
     const centerY = (plan.rect.y0 + plan.rect.y1) / 2;
     let x = centerX - totalWidth / 2;
-    for (const glyph of glyphs) {
+    for (const [index, glyph] of glyphs.entries()) {
+      if (index === 2 && separatorImage && plan.separator) {
+        context.drawImage(
+          separatorImage,
+          x * scale,
+          (centerY - plan.separator.file.height / 2) * scale,
+          plan.separator.file.width * scale,
+          plan.separator.file.height * scale
+        );
+        x += plan.separator.file.width;
+      }
       context.drawImage(
         glyph.image,
         x * scale,


### PR DESCRIPTION
## What changed

- render and edit COROS `watchface_time_format=1` auto-aligned time blocks
- expose the shared time block as a single movable and styleable editor layer
- add an editor action that converts auto-aligned time into independently editable hour and minute digits
- preserve the source digit folder, colon artwork, styles, offsets, and visibility through conversion and export
- allow required separate-time config keys to be appended when legacy templates omit them
- add regression coverage for auto-time layout, styling, conversion, and independent layer bounds

## Why

Some supported COROS watchfaces use `autoalign_time_*` configuration instead of four individually positioned hour/minute digits. CorosLink previously preserved those keys but did not interpret or edit them.

## Validation

- `npm run test:watchface-studio`
- `npm run test:watchface-editor`
- `npm run test:coros-watchface-creator`
- `npm run build`
- `git diff --check`