### PR TITLE
Add animated supporter plaques to the website hero

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -348,10 +348,9 @@ body::after {
   }
 
   .hero-supporter-bubble span {
-    min-width: 0;
-    max-width: calc(100% - 52px);
-    overflow: hidden;
-    text-overflow: ellipsis;
+    max-width: none;
+    overflow: visible;
+    text-overflow: clip;
     color: #fff1cf;
     font-size: 11px;
     font-weight: 650;
@@ -362,7 +361,7 @@ body::after {
 
   .hero-supporter-bubbles--static {
     display: grid;
-    grid-template-columns: repeat(2, minmax(132px, 156px));
+    grid-template-columns: minmax(218px, 236px);
     align-content: end;
     justify-content: flex-end;
     gap: 10px;
@@ -571,7 +570,7 @@ body::after {
   }
 
   .hero-supporter-bubble {
-    width: 118px !important;
+    width: min(170px, 44vw) !important;
     height: 66px !important;
     border-radius: 10px;
     gap: 8px;
@@ -584,7 +583,7 @@ body::after {
   }
 
   .hero-supporter-bubble span {
-    max-width: calc(100% - 40px);
+    max-width: none;
     font-size: 9px;
   }
 
@@ -594,14 +593,14 @@ body::after {
 
   .hero-supporter-bubbles--static {
     display: grid;
-    grid-template-columns: 112px;
+    grid-template-columns: min(166px, 43vw);
     align-content: end;
     gap: 8px;
     padding: 0 14px 22vh 0;
   }
 
   .hero-supporter-bubble--static {
-    width: 112px !important;
+    width: min(166px, 43vw) !important;
     height: 64px !important;
   }
 }

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -188,7 +188,7 @@ body::after {
 
   .hero-supporter-bubble {
     position: absolute;
-    bottom: -140px;
+    bottom: -100px;
     display: flex;
     align-items: center;
     justify-content: flex-start;

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -164,6 +164,254 @@ body::after {
       0 0 60px -20px rgba(216, 155, 34, 0.35);
   }
 
+  .hero-supporter-bubbles {
+    position: absolute;
+    inset: 0 0 0 auto;
+    z-index: 0;
+    width: min(38vw, 560px);
+    overflow: hidden;
+    pointer-events: none;
+    mask-image: linear-gradient(to left, #000 76%, transparent 100%);
+    -webkit-mask-image: linear-gradient(to left, #000 76%, transparent 100%);
+  }
+
+  .hero-supporter-bubbles__wake {
+    position: absolute;
+    right: -10%;
+    bottom: -12%;
+    height: 52%;
+    width: 86%;
+    border-radius: 50%;
+    background: rgba(230, 174, 58, 0.2);
+    filter: blur(70px);
+  }
+
+  .hero-supporter-bubble {
+    position: absolute;
+    bottom: -140px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 10px;
+    overflow: visible;
+    border: 1px solid rgba(255, 218, 133, 0.72);
+    border-radius: 12px;
+    background:
+      radial-gradient(circle at 28% 18%, rgba(255, 247, 210, 0.54), transparent 20%),
+      radial-gradient(circle at 72% 76%, rgba(255, 177, 41, 0.2), transparent 38%),
+      linear-gradient(145deg, rgba(126, 86, 16, 0.7), rgba(31, 18, 3, 0.9));
+    padding: 10px 12px;
+    backdrop-filter: blur(20px) saturate(170%);
+    -webkit-backdrop-filter: blur(20px) saturate(170%);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 250, 224, 0.78),
+      inset 0 -22px 34px rgba(38, 18, 0, 0.46),
+      inset 12px 0 30px rgba(255, 196, 70, 0.08),
+      0 0 0 1px rgba(180, 111, 12, 0.34),
+      0 20px 56px -22px rgba(242, 177, 44, 0.88);
+    color: #fff4dc;
+    text-align: center;
+    will-change: transform, opacity;
+  }
+
+  .hero-supporter-bubble::after {
+    content: "";
+    position: absolute;
+    inset: 4px;
+    border: 1px solid rgba(255, 235, 178, 0.26);
+    border-radius: inherit;
+    pointer-events: none;
+  }
+
+  .hero-supporter-bubble__surface {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    border-radius: inherit;
+    pointer-events: none;
+  }
+
+  .hero-supporter-bubble__shine {
+    position: absolute;
+    left: -76%;
+    top: -32%;
+    height: 168%;
+    width: 42%;
+    transform: translate3d(0, 0, 0) rotate(18deg);
+    border-radius: 999px;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      rgba(255, 250, 224, 0.08) 24%,
+      rgba(255, 255, 245, 0.82) 52%,
+      rgba(255, 225, 142, 0.12) 76%,
+      transparent
+    );
+    filter: blur(2px);
+    animation: supporter-bubble-shine 3.4s cubic-bezier(0.55, 0, 0.25, 1) infinite;
+    pointer-events: none;
+  }
+
+  .hero-supporter-bubble:nth-child(2n) .hero-supporter-bubble__shine {
+    animation-delay: -1.25s;
+  }
+
+  .hero-supporter-bubble:nth-child(3n) .hero-supporter-bubble__shine {
+    animation-delay: -2.1s;
+  }
+
+  .hero-supporter-bubble__sparks {
+    position: absolute;
+    inset: -18px;
+    overflow: visible;
+    pointer-events: none;
+  }
+
+  .hero-supporter-bubble__spark {
+    --spark-x: 0px;
+    --spark-y: -16px;
+    --spark-rotate: 0deg;
+    position: absolute;
+    width: 3px;
+    height: 7px;
+    border-radius: 999px;
+    background: linear-gradient(to bottom, #fffdf2, #ffd568 58%, rgba(222, 142, 19, 0));
+    box-shadow:
+      0 0 5px rgba(255, 250, 220, 0.92),
+      0 0 12px rgba(255, 184, 48, 0.76);
+    opacity: 0;
+    animation: supporter-spark-burst 2.8s cubic-bezier(0.3, 0, 0.25, 1) infinite;
+    will-change: transform, opacity;
+  }
+
+  .hero-supporter-bubble__spark:nth-child(1) {
+    top: 10%;
+    left: 14%;
+    --spark-x: -12px;
+    --spark-y: -18px;
+    --spark-rotate: -28deg;
+    animation-delay: -0.4s;
+  }
+
+  .hero-supporter-bubble__spark:nth-child(2) {
+    top: 22%;
+    right: 6%;
+    --spark-x: 17px;
+    --spark-y: -11px;
+    --spark-rotate: 48deg;
+    animation-delay: -1.65s;
+  }
+
+  .hero-supporter-bubble__spark:nth-child(3) {
+    bottom: 2%;
+    left: 38%;
+    width: 2px;
+    height: 6px;
+    --spark-x: -4px;
+    --spark-y: 17px;
+    --spark-rotate: 12deg;
+    animation-delay: -2.25s;
+  }
+
+  .hero-supporter-bubble__spark:nth-child(4) {
+    top: 54%;
+    left: 1%;
+    width: 2px;
+    height: 5px;
+    --spark-x: -16px;
+    --spark-y: 3px;
+    --spark-rotate: -72deg;
+    animation-delay: -1.05s;
+  }
+
+  .hero-supporter-bubble__spark:nth-child(5) {
+    right: 22%;
+    bottom: 0;
+    width: 2px;
+    height: 5px;
+    --spark-x: 10px;
+    --spark-y: 16px;
+    --spark-rotate: 32deg;
+    animation-delay: -2.6s;
+  }
+
+  .hero-supporter-bubble__avatar {
+    width: 42px;
+    height: 42px;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    object-fit: cover;
+    box-shadow:
+      0 0 0 2px rgba(255, 239, 188, 0.92),
+      0 0 0 5px rgba(217, 154, 33, 0.26),
+      0 9px 22px -10px rgba(34, 17, 0, 0.94);
+  }
+
+  .hero-supporter-bubble span {
+    min-width: 0;
+    max-width: calc(100% - 52px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: #fff1cf;
+    font-size: 11px;
+    font-weight: 650;
+    line-height: 1.2;
+    text-shadow: 0 1px 8px rgba(255, 196, 70, 0.24);
+    white-space: nowrap;
+  }
+
+  .hero-supporter-bubbles--static {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(132px, 156px));
+    align-content: end;
+    justify-content: flex-end;
+    gap: 10px;
+    padding: 0 3vw 16vh 0;
+  }
+
+  .hero-supporter-bubble--static {
+    position: relative;
+    bottom: auto;
+    flex: 0 0 auto;
+  }
+
+  @keyframes supporter-bubble-shine {
+    0%, 18% {
+      opacity: 0;
+      transform: translate3d(0, 0, 0) rotate(18deg);
+    }
+    32% {
+      opacity: 0.92;
+    }
+    58% {
+      opacity: 0.4;
+      transform: translate3d(420%, 0, 0) rotate(18deg);
+    }
+    72%, 100% {
+      opacity: 0;
+      transform: translate3d(420%, 0, 0) rotate(18deg);
+    }
+  }
+
+  @keyframes supporter-spark-burst {
+    0%, 38% {
+      opacity: 0;
+      transform: translate3d(0, 0, 0) rotate(var(--spark-rotate)) scale(0.35);
+    }
+    47% {
+      opacity: 1;
+      transform: translate3d(0, 0, 0) rotate(var(--spark-rotate)) scale(1);
+    }
+    72% {
+      opacity: 0.5;
+      transform: translate3d(var(--spark-x), var(--spark-y), 0) rotate(var(--spark-rotate)) scale(0.72);
+    }
+    100% {
+      opacity: 0;
+      transform: translate3d(var(--spark-x), var(--spark-y), 0) rotate(var(--spark-rotate)) scale(0.25);
+    }
+  }
+
   .github-star-badge {
     --star-gold-deep: #5c3d08;
     --star-gold-mid: #8f6310;
@@ -311,6 +559,50 @@ body::after {
     font-weight: 700;
     letter-spacing: 0.05em;
     text-transform: uppercase;
+  }
+}
+
+@media (max-width: 767px) {
+  .hero-supporter-bubbles {
+    width: 48vw;
+    opacity: 0.72;
+    mask-image: linear-gradient(to left, #000 68%, transparent 100%);
+    -webkit-mask-image: linear-gradient(to left, #000 68%, transparent 100%);
+  }
+
+  .hero-supporter-bubble {
+    width: 118px !important;
+    height: 66px !important;
+    border-radius: 10px;
+    gap: 8px;
+    padding: 8px 9px;
+  }
+
+  .hero-supporter-bubble__avatar {
+    width: 32px;
+    height: 32px;
+  }
+
+  .hero-supporter-bubble span {
+    max-width: calc(100% - 40px);
+    font-size: 9px;
+  }
+
+  .hero-supporter-bubble__spark:nth-child(n + 4) {
+    display: none;
+  }
+
+  .hero-supporter-bubbles--static {
+    display: grid;
+    grid-template-columns: 112px;
+    align-content: end;
+    gap: 8px;
+    padding: 0 14px 22vh 0;
+  }
+
+  .hero-supporter-bubble--static {
+    width: 112px !important;
+    height: 64px !important;
   }
 }
 
@@ -2545,6 +2837,14 @@ body::after {
   animation-delay: 0.9s;
 }
 
+@media (prefers-reduced-transparency: reduce) {
+  .hero-supporter-bubble {
+    background: #4a2d08;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
   .animate-float,
@@ -2552,6 +2852,8 @@ body::after {
   .aurora-b,
   .animate-marquee,
   .coffee-steam span,
+  .hero-supporter-bubble__shine,
+  .hero-supporter-bubble__spark,
   .github-star-badge,
   .github-star-count-link__icon,
   .music-transfer-mock__flying-note,

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -16,6 +16,7 @@ import {
   SITE_URL,
   absoluteUrl,
 } from "../src/lib/site";
+import { getPublicSupporters } from "../src/lib/supporters";
 
 const structuredData = {
   "@context": "https://schema.org",
@@ -83,7 +84,9 @@ const structuredData = {
   ],
 };
 
-export default function Home() {
+export default async function Home() {
+  const supporters = await getPublicSupporters();
+
   return (
     <>
       <script
@@ -93,7 +96,7 @@ export default function Home() {
       <SmoothScroll />
       <Nav />
       <main>
-        <Hero />
+        <Hero supporters={supporters} />
 
         {/* Section intro */}
         <section className="mx-auto max-w-3xl px-5 pt-16 text-center md:pt-24">

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -12,6 +12,15 @@ const nextConfig = {
   turbopack: {
     root: monorepoRoot,
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "cdn.buymeacoffee.com",
+        pathname: "/uploads/profile_pictures/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -7,6 +7,8 @@ import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
 import { BuyMeCoffee } from "./BuyMeCoffee";
 import { GitHubLink } from "./GitHubLink";
 import { SourceStrip } from "./SourceStrip";
+import { SupporterBubbles } from "./SupporterBubbles";
+import type { PublicSupporter } from "../lib/supporters";
 
 const WATCHES = [
   { src: "/assets/pace-pro-hero.webp", label: "Pace Pro" },
@@ -15,7 +17,7 @@ const WATCHES = [
   { src: "/assets/nomad-hero.webp", label: "Nomad" },
 ];
 
-export function Hero() {
+export function Hero({ supporters }: { supporters: PublicSupporter[] }) {
   const reduced = usePrefersReducedMotion();
 
   const fade = (delay: number) => ({
@@ -27,7 +29,7 @@ export function Hero() {
   return (
     <section
       id="top"
-      className="relative flex min-h-[100svh] flex-col overflow-hidden px-5 pt-24 pb-5"
+      className="relative flex min-h-[100dvh] flex-col overflow-hidden px-5 pt-24 pb-5"
     >
       {/* Aurora backdrop */}
       <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
@@ -46,8 +48,10 @@ export function Hero() {
         />
       </div>
 
+      <SupporterBubbles supporters={supporters} />
+
       {/* Main content */}
-      <div className="flex flex-1 flex-col items-center justify-center text-center">
+      <div className="relative z-10 flex flex-1 flex-col items-center justify-center text-center">
         <motion.span
           {...fade(0)}
           className="glass-soft mb-6 inline-flex items-center gap-2 rounded-full px-4 py-1.5 text-xs font-medium text-muted"
@@ -111,7 +115,9 @@ export function Hero() {
       </div>
 
       {/* Scrolling source marquee — kept in view within the hero */}
-      <SourceStrip />
+      <div className="relative z-10">
+        <SourceStrip />
+      </div>
     </section>
   );
 }

--- a/website/src/components/SupporterBubbles.tsx
+++ b/website/src/components/SupporterBubbles.tsx
@@ -63,7 +63,11 @@ export function SupporterBubbles({
               width: path.width,
               height: path.height,
             }}
-            initial={{ opacity: 0, x: path.drift[0], y: 130, scale: 0.68 }}
+            initial={
+              index === 0
+                ? { opacity: 0.92, x: path.drift[1], y: -82, scale: 1 }
+                : { opacity: 0, x: path.drift[0], y: 130, scale: 0.68 }
+            }
             animate={{
               opacity: [0, 0.92, 0.92, 0.78, 0],
               x: path.drift,
@@ -79,7 +83,7 @@ export function SupporterBubbles({
             }}
             transition={{
               duration: 12,
-              delay: index * 2.2 - 0.35,
+              delay: index * 2.2 - 3.4,
               repeat: Infinity,
               ease: [0.37, 0, 0.63, 1],
               times: [0, 0.16, 0.48, 0.78, 1],

--- a/website/src/components/SupporterBubbles.tsx
+++ b/website/src/components/SupporterBubbles.tsx
@@ -63,11 +63,11 @@ export function SupporterBubbles({
               width: path.width,
               height: path.height,
             }}
-            initial={{ opacity: 0, x: path.drift[0], y: 170, scale: 0.68 }}
+            initial={{ opacity: 0, x: path.drift[0], y: 130, scale: 0.68 }}
             animate={{
               opacity: [0, 0.92, 0.92, 0.78, 0],
               x: path.drift,
-              y: [170, 20, -210, -470, -760],
+              y: [130, 0, -220, -470, -760],
               scale: [0.68, 1, 1.04, 0.96, 0.8],
               rotate: [
                 0,
@@ -79,7 +79,7 @@ export function SupporterBubbles({
             }}
             transition={{
               duration: 12,
-              delay: index * 2.35,
+              delay: index * 2.2 - 0.35,
               repeat: Infinity,
               ease: [0.37, 0, 0.63, 1],
               times: [0, 0.16, 0.48, 0.78, 1],

--- a/website/src/components/SupporterBubbles.tsx
+++ b/website/src/components/SupporterBubbles.tsx
@@ -6,12 +6,12 @@ import type { PublicSupporter } from "../lib/supporters";
 import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
 
 const BUBBLE_PATHS = [
-  { right: "8%", width: 168, height: 72, drift: [0, -28, 14, -42, 0] },
-  { right: "31%", width: 148, height: 64, drift: [0, 24, -12, 34, 0] },
-  { right: "2%", width: 158, height: 68, drift: [0, -18, 22, -24, 0] },
-  { right: "24%", width: 176, height: 74, drift: [0, 30, -18, 18, 0] },
-  { right: "42%", width: 142, height: 62, drift: [0, -22, 14, -30, 0] },
-  { right: "14%", width: 154, height: 66, drift: [0, 18, -20, 26, 0] },
+  { right: "8%", width: 228, height: 72, drift: [0, -28, 14, -42, 0] },
+  { right: "31%", width: 220, height: 64, drift: [0, 24, -12, 34, 0] },
+  { right: "2%", width: 236, height: 68, drift: [0, -18, 22, -24, 0] },
+  { right: "24%", width: 232, height: 74, drift: [0, 30, -18, 18, 0] },
+  { right: "42%", width: 218, height: 62, drift: [0, -22, 14, -30, 0] },
+  { right: "14%", width: 224, height: 66, drift: [0, 18, -20, 26, 0] },
 ];
 
 export function SupporterBubbles({

--- a/website/src/components/SupporterBubbles.tsx
+++ b/website/src/components/SupporterBubbles.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import Image from "next/image";
+import { motion } from "motion/react";
+import type { PublicSupporter } from "../lib/supporters";
+import { usePrefersReducedMotion } from "../hooks/usePrefersReducedMotion";
+
+const BUBBLE_PATHS = [
+  { right: "8%", width: 168, height: 72, drift: [0, -28, 14, -42, 0] },
+  { right: "31%", width: 148, height: 64, drift: [0, 24, -12, 34, 0] },
+  { right: "2%", width: 158, height: 68, drift: [0, -18, 22, -24, 0] },
+  { right: "24%", width: 176, height: 74, drift: [0, 30, -18, 18, 0] },
+  { right: "42%", width: 142, height: 62, drift: [0, -22, 14, -30, 0] },
+  { right: "14%", width: 154, height: 66, drift: [0, 18, -20, 26, 0] },
+];
+
+export function SupporterBubbles({
+  supporters,
+}: {
+  supporters: PublicSupporter[];
+}) {
+  const reduced = usePrefersReducedMotion();
+  const visibleSupporters = supporters.slice(0, BUBBLE_PATHS.length);
+
+  if (reduced) {
+    return (
+      <div className="hero-supporter-bubbles hero-supporter-bubbles--static" aria-label="CorosLink supporters">
+        {visibleSupporters.slice(0, 4).map((supporter, index) => (
+          <div
+            key={supporter.id}
+            className="hero-supporter-bubble hero-supporter-bubble--static"
+            style={{
+              width: BUBBLE_PATHS[index].width,
+              height: BUBBLE_PATHS[index].height,
+            }}
+          >
+            <Image
+              src={supporter.avatarUrl}
+              alt=""
+              width={52}
+              height={52}
+              className="hero-supporter-bubble__avatar"
+            />
+            <span>{supporter.name}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="hero-supporter-bubbles" aria-label="CorosLink supporters">
+      <div className="hero-supporter-bubbles__wake" aria-hidden="true" />
+      {visibleSupporters.map((supporter, index) => {
+        const path = BUBBLE_PATHS[index];
+
+        return (
+          <motion.div
+            key={supporter.id}
+            className="hero-supporter-bubble"
+            style={{
+              right: path.right,
+              width: path.width,
+              height: path.height,
+            }}
+            initial={{ opacity: 0, x: path.drift[0], y: 170, scale: 0.68 }}
+            animate={{
+              opacity: [0, 0.92, 0.92, 0.78, 0],
+              x: path.drift,
+              y: [170, 20, -210, -470, -760],
+              scale: [0.68, 1, 1.04, 0.96, 0.8],
+              rotate: [
+                0,
+                index % 2 === 0 ? -3 : 3,
+                index % 2 === 0 ? 2 : -2,
+                index % 2 === 0 ? -1 : 1,
+                0,
+              ],
+            }}
+            transition={{
+              duration: 12,
+              delay: index * 2.35,
+              repeat: Infinity,
+              ease: [0.37, 0, 0.63, 1],
+              times: [0, 0.16, 0.48, 0.78, 1],
+            }}
+          >
+            <div className="hero-supporter-bubble__surface" aria-hidden="true">
+              <div className="hero-supporter-bubble__shine" />
+            </div>
+            <Image
+              src={supporter.avatarUrl}
+              alt=""
+              width={52}
+              height={52}
+              className="hero-supporter-bubble__avatar"
+            />
+            <span>{supporter.name}</span>
+            <div className="hero-supporter-bubble__sparks" aria-hidden="true">
+              {Array.from({ length: 5 }, (_, sparkIndex) => (
+                <i key={sparkIndex} className="hero-supporter-bubble__spark" />
+              ))}
+            </div>
+          </motion.div>
+        );
+      })}
+    </div>
+  );
+}

--- a/website/src/lib/supporters.ts
+++ b/website/src/lib/supporters.ts
@@ -1,0 +1,92 @@
+const SUPPORTERS_ENDPOINT =
+  "https://app.buymeacoffee.com/api/v1/timeline/project/10978680/?page=1&per_page=100";
+
+export type PublicSupporter = {
+  id: string;
+  name: string;
+  avatarUrl: string;
+};
+
+const FALLBACK_SUPPORTERS: PublicSupporter[] = [
+  {
+    id: "joe-c",
+    name: "Joe C",
+    avatarUrl:
+      "https://cdn.buymeacoffee.com/uploads/profile_pictures/default/v2/FFB3A0/JC.png",
+  },
+  {
+    id: "gunda-and-jan",
+    name: "Gunda&Jan",
+    avatarUrl:
+      "https://cdn.buymeacoffee.com/uploads/profile_pictures/default/v2/80BEAF/GJ.png",
+  },
+  {
+    id: "divilabotherbeonya",
+    name: "DivilABotherBeOnYa",
+    avatarUrl:
+      "https://cdn.buymeacoffee.com/uploads/profile_pictures/default/v2/E3CBF4/DA.png",
+  },
+  {
+    id: "anonymous-supporter",
+    name: "Anonymous supporter",
+    avatarUrl:
+      "https://cdn.buymeacoffee.com/uploads/profile_pictures/default/v2/EC9689/SO.png",
+  },
+];
+
+type TimelineResponse = {
+  data?: Array<{
+    supporter?: {
+      id?: number | string;
+      name?: string;
+      dp?: string;
+    };
+  }>;
+};
+
+function isSafeAvatarUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && url.hostname === "cdn.buymeacoffee.com";
+  } catch {
+    return false;
+  }
+}
+
+export async function getPublicSupporters(): Promise<PublicSupporter[]> {
+  try {
+    const response = await fetch(SUPPORTERS_ENDPOINT, {
+      headers: {
+        Accept: "application/json",
+        "X-Requested-With": "XMLHttpRequest",
+      },
+      next: { revalidate: 3600 },
+    });
+
+    if (!response.ok) return FALLBACK_SUPPORTERS;
+
+    const payload = (await response.json()) as TimelineResponse;
+    const supporters = new Map<string, PublicSupporter>();
+
+    for (const transaction of payload.data ?? []) {
+      const supporter = transaction.supporter;
+      const name = supporter?.name?.trim();
+      const avatarUrl = supporter?.dp?.trim();
+
+      if (!name || !avatarUrl || !isSafeAvatarUrl(avatarUrl)) continue;
+
+      const id = String(supporter?.id ?? `${name}-${avatarUrl}`);
+      supporters.set(id, {
+        id,
+        name: name === "Someone" ? "Anonymous supporter" : name,
+        avatarUrl,
+      });
+    }
+
+    return supporters.size > 0
+      ? Array.from(supporters.values())
+      : FALLBACK_SUPPORTERS;
+  } catch {
+    return FALLBACK_SUPPORTERS;
+  }
+}


### PR DESCRIPTION
## What changed

- Fetch public supporters from Buy Me a Coffee with hourly revalidation and safe fallbacks.
- Display supporter avatars and names as looping gold plaques in the website hero.
- Add shine, ember sparks, responsive sizing, and reduced-motion behavior.
- Allow Buy Me a Coffee profile images through the Next.js image configuration.

## Why

The hero had no visible supporter recognition. This adds live social proof while keeping the existing dark-tech visual language and page structure.

## Impact

Visitors see recent public supporters floating from the bottom-right of the hero. The animation is decorative, does not intercept interaction, and falls back to a static layout when reduced motion is enabled.

## Validation

- npm run build
- git diff --check
- Visual verification at a desktop viewport
