### PR TITLE
Update README: new domain and documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@
 </p>
 
 <p align="center">
-  <strong>Live site:</strong> <a href="https://coros-link.vercel.app/">coros-link.vercel.app</a>
+  <strong>Live site:</strong> <a href="https://coroslink.com/">coroslink.com</a>
+</p>
+
+<p align="center">
+  <strong>Documentation:</strong> <a href="https://doc.coroslink.com/">doc.coroslink.com</a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Update live site link from `https://coros-link.vercel.app/` to `https://coroslink.com/`
- Add documentation link pointing to `https://doc.coroslink.com/`

## Test plan
- [x] Verified links render correctly in README.md