### PR TITLE
Finish PACE 4 watchface exports and always-on editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,11 @@ then claim it through COROS's official share page on iPhone.
   CorosLink generates an isolated ten-digit folder for each customized metric
 - **Drag-to-move layout (experimental)** — position hours, minutes, weekday,
   month, day, battery, and metric elements independently; CorosLink rewrites the matching
-  `config.txt` position keys for every resolution (scaled automatically),
-  leaving the always-on-display layout untouched
+  `config.txt` position keys for every resolution (scaled automatically)
+- **Independent always-on studio** — switch to `AODconfig.txt` and edit its
+  existing firmware layers, artwork, styles, effects, visibility, and placement
+  without changing the current display; shared template sprites are isolated
+  into AOD-owned folders during export
 - **Live metric studio (experimental)** — activate fixed heart rate, steps,
   calories, and elevation fields when the source template exposes them; preview
   the selectable metric slot and drag every enabled field into place

--- a/electron/corosWatchfaceService.ts
+++ b/electron/corosWatchfaceService.ts
@@ -1657,6 +1657,9 @@ export function applyCorosWatchfaceConfigOverrides(
   }
   const appendableKeys = new Set([
     "watchface_id",
+    // Independent AOD artwork may add a flattened background to a valid
+    // color-only AODconfig that did not originally declare a PNG.
+    "background_icon",
     // Studio can expose selectable components that the imported template did
     // not originally declare. The renderer only emits this fixed allow-list;
     // arbitrary missing keys remain rejected below.

--- a/electron/corosWatchfaceService.ts
+++ b/electron/corosWatchfaceService.ts
@@ -3363,7 +3363,7 @@ function assertFirmwareResolutionCompatibility(
 ): void {
   const normalizedFirmwareType = firmwareType?.trim().toUpperCase();
   const compatibility =
-    normalizedFirmwareType === "COROS W335" || watchModel === "pace-4"
+    normalizedFirmwareType === "COROS W336" || watchModel === "pace-4"
       ? {
           label: "PACE 4",
           required: ["watchface_390x390", "watchface_800x800"]

--- a/electron/corosWatchfaceService.ts
+++ b/electron/corosWatchfaceService.ts
@@ -1657,6 +1657,10 @@ export function applyCorosWatchfaceConfigOverrides(
   }
   const appendableKeys = new Set([
     "watchface_id",
+    // Studio can expose selectable components that the imported template did
+    // not originally declare. The renderer only emits this fixed allow-list;
+    // arbitrary missing keys remain rejected below.
+    "rect_control1_pos",
     "weather_icon_pos",
     "weather_icon_dir",
     "battery_icon_pos",
@@ -1695,6 +1699,45 @@ export function applyCorosWatchfaceConfigOverrides(
     "time_minute_low_font",
     "colon_icon"
   ]);
+  for (const prefix of [
+    "hr",
+    "step",
+    "kcal",
+    "floor",
+    "elevation",
+    "temperature"
+  ]) {
+    for (const suffix of [
+      "icon_pos",
+      "icon",
+      "rect",
+      "font",
+      "font_color"
+    ]) {
+      appendableKeys.add(`control_${prefix}_${suffix}`);
+    }
+  }
+  appendableKeys.add("control_temperature_negative_sign_icon");
+  for (const prefix of ["exercise", "sunrise", "sunset"]) {
+    for (const suffix of [
+      "icon_pos",
+      "icon",
+      "hour_rect",
+      "minute_rect",
+      "font",
+      "font_color"
+    ]) {
+      appendableKeys.add(`control_${prefix}_${suffix}`);
+    }
+  }
+  for (const suffix of [
+    "icon_dir",
+    "level_rect",
+    "level_font",
+    "level_font_color"
+  ]) {
+    appendableKeys.add(`control_battery_${suffix}`);
+  }
   const appended: string[] = [];
   for (const [key, value] of pending) {
     if (value === COROS_CONFIG_DELETE_VALUE) {
@@ -3318,21 +3361,32 @@ function assertFirmwareResolutionCompatibility(
   firmwareType: string | undefined,
   watchModel?: WatchModelId
 ): void {
-  if (
-    firmwareType?.trim().toUpperCase() !== "COROS W541" &&
-    watchModel !== "apex-4"
-  ) {
+  const normalizedFirmwareType = firmwareType?.trim().toUpperCase();
+  const compatibility =
+    normalizedFirmwareType === "COROS W335" || watchModel === "pace-4"
+      ? {
+          label: "PACE 4",
+          required: ["watchface_390x390", "watchface_800x800"]
+        }
+      : normalizedFirmwareType === "COROS W541" || watchModel === "apex-4"
+        ? {
+            label: "APEX 4",
+            required: ["watchface_240x240", "watchface_260x260"]
+          }
+        : null;
+  if (!compatibility) {
     return;
   }
-  const required = ["watchface_240x240", "watchface_260x260"];
-  const missing = required.filter(
+  const missing = compatibility.required.filter(
     (directory) => !resolutionDirectories.includes(directory)
   );
   if (missing.length > 0) {
     throw new Error(
-      `APEX 4 (${firmwareType}) requires 240×240 and 260×260 exports. This template is missing ${missing
+      `${compatibility.label}${firmwareType ? ` (${firmwareType})` : ""} requires ${compatibility.required
+        .map((directory) => directory.replace("watchface_", "").replace("x", "×"))
+        .join(" and ")} exports. This template is missing ${missing
         .map((directory) => directory.replace("watchface_", ""))
-        .join(" and ")}. Browse and choose an APEX 4 template before exporting.`
+        .join(" and ")}. Browse and choose a ${compatibility.label} template before exporting.`
     );
   }
 }

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -694,6 +694,11 @@ export interface CorosWatchfaceDesignState {
     /** Preserve each selectable digit's natural width and expand value rectangles. */
     nativeSize?: boolean;
   };
+  /**
+   * Per-component selectable-control state. Missing entries inherit whether
+   * the imported template already declares that component.
+   */
+  controlComplicationEnabled?: Record<string, boolean>;
   /** False removes the Battery choice from the firmware-selectable control slot. */
   controlBatteryEnabled?: boolean;
   /** False removes the Sunrise choice from the firmware-selectable control slot. */

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -652,6 +652,13 @@ export type CorosWatchfaceBackgroundElement =
 
 export interface CorosWatchfaceDesignState {
   version: 1;
+  /**
+   * Independent visual state for alternate firmware display modes. Current
+   * display fields remain at the top level for backwards compatibility.
+   */
+  modeDesigns?: {
+    aod?: CorosWatchfaceModeDesignState;
+  };
   /** Exact archive `o_wf_ver`; absent keeps automatic compatibility behavior. */
   archiveWatchFaceVersion?: number;
   /** Deletes blank `[key]=` config lines from built archives (see creator input). */
@@ -803,6 +810,57 @@ export interface CorosWatchfaceDesignState {
    */
   backgroundElements?: CorosWatchfaceBackgroundElement[];
 }
+
+/**
+ * Visual/editor state that can diverge between Current and Always-on without
+ * duplicating archive-wide settings or raw config text.
+ */
+export type CorosWatchfaceModeDesignState = Partial<
+  Pick<
+    CorosWatchfaceDesignState,
+    | "backgroundColor"
+    | "accentColor"
+    | "artwork"
+    | "artworkVisible"
+    | "zoom"
+    | "fontFamily"
+    | "rasterFont"
+    | "fontWeight"
+    | "fontStyle"
+    | "letterSpacing"
+    | "digitColor"
+    | "tintLabels"
+    | "tintIcons"
+    | "previewComplication"
+    | "metricChanges"
+    | "metricStyles"
+    | "selectableMetricStyle"
+    | "controlComplicationEnabled"
+    | "controlIconOffsets"
+    | "separateAutoTime"
+    | "timeStyles"
+    | "dateStyles"
+    | "staticSeparators"
+    | "ampmIndicator"
+    | "weatherIndicator"
+    | "layoutOffsets"
+    | "linkedLayerGroups"
+    | "editorGroups"
+    | "editorGuides"
+    | "lockedLayerIds"
+    | "effectStyles"
+    | "layerEffects"
+    | "layerVisibility"
+    | "layerColors"
+    | "configAssetOverrides"
+    | "designSprites"
+    | "artworkLayerOrder"
+    | "backgroundElements"
+  >
+> & {
+  /** Whether Studio must emit a flattened background for this mode. */
+  backgroundEdited?: boolean;
+};
 
 export interface CorosWatchfaceProjectSummary {
   projectId: string;

--- a/electron/watchModels.ts
+++ b/electron/watchModels.ts
@@ -38,6 +38,10 @@ const WATCHFACE_DEVICE_PROFILES: Partial<
     firmwareType: "COROS W332",
     modelVersion: "W332-3.1708.0"
   },
+  "pace-4": {
+    firmwareType: "COROS W335",
+    modelVersion: "W335-3.1709.0"
+  },
   "apex-4": {
     firmwareType: "COROS W541"
   }

--- a/electron/watchModels.ts
+++ b/electron/watchModels.ts
@@ -39,8 +39,8 @@ const WATCHFACE_DEVICE_PROFILES: Partial<
     modelVersion: "W332-3.1708.0"
   },
   "pace-4": {
-    firmwareType: "COROS W335",
-    modelVersion: "W335-3.1709.0"
+    firmwareType: "COROS W336",
+    modelVersion: "W336-3.1709.0"
   },
   "apex-4": {
     firmwareType: "COROS W541"

--- a/scripts/test-coros-watchface-creator.cjs
+++ b/scripts/test-coros-watchface-creator.cjs
@@ -574,6 +574,24 @@ async function main() {
   );
 
   // --- PACE 4 class AMOLED bundles (390px + 800px master) -----------------
+  await assert.rejects(
+    watchfaces.createCorosWatchfaceArchive({
+      sourceArchiveId: starter.archiveId,
+      backgroundDataUrl: pngDataUrl(icon),
+      watchModel: "pace-4"
+    }),
+    /PACE 4.*requires 390×390 and 800×800 exports.*missing 390x390/,
+    "PACE 4 exports must reject templates without the 390px device tree"
+  );
+  await assert.rejects(
+    watchfaces.createCorosWatchfaceArchive({
+      sourceArchiveId: starter.archiveId,
+      backgroundDataUrl: pngDataUrl(icon),
+      firmwareType: "COROS W335"
+    }),
+    /PACE 4.*requires 390×390 and 800×800 exports.*missing 390x390/,
+    "W335 exports must reject templates without the PACE 4 resolution tree"
+  );
   const pace4Entries = [
     {
       name: "info.json",

--- a/scripts/test-coros-watchface-creator.cjs
+++ b/scripts/test-coros-watchface-creator.cjs
@@ -587,10 +587,10 @@ async function main() {
     watchfaces.createCorosWatchfaceArchive({
       sourceArchiveId: starter.archiveId,
       backgroundDataUrl: pngDataUrl(icon),
-      firmwareType: "COROS W335"
+      firmwareType: "COROS W336"
     }),
     /PACE 4.*requires 390×390 and 800×800 exports.*missing 390x390/,
-    "W335 exports must reject templates without the PACE 4 resolution tree"
+    "W336 exports must reject templates without the PACE 4 resolution tree"
   );
   const pace4Entries = [
     {

--- a/scripts/test-coros-watchface-service.mjs
+++ b/scripts/test-coros-watchface-service.mjs
@@ -112,6 +112,14 @@ assert.equal(
   "[background_icon]=background.png\r\n[watchface_id]=0x3B9ACE60\r\n",
   "watch-face ID override must append [watchface_id] when AOD omits it"
 );
+assert.equal(
+  applyCorosWatchfaceConfigOverrides(
+    "[bg_color]=0x000000\r\n",
+    { background_icon: "studio\\aod_background\\00.png" }
+  ),
+  "[bg_color]=0x000000\r\n[background_icon]=studio\\aod_background\\00.png\r\n",
+  "independent AOD artwork may add a background to a color-only config"
+);
 assert.deepEqual(
   [...validateConfigTextReplacements([
     {

--- a/scripts/test-coros-watchface-service.mjs
+++ b/scripts/test-coros-watchface-service.mjs
@@ -245,6 +245,29 @@ assert.equal(
 );
 assert.equal(
   applyCorosWatchfaceConfigOverrides(configWithoutWeather, {
+    rect_control1_pos: "{0,0}",
+    control_exercise_icon_pos: "{139,349}",
+    control_exercise_icon: "studio\\exercise\\00.png",
+    control_exercise_hour_rect: "{166,349,199,375,hcenter|vcenter}",
+    control_exercise_minute_rect: "{216,349,248,375,hcenter|vcenter}",
+    control_exercise_font: "02",
+    control_exercise_font_color: ""
+  }),
+  [
+    "[time_hour_high_pos]={1,2}",
+    "[rect_control1_pos]={0,0}",
+    "[control_exercise_icon_pos]={139,349}",
+    "[control_exercise_icon]=studio\\exercise\\00.png",
+    "[control_exercise_hour_rect]={166,349,199,375,hcenter|vcenter}",
+    "[control_exercise_minute_rect]={216,349,248,375,hcenter|vcenter}",
+    "[control_exercise_font]=02",
+    "[control_exercise_font_color]=",
+    ""
+  ].join("\r\n"),
+  "enabled missing Exercise controls should be appendable during archive export"
+);
+assert.equal(
+  applyCorosWatchfaceConfigOverrides(configWithoutWeather, {
     temperature_rect: "{120,180,296,240,hcenter|vcenter}",
     temperature_font: "13x19",
     temperature_font_color: "0xFFFFFF",

--- a/scripts/test-watch-models.mjs
+++ b/scripts/test-watch-models.mjs
@@ -91,12 +91,12 @@ assert.deepEqual(getWatchfaceDeviceProfile("pace-pro"), {
   modelVersion: "W332-3.1708.0"
 });
 assert.deepEqual(getWatchfaceDeviceProfile("pace-4"), {
-  firmwareType: "COROS W335",
-  modelVersion: "W335-3.1709.0"
+  firmwareType: "COROS W336",
+  modelVersion: "W336-3.1709.0"
 });
-assert.deepEqual(getWatchfaceDeviceProfileByFirmware("coros w335"), {
-  firmwareType: "COROS W335",
-  modelVersion: "W335-3.1709.0"
+assert.deepEqual(getWatchfaceDeviceProfileByFirmware("coros w336"), {
+  firmwareType: "COROS W336",
+  modelVersion: "W336-3.1709.0"
 });
 assert.deepEqual(getWatchfaceDeviceProfileByFirmware("coros w541"), {
   firmwareType: "COROS W541"

--- a/scripts/test-watch-models.mjs
+++ b/scripts/test-watch-models.mjs
@@ -90,6 +90,14 @@ assert.deepEqual(getWatchfaceDeviceProfile("pace-pro"), {
   firmwareType: "COROS W332",
   modelVersion: "W332-3.1708.0"
 });
+assert.deepEqual(getWatchfaceDeviceProfile("pace-4"), {
+  firmwareType: "COROS W335",
+  modelVersion: "W335-3.1709.0"
+});
+assert.deepEqual(getWatchfaceDeviceProfileByFirmware("coros w335"), {
+  firmwareType: "COROS W335",
+  modelVersion: "W335-3.1709.0"
+});
 assert.deepEqual(getWatchfaceDeviceProfileByFirmware("coros w541"), {
   firmwareType: "COROS W541"
 });

--- a/scripts/test-watchface-editor.mjs
+++ b/scripts/test-watchface-editor.mjs
@@ -22,6 +22,11 @@ import {
   watchfaceEditorSelectionExists
 } from "../src/watchfaces/watchfaceEditorGeometry.ts";
 import {
+  listWatchfaceEditorConfigAssets,
+  watchfaceEditorControlBatteryIsListed,
+  watchfaceEditorLayerIsListed
+} from "../src/watchfaces/watchfaceEditorVisibility.ts";
+import {
   duplicateWatchfaceDesignSprite,
   normalizeWatchfaceCrop,
   normalizeWatchfaceOpacity,
@@ -299,6 +304,66 @@ assert.equal(
   watchfaceEditorSelectionExists("bgel:removed", editorLayers, [{ id: "text-1" }]),
   false,
   "removed background elements should fall back to a live editor layer"
+);
+
+const configAssetDetails = {
+  archiveId: "editor-layer-fixture",
+  resolutions: [{
+    directory: "800",
+    width: 800,
+    height: 800,
+    config: {
+      bluetooth_on_icon: "bluetooth-on.png"
+    },
+    aodConfig: {},
+    icons: [{
+      path: "800/bluetooth-on.png",
+      width: 24,
+      height: 24
+    }],
+    spriteFolders: []
+  }]
+};
+const hiddenConfigAssetDetails = {
+  ...configAssetDetails,
+  resolutions: configAssetDetails.resolutions.map((resolution) => ({
+    ...resolution,
+    config: {}
+  }))
+};
+assert.deepEqual(
+  listWatchfaceEditorConfigAssets(
+    configAssetDetails,
+    hiddenConfigAssetDetails
+  ).map((reference) => reference.id),
+  ["config:bluetooth_on_icon"],
+  "hidden config assets must retain their source reference in the layer panel"
+);
+
+const explicitlyHiddenAodMetric = {
+  id: "steps",
+  kind: "metric",
+  label: "Steps",
+  layoutGroupId: "steps",
+  metricId: "steps",
+  visible: false,
+  canHide: true,
+  present: false,
+  bounds: null,
+  capabilities: {}
+};
+assert.equal(
+  watchfaceEditorLayerIsListed(explicitlyHiddenAodMetric, "aod", {
+    metricChanges: { steps: false }
+  }),
+  true,
+  "an explicitly hidden AOD component must remain available to show again"
+);
+
+assert.equal(
+  watchfaceEditorControlBatteryIsListed(false, false, false, undefined),
+  true,
+  "a selectable battery added by the editor must stay in the panel when hidden"
 );
 
 // Image transform handles preserve the opposite corner, work in local rotated

--- a/scripts/test-watchface-studio.mjs
+++ b/scripts/test-watchface-studio.mjs
@@ -60,6 +60,7 @@ import {
   pickWatchPreviewResolution,
   rasterFontSupportsText,
   rasterFontNativeSpriteSize,
+  removeWatchfaceDateFontOverride,
   rebaseNegativeControlChildren,
   retargetWatchfaceCompositionToAod,
   retargetWatchfaceCompositionToCurrent,
@@ -710,6 +711,31 @@ assert.deepEqual(
   dateSpriteCanvasSize(monthLabelResolution, "dateMonth", monthLabelStyle, 1),
   { width: 73, height: 29, native: true },
   "12-sprite month folders should resolve JAN from firmware slot 01"
+);
+assert.equal(
+  removeWatchfaceDateFontOverride({
+    scale: 1,
+    fontFamily: "Fixture Sans",
+    letterSpacing: 0.08,
+    nativeSize: true
+  }),
+  undefined,
+  "restoring a rasterized weekday font should remove its inert style entry"
+);
+assert.deepEqual(
+  removeWatchfaceDateFontOverride({
+    scale: 1.25,
+    color: "#44ccaa",
+    fontFamily: "Fixture Sans",
+    rasterFont: monthLabelStyle.rasterFont,
+    nativeSize: true,
+    monthFormat: "labels"
+  }),
+  {
+    scale: 1.25,
+    color: "#44ccaa"
+  },
+  "font reset should preserve independent artwork edits while clearing raster sizing"
 );
 assert.equal(
   buildDateStyleOverrides(
@@ -2504,6 +2530,58 @@ assert.equal(fullTimeStyle?.values.time_second_high_pos, "{398,68}");
 assert.equal(fullTimeStyle?.values.time_second_low_pos, "{478,68}");
 assert.equal(fullTimeStyle?.values.time_second_high_font, "cl_sh");
 assert.equal(fullTimeStyle?.values.time_second_low_font, "cl_sl");
+const previewTimeStyles = {
+  hours: { color: "#33ddff", scale: 1.5 },
+  minutes: { scale: 1.25 },
+  seconds: { color: "#ffcc22", scale: 2 }
+};
+const styledTimeDetails = applyConfigOverridesToDetails(
+  withMetrics,
+  buildTimeStyleOverrides(withMetrics, previewTimeStyles)
+);
+const styledTimeBounds = computeLayoutGroupBounds(
+  styledTimeDetails.resolutions[1],
+  {
+    timeStyles: previewTimeStyles,
+    letterSpacing: 0.2
+  }
+);
+assert.deepEqual(
+  styledTimeBounds.find(({ id }) => id === "hours"),
+  {
+    id: "hours",
+    label: "Hour digits",
+    x0: 64,
+    y0: 84,
+    x1: 240,
+    y1: 180
+  },
+  "scaled hour bounds should use rendered glyph dimensions and tracking"
+);
+assert.deepEqual(
+  styledTimeBounds.find(({ id }) => id === "minutes"),
+  {
+    id: "minutes",
+    label: "Minute digits",
+    x0: 259,
+    y0: 92,
+    x1: 405,
+    y1: 172
+  },
+  "scaled minute bounds should follow both enlarged glyphs"
+);
+assert.deepEqual(
+  styledTimeBounds.find(({ id }) => id === "seconds"),
+  {
+    id: "seconds",
+    label: "Seconds",
+    x0: 385,
+    y0: 68,
+    x1: 579,
+    y1: 196
+  },
+  "seconds should share the same scale-aware selection geometry"
+);
 const timeTrackingOverrides = buildTimeTrackingOverrides(withMetrics, 0.2);
 const fullTimeTracking = timeTrackingOverrides.find((entry) =>
   entry.path.includes("800x800")

--- a/scripts/test-watchface-studio.mjs
+++ b/scripts/test-watchface-studio.mjs
@@ -36,6 +36,7 @@ import {
   corosMonthLabelForSpriteIndex,
   corosMonthSpriteIndex,
   corosWeekdayIndex,
+  detailsForCompositionMode,
   detailsForPreviewMode,
   detailsForPreviewResolution,
   getAvailableComplications,
@@ -60,6 +61,8 @@ import {
   rasterFontSupportsText,
   rasterFontNativeSpriteSize,
   rebaseNegativeControlChildren,
+  retargetWatchfaceCompositionToAod,
+  retargetWatchfaceCompositionToCurrent,
   resizeConfigRectToCanvas,
   resolveWatchfaceSpriteRotation,
   rotateSpriteInCanvas,
@@ -69,6 +72,11 @@ import {
   WATCHFACE_COMPLICATIONS,
   watchfaceEffectRenderScale
 } from "../src/watchfaces/watchfaceStudio.ts";
+import {
+  materializeLegacyAodDesign,
+  resolveWatchfaceModeDesign,
+  writeWatchfaceModeDesign
+} from "../src/watchfaces/watchfaceDisplayModes.ts";
 import {
   classifyRasterSpriteFolder,
   createRasterFontFolderReplacement
@@ -835,6 +843,142 @@ assert.equal(
   details,
   "The current preview should retain the original details object"
 );
+
+const sharedModeResolution = resolution(260, 8, 12);
+sharedModeResolution.config.time_hour_high_font = "shared_digits";
+sharedModeResolution.aodConfig = {
+  time_hour_high_pos: "{20,30}",
+  time_hour_high_font: "shared_digits"
+};
+sharedModeResolution.spriteFolders = [{
+  folder: "shared_digits",
+  kind: "digits",
+  aod: false,
+  files: digitFiles(8, 12, sharedModeResolution.directory, "shared_digits")
+}];
+const sharedModeDetails = {
+  archiveId: "shared-mode-assets",
+  resolutions: [sharedModeResolution]
+};
+const isolatedAodDetails = detailsForCompositionMode(
+  sharedModeDetails,
+  "aod"
+);
+assert.equal(
+  isolatedAodDetails.resolutions[0].config.time_hour_high_font,
+  "shared_digits"
+);
+assert.deepEqual(isolatedAodDetails.resolutions[0].aodConfig, {});
+assert.equal(isolatedAodDetails.resolutions[0].spriteFolders.length, 1);
+assert.equal(
+  isolatedAodDetails.resolutions[0].spriteFolders[0].aod,
+  false,
+  "independent AOD colors must not be dimmed a second time"
+);
+const isolatedAodComposition = retargetWatchfaceCompositionToAod(
+  isolatedAodDetails,
+  {
+    assetReplacements: [{
+      path: `${sharedModeResolution.directory}/shared_digits/00.png`,
+      dataUrl: "aod-zero"
+    }],
+    configOverrides: [{
+      path: `${sharedModeResolution.directory}/config.txt`,
+      values: { time_hour_high_pos: "{24,34}" }
+    }]
+  }
+);
+assert.match(
+  isolatedAodComposition.assetReplacements[0].path,
+  /\/studio\/aod_shared_digits_[a-z0-9]+\/00\.png$/
+);
+assert.equal(
+  isolatedAodComposition.assetReplacements[0].create,
+  true
+);
+assert.ok(
+  isolatedAodComposition.configOverrides.every((override) =>
+    override.path.endsWith("/AODconfig.txt")
+  )
+);
+assert.match(
+  isolatedAodComposition.configOverrides
+    .flatMap((override) => Object.values(override.values))
+    .find((value) => value.includes("aod_shared_digits")),
+  /^studio\\aod_shared_digits_[a-z0-9]+$/
+);
+const isolatedCurrentComposition = retargetWatchfaceCompositionToCurrent(
+  detailsForCompositionMode(sharedModeDetails, "current"),
+  {
+    assetReplacements: [{
+      path: `${sharedModeResolution.directory}/shared_digits/00.png`,
+      dataUrl: "current-zero"
+    }],
+    configOverrides: []
+  }
+);
+assert.match(
+  isolatedCurrentComposition.assetReplacements[0].path,
+  /\/studio\/current_shared_digits_[a-z0-9]+\/00\.png$/
+);
+assert.ok(
+  isolatedCurrentComposition.configOverrides.every((override) =>
+    override.path.endsWith("/config.txt")
+  )
+);
+
+const legacyModeRoot = {
+  version: 1,
+  accentColor: "#51e0b5",
+  digitColor: "#ffffff",
+  fontFamily: "",
+  tintLabels: false,
+  tintIcons: false,
+  metricStyles: {},
+  timeStyles: {},
+  dateStyles: {},
+  layerColors: {},
+  effectStyles: [],
+  layerEffects: {},
+  configAssetOverrides: {
+    "aod:background_icon": { enabled: false }
+  },
+  layoutOffsets: {}
+};
+const materializedAod = materializeLegacyAodDesign(
+  legacyModeRoot,
+  null
+);
+assert.equal(materializedAod.digitColor, "#8c8c8c");
+assert.equal(
+  materializedAod.configAssetOverrides["config:background_icon"].enabled,
+  false
+);
+const independentModeRoot = {
+  ...legacyModeRoot,
+  modeDesigns: { aod: materializedAod }
+};
+const activeAod = resolveWatchfaceModeDesign(independentModeRoot, "aod");
+const movedAodRoot = writeWatchfaceModeDesign(
+  independentModeRoot,
+  "aod",
+  {
+    ...activeAod,
+    layoutOffsets: { hours: { dx: 5, dy: 7 } }
+  }
+);
+assert.deepEqual(movedAodRoot.layoutOffsets, {});
+assert.deepEqual(
+  movedAodRoot.modeDesigns.aod.layoutOffsets.hours,
+  { dx: 5, dy: 7 }
+);
+assert.equal(movedAodRoot.modeDesigns.aod.backgroundEdited, undefined);
+const repaintedAodRoot = writeWatchfaceModeDesign(
+  movedAodRoot,
+  "aod",
+  { ...resolveWatchfaceModeDesign(movedAodRoot, "aod"), backgroundColor: "#112233" }
+);
+assert.equal(repaintedAodRoot.modeDesigns.aod.backgroundEdited, true);
 
 const analogResolution = resolution(260, 8, 12);
 analogResolution.config.time_center_pos = "{130,130}";

--- a/scripts/test-watchface-studio.mjs
+++ b/scripts/test-watchface-studio.mjs
@@ -8,7 +8,10 @@ import {
   buildControlTemperatureOverrides,
   buildControlIconPositionOverrides,
   buildControlBatteryVisibilityOverrides,
+  buildControlComplicationConfigurationOverrides,
   buildControlComplicationVisibilityOverrides,
+  buildDisabledControlComplicationOverrides,
+  buildDisabledWatchfaceConfigAssetOverrides,
   buildDateSpriteComposition,
   buildDateStyleOverrides,
   dateSpriteCanvasSize,
@@ -42,9 +45,11 @@ import {
   getWatchfaceAnalogPreviewLayers,
   getWatchfaceControlStatusPreviewLayers,
   hasControlBattery,
+  hasControlComplication,
   hasAutoAlignedTime,
   hasWatchfaceAod,
   inferStaticSeparators,
+  isControlComplicationEnabled,
   listWatchfaceConfigAssets,
   loadStudioImage,
   mergeAssetReplacements,
@@ -61,6 +66,7 @@ import {
   scaledBatterySpriteCanvasSize,
   scaleConfigRectValue,
   supportsWatchfaceSpriteRotation,
+  WATCHFACE_COMPLICATIONS,
   watchfaceEffectRenderScale
 } from "../src/watchfaces/watchfaceStudio.ts";
 import {
@@ -420,6 +426,226 @@ const details = {
   archiveId: "fixture",
   resolutions: [resolution(416, 23, 33), resolution(800, 44, 64)]
 };
+
+assert.equal(WATCHFACE_COMPLICATIONS.length, 10);
+assert.equal(
+  isControlComplicationEnabled(details, {}, "heartRate"),
+  true,
+  "a selectable declared by the imported template should default on"
+);
+assert.equal(
+  isControlComplicationEnabled(details, {}, "calories"),
+  false,
+  "a selectable missing from the imported template should default off"
+);
+assert.equal(hasControlComplication(details, "steps"), true);
+assert.equal(hasControlComplication(details, "calories"), false);
+
+const noControlDetails = {
+  ...details,
+  resolutions: details.resolutions.map((candidate) => ({
+    ...candidate,
+    config: Object.fromEntries(
+      Object.entries(candidate.config).filter(
+        ([key]) =>
+          !key.startsWith("control_") &&
+          !/^rect_control\d+_pos$/.test(key)
+      )
+    )
+  }))
+};
+const enabledMissingCalories =
+  buildControlComplicationConfigurationOverrides(noControlDetails, {
+    controlComplicationEnabled: { calories: true }
+  });
+for (const candidate of noControlDetails.resolutions) {
+  const override = enabledMissingCalories.find(
+    ({ path }) => path === `${candidate.directory}/config.txt`
+  );
+  assert.equal(override?.values.rect_control1_pos, "{0,0}");
+  assert.match(
+    override?.values.control_kcal_rect ?? "",
+    /^\{\d+,\d+,\d+,\d+,hcenter\|vcenter\}$/
+  );
+  assert.ok(
+    override?.values.control_kcal_font,
+    "enabling a missing selectable should inject a usable digit font"
+  );
+}
+const configuredCalories = applyConfigOverridesToDetails(
+  noControlDetails,
+  enabledMissingCalories
+);
+assert.equal(
+  hasControlComplication(configuredCalories, "calories"),
+  true,
+  "the synthesized configuration should be recognized when the project reloads"
+);
+
+const virtualExerciseAsset = listWatchfaceConfigAssets(
+  details,
+  undefined,
+  ["exercise"]
+).find(({ id }) => id === "config:control_exercise_icon");
+assert.equal(virtualExerciseAsset?.label, "Control Exercise");
+assert.equal(virtualExerciseAsset?.source, null);
+assert.match(
+  virtualExerciseAsset?.relativePath ?? "",
+  /^studio\/.+\/00\.png$/,
+  "an enabled injected selectable should expose an editable virtual icon row"
+);
+const exerciseDetails = applyConfigOverridesToDetails(
+  details,
+  buildControlComplicationConfigurationOverrides(details, {
+    controlComplicationEnabled: { exercise: true }
+  })
+);
+const exerciseIconOverrides = buildWatchfaceConfigAssetOverrides(
+  exerciseDetails,
+  {
+    "config:control_exercise_icon": {
+      enabled: true,
+      nativeSize: true,
+      replacement: {
+        dataUrl: "data:image/png;base64,AA==",
+        width: 32,
+        height: 32
+      }
+    }
+  }
+);
+for (const candidate of details.resolutions) {
+  const override = exerciseIconOverrides.find(
+    ({ path }) => path === `${candidate.directory}/config.txt`
+  );
+  assert.match(
+    override?.values.control_exercise_icon ?? "",
+    /^studio\\.+\\00\.png$/,
+    "a custom icon for an injected selectable should add its config path"
+  );
+  assert.match(
+    override?.values.control_exercise_icon_pos ?? "",
+    /^\{\d+,\d+\}$/,
+    "a custom icon for an injected selectable should receive an editable position"
+  );
+}
+const positionedVirtualExercise = buildControlIconPositionOverrides(
+  applyConfigOverridesToDetails(exerciseDetails, exerciseIconOverrides),
+  { exercise: { dx: 10, dy: -6 } }
+);
+assert.deepEqual(
+  positionedVirtualExercise.map(({ values }) => values.control_exercise_icon_pos),
+  ["{88,-3}", "{170,-6}"],
+  "an imported virtual selectable icon should participate in position editing"
+);
+const finalVirtualExerciseVisibility =
+  buildDisabledWatchfaceConfigAssetOverrides(exerciseDetails, {
+    "config:control_exercise_icon": {
+      enabled: true,
+      nativeSize: true,
+      replacement: {
+        dataUrl: "data:image/png;base64,AA==",
+        width: 32,
+        height: 32
+      }
+    }
+  });
+assert.deepEqual(
+  finalVirtualExerciseVisibility,
+  [],
+  "the final visibility safeguard must not restore a virtual icon's fallback position"
+);
+const pace4ExerciseExportDetails = {
+  archiveId: "pace4-exercise-export",
+  resolutions: [
+    {
+      directory: "watchface_390x390",
+      width: 390,
+      height: 390,
+      config: { rect_control1_pos: "{140,-246}" },
+      aodConfig: {},
+      spriteFolders: [],
+      icons: []
+    },
+    {
+      directory: "watchface_800x800",
+      width: 800,
+      height: 800,
+      config: { rect_control1_pos: "{286,-504}" },
+      aodConfig: {},
+      spriteFolders: [],
+      icons: []
+    }
+  ]
+};
+const pace4MovedExerciseOverrides = rebaseNegativeControlChildren(
+  pace4ExerciseExportDetails,
+  [
+    {
+      path: "watchface_390x390/config.txt",
+      values: {
+        rect_control1_pos: "{120,-231}",
+        control_step_icon_pos: "{153,300}",
+        control_step_rect: "{166,349,248,375,hcenter|vcenter}",
+        control_exercise_hour_rect: "{166,349,204,375,hcenter|vcenter}",
+        control_exercise_minute_rect: "{210,349,248,375,hcenter|vcenter}",
+        control_exercise_icon_pos: "{135,351}"
+      }
+    },
+    {
+      path: "watchface_800x800/config.txt",
+      values: {
+        rect_control1_pos: "{246,-473}",
+        control_step_icon_pos: "{313,615}",
+        control_step_rect: "{340,716,510,770,hcenter|vcenter}",
+        control_exercise_hour_rect: "{340,716,418,770,hcenter|vcenter}",
+        control_exercise_minute_rect: "{432,716,510,770,hcenter|vcenter}",
+        control_exercise_icon_pos: "{276,720}"
+      }
+    }
+  ]
+);
+assert.equal(
+  pace4MovedExerciseOverrides.find(({ path }) =>
+    path === "watchface_390x390/config.txt"
+  )?.values.control_exercise_icon_pos,
+  "{135,120}"
+);
+assert.equal(
+  pace4MovedExerciseOverrides.find(({ path }) =>
+    path === "watchface_800x800/config.txt"
+  )?.values.control_exercise_icon_pos,
+  "{276,247}",
+  "PACE 4 Exercise movement must survive shared-origin rebasing at every resolution"
+);
+
+const disabledSteps = buildControlComplicationConfigurationOverrides(details, {
+  controlComplicationEnabled: { steps: false }
+});
+for (const candidate of details.resolutions) {
+  const override = disabledSteps.find(
+    ({ path }) => path === `${candidate.directory}/config.txt`
+  );
+  for (const key of Object.keys(candidate.config).filter((key) =>
+    key.startsWith("control_step_")
+  )) {
+    assert.equal(
+      override?.values[key],
+      "__COROSLINK_DELETE_CONFIG_KEY__",
+      "turning off a selectable should delete every related config field"
+    );
+  }
+}
+for (const override of buildDisabledControlComplicationOverrides(details, {
+  controlComplicationEnabled: { steps: false }
+})) {
+  assert.ok(
+    Object.values(override.values).every(
+      (value) => value === "__COROSLINK_DELETE_CONFIG_KEY__"
+    ),
+    "the final cleanup pass must contain deletions only"
+  );
+}
 
 assert.deepEqual(
   parseWatchfaceConfigText(
@@ -1460,7 +1686,8 @@ assert.deepEqual(
 );
 assert.deepEqual(
   getAvailableComplications(details).map(({ id }) => id),
-  ["heartRate", "steps", "battery", "temperature"]
+  ["heartRate", "steps"],
+  "the effective selector should contain only components with complete config"
 );
 const selectableStyleOverrides = buildSelectableMetricStyleOverrides(
   details,
@@ -1816,9 +2043,7 @@ assert.deepEqual(
     "steps",
     "exercise",
     "sunrise",
-    "sunset",
-    "battery",
-    "temperature"
+    "sunset"
   ]
 );
 const controlIconOverrides = buildControlIconPositionOverrides(iconPositionDetails, {
@@ -1875,6 +2100,42 @@ assert.deepEqual(
     control_battery_icon_pos: "{21,12}",
     control_hr_rect: "{87,2,154,35,hcenter|vcenter}",
     control_step_rect: "{46,2,162,35,hcenter|vcenter}"
+  }
+);
+
+// A moved PACE 4 / 416 control can have positive absolute positions despite a
+// negative container origin. Fold the negative axis into every relative child
+// so the firmware receives the same positions with a non-negative origin.
+const pace416NegativeOriginDetails = {
+  resolutions: [
+    {
+      directory: "watchface_416x416",
+      config: {
+        rect_control1_pos: "{140,-246}",
+        control_step_icon_pos: "{186,328}",
+        control_step_rect: "{177,372,265,400,hcenter|vcenter}",
+        control_kcal_icon_pos: "{148,372}",
+        control_kcal_rect: "{177,372,265,400,hcenter|vcenter}",
+        control_hr_icon_pos: "{184,334}",
+        control_hr_rect: "{177,372,265,400,hcenter|vcenter}",
+        control_elevation_icon_pos: "{182,328}",
+        control_elevation_rect: "{177,372,265,400,hcenter|vcenter}"
+      }
+    }
+  ]
+};
+assert.deepEqual(
+  rebaseNegativeControlChildren(pace416NegativeOriginDetails, [])[0]?.values,
+  {
+    rect_control1_pos: "{140,0}",
+    control_step_icon_pos: "{186,82}",
+    control_step_rect: "{177,126,265,154,hcenter|vcenter}",
+    control_kcal_icon_pos: "{148,126}",
+    control_kcal_rect: "{177,126,265,154,hcenter|vcenter}",
+    control_hr_icon_pos: "{184,88}",
+    control_hr_rect: "{177,126,265,154,hcenter|vcenter}",
+    control_elevation_icon_pos: "{182,82}",
+    control_elevation_rect: "{177,126,265,154,hcenter|vcenter}"
   }
 );
 
@@ -2376,6 +2637,7 @@ const temperatureLayerDetails = {
     config: {
       ...resolution.config,
       temperature_rect: "{120,180,296,240,hcenter|vcenter}",
+      temperature_font: "13x19",
       temperature_font_color: "0xFFFFFF",
       temperature_negative_sign_icon: "icon\\negative.png"
     }
@@ -2389,6 +2651,11 @@ assert.equal(
   hiddenStaticTemperature?.values.temperature_rect,
   "__COROSLINK_DELETE_CONFIG_KEY__",
   "hiding static temperature should delete its rect key"
+);
+assert.equal(
+  hiddenStaticTemperature?.values.temperature_font,
+  "__COROSLINK_DELETE_CONFIG_KEY__",
+  "hiding static temperature should delete its font key"
 );
 assert.equal(
   hiddenStaticTemperature?.values.temperature_font_color,

--- a/src/styles.css
+++ b/src/styles.css
@@ -4704,6 +4704,119 @@ td span {
   accent-color: var(--accent);
 }
 
+.wf-selectable-components {
+  display: grid;
+  gap: 9px;
+}
+
+.wf-selectable-components-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.wf-selectable-components-heading h3 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.wf-selectable-components-heading span {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.wf-selectable-component-list {
+  display: grid;
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.018);
+}
+
+.wf-selectable-component {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 0;
+  gap: 12px;
+  padding: 9px 10px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.wf-selectable-component + .wf-selectable-component {
+  border-top: 1px solid var(--glass-border);
+}
+
+.wf-selectable-component.is-enabled {
+  background: rgba(45, 154, 116, 0.075);
+  color: var(--text-primary);
+}
+
+.wf-selectable-component > span {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.wf-selectable-component strong {
+  overflow: hidden;
+  font-size: 12px;
+  font-weight: 620;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wf-selectable-component small {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.wf-selectable-component input[role="switch"] {
+  appearance: none;
+  position: relative;
+  flex: 0 0 auto;
+  width: 30px;
+  height: 17px;
+  margin: 0;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.09);
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.wf-selectable-component input[role="switch"]::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: var(--text-secondary);
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+
+.wf-selectable-component input[role="switch"]:checked {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 55%, transparent);
+}
+
+.wf-selectable-component input[role="switch"]:checked::after {
+  background: #ffffff;
+  transform: translateX(13px);
+}
+
+.wf-selectable-component input[role="switch"]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .watchface-studio-summary {
   margin: 0;
   color: var(--text-muted);

--- a/src/watchfaces/WatchfaceEditor.tsx
+++ b/src/watchfaces/WatchfaceEditor.tsx
@@ -181,6 +181,7 @@ import {
   type WatchfaceEditorBounds
 } from "./watchfaceEditorGeometry";
 import {
+  buildAodBackgroundComposition,
   composeWatchfaceReplacements,
   deriveDesignDetails,
   toStudioOptions
@@ -190,6 +191,11 @@ import {
   MAX_DESIGN_SPRITES,
   renderDesignBackground
 } from "./watchfaceBackground";
+import {
+  materializeLegacyAodDesign,
+  resolveWatchfaceModeDesign,
+  writeWatchfaceModeDesign
+} from "./watchfaceDisplayModes";
 import {
   BACKGROUND_SPACE,
   backgroundElementAtPoint,
@@ -208,15 +214,13 @@ import {
   computeLayoutOffsetLimits,
   configAssetCanvasSize,
   configAssetSupportsNativeSize,
-  AOD_DIM_FACTOR,
   applyConfigTextEditsToDetails,
   buildDisabledControlComplicationOverrides,
   buildDisabledWatchfaceConfigAssetOverrides,
   buildWatchfaceConfigAssetOverrides,
-  detailsForPreviewMode,
+  detailsForCompositionMode,
   detailsForPreviewResolution,
   dateSpriteCanvasSize,
-  dimHexColor,
   downscaleArtwork,
   drawStudioPreview,
   getAmPmCapability,
@@ -228,11 +232,14 @@ import {
   inferStaticSeparators,
   listWatchfaceConfigAssets,
   loadStudioImage,
+  mergeAssetReplacements,
   mergeConfigOverrides,
   parseConfigPos,
   pickPreviewResolution,
   pickWatchPreviewResolution,
   rasterFontSupportsText,
+  retargetWatchfaceCompositionToAod,
+  retargetWatchfaceCompositionToCurrent,
   supportsWatchfaceSpriteRotation,
   virtualControlIconCanvasSize,
   isControlComplicationEnabled,
@@ -470,19 +477,6 @@ function maskCanvasToCircle(canvas: HTMLCanvasElement): void {
   context.restore();
 }
 
-function solidPreviewBackground(colorValue: string | undefined): string {
-  const canvas = document.createElement("canvas");
-  canvas.width = 1;
-  canvas.height = 1;
-  const context = canvas.getContext("2d");
-  const hex = colorValue?.trim().match(/^0x([0-9a-f]{6})$/i)?.[1];
-  if (context) {
-    context.fillStyle = hex ? `#${hex}` : "#000000";
-    context.fillRect(0, 0, 1, 1);
-  }
-  return canvas.toDataURL("image/png");
-}
-
 function parseBackgroundColor(colorValue: string | undefined): {
   hex: string;
   alpha: number;
@@ -671,10 +665,17 @@ export function WatchfaceEditor({
   const [checkpoint, setCheckpoint] = useState(() =>
     createWatchfaceEditorCheckpoint(history, sessionId)
   );
-  const design = history.present.value.design;
+  const rootDesign = history.present.value.design;
   const projectName = history.present.value.projectName;
   const [selectedId, setSelectedId] = useState<string>("background");
   const [selectedIds, setSelectedIds] = useState<string[]>(["background"]);
+  const previousPreviewModeRef = useRef<WatchfacePreviewMode>("current");
+  const selectionByModeRef = useRef<
+    Record<WatchfacePreviewMode, { selectedId: string; selectedIds: string[] }>
+  >({
+    current: { selectedId: "background", selectedIds: ["background"] },
+    aod: { selectedId: "background", selectedIds: ["background"] }
+  });
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [draggedArtworkLayerId, setDraggedArtworkLayerId] =
     useState<string | null>(null);
@@ -683,13 +684,19 @@ export function WatchfaceEditor({
     placement: "before" | "after";
   } | null>(null);
   const [backgroundDataUrl, setBackgroundDataUrl] = useState("");
-  const [aodBackgroundDataUrl, setAodBackgroundDataUrl] = useState("");
   const [previewMode, setPreviewMode] = useState<WatchfacePreviewMode>("current");
+  const design = useMemo(
+    () => resolveWatchfaceModeDesign(rootDesign, previewMode),
+    [rootDesign, previewMode]
+  );
   const [projectId, setProjectId] = useState<string | undefined>(initialProjectId);
   const [creating, setCreating] = useState(false);
   const [exporting, setExporting] = useState(false);
   const [previewingExport, setPreviewingExport] = useState(false);
-  const [exportPreviewDataUrl, setExportPreviewDataUrl] = useState<string | null>(null);
+  const [exportPreviewImages, setExportPreviewImages] = useState<{
+    current: string;
+    aod: string;
+  } | null>(null);
   const [saving, setSaving] = useState(false);
   const spriteImportTrackerRef = useRef(new WatchfaceSpriteImportTracker());
   const [pendingSpriteImportCount, setPendingSpriteImportCount] = useState(0);
@@ -763,9 +770,20 @@ export function WatchfaceEditor({
   ) {
     const current = historyRef.current;
     const currentValue = current.present.value;
+    const activeDesign = resolveWatchfaceModeDesign(
+      currentValue.design,
+      previewMode
+    );
     const nextDesign =
-      typeof action === "function" ? action(currentValue.design) : action;
-    const nextValue = { ...currentValue, design: nextDesign };
+      typeof action === "function" ? action(activeDesign) : action;
+    const nextValue = {
+      ...currentValue,
+      design: writeWatchfaceModeDesign(
+        currentValue.design,
+        previewMode,
+        nextDesign
+      )
+    };
     applyHistory(
       current.transactionBase
         ? updateWatchfaceEditorHistoryTransaction(current, nextValue)
@@ -1012,9 +1030,13 @@ export function WatchfaceEditor({
     setProjectId(initialProjectId);
     setSelectedId("background");
     setSelectedIds(["background"]);
+    previousPreviewModeRef.current = "current";
+    selectionByModeRef.current = {
+      current: { selectedId: "background", selectedIds: ["background"] },
+      aod: { selectedId: "background", selectedIds: ["background"] }
+    };
     setHoveredId(null);
     setBackgroundDataUrl("");
-    setAodBackgroundDataUrl("");
     setPreviewMode("current");
     setDetails(null);
     setConfigTextBaselines({});
@@ -1044,6 +1066,7 @@ export function WatchfaceEditor({
     ])
       .then(async ([described, configTexts]) => {
         let templateArtwork: CorosWatchfaceTemplateAsset | undefined;
+        let aodArtwork: CorosWatchfaceTemplateAsset | undefined;
         if (!initialDesign) {
           for (const assetPath of getTemplateBackgroundAssetPaths(described)) {
             try {
@@ -1054,6 +1077,33 @@ export function WatchfaceEditor({
               }
             } catch {
               // Older templates may only include one of the preview variants.
+            }
+          }
+        }
+        if (hasWatchfaceAod(described) && !initialDesign?.modeDesigns?.aod) {
+          const preferred = pickWatchPreviewResolution(described);
+          const aodResolutions = [
+            ...(preferred ? [preferred] : []),
+            ...described.resolutions.filter(
+              (resolution) => resolution !== preferred
+            )
+          ];
+          for (const resolution of aodResolutions) {
+            const relativePath = resolution.aodConfig.background_icon
+              ?.trim()
+              .replace(/\\/g, "/")
+              .replace(/^\.\//, "");
+            if (!relativePath) continue;
+            try {
+              const [asset] = await loadAssets([
+                `${resolution.directory}/${relativePath}`
+              ]);
+              if (asset) {
+                aodArtwork = asset;
+                break;
+              }
+            } catch {
+              // AOD may use only bg_color and no standalone background PNG.
             }
           }
         }
@@ -1121,6 +1171,40 @@ export function WatchfaceEditor({
             };
           }
         }
+        if (hasWatchfaceAod(described) && !nextDesign.modeDesigns?.aod) {
+          const sourceResolution =
+            pickWatchPreviewResolution(described) ??
+            described.resolutions.find(
+              (resolution) => Object.keys(resolution.aodConfig).length > 0
+            );
+          nextDesign = {
+            ...nextDesign,
+            configAssetOverrides: Object.fromEntries(
+              Object.entries(nextDesign.configAssetOverrides ?? {}).filter(
+                ([key]) => !key.startsWith("aod:")
+              )
+            ),
+            layerEffects: Object.fromEntries(
+              Object.entries(nextDesign.layerEffects ?? {}).filter(
+                ([key]) => !key.startsWith("aod:")
+              )
+            ),
+            modeDesigns: {
+              ...(nextDesign.modeDesigns ?? {}),
+              aod: materializeLegacyAodDesign(
+                nextDesign,
+                aodArtwork
+                  ? {
+                      dataUrl: aodArtwork.dataUrl,
+                      width: aodArtwork.width,
+                      height: aodArtwork.height
+                    }
+                  : null,
+                sourceResolution?.aodConfig.bg_color ?? "#000000"
+              )
+            }
+          };
+        }
         const initialized = {
           ...current,
           present: {
@@ -1170,6 +1254,7 @@ export function WatchfaceEditor({
     () => (details ? hasWatchfaceAod(details) : false),
     [details]
   );
+  const canEditActiveMode = previewMode === "current" || supportsAod;
   const studioOptions = useMemo(
     () => toStudioOptions(design),
     [
@@ -1201,24 +1286,7 @@ export function WatchfaceEditor({
       design.layerEffects
     ]
   );
-  const previewStudioOptions = useMemo(
-    () => previewMode === "current" || !supportsAod
-      ? studioOptions
-      : {
-          ...studioOptions,
-          digitColor: dimHexColor(studioOptions.digitColor, AOD_DIM_FACTOR),
-          accentColor: dimHexColor(studioOptions.accentColor, AOD_DIM_FACTOR),
-          previewComplication: undefined,
-          metricStyles: {},
-          complicationStyle: undefined,
-          timeStyles: {},
-          dateStyles: {},
-          layerColors: {},
-          ampmStyle: undefined,
-          configAssetScope: "aod" as const
-        },
-    [previewMode, studioOptions, supportsAod]
-  );
+  const previewStudioOptions = studioOptions;
   const detailsWithConfigEdits = useMemo(
     () =>
       details
@@ -1226,13 +1294,19 @@ export function WatchfaceEditor({
         : null,
     [details, design.configTextEdits]
   );
+  const modeSourceDetails = useMemo(
+    () => detailsWithConfigEdits
+      ? detailsForCompositionMode(detailsWithConfigEdits, previewMode)
+      : null,
+    [detailsWithConfigEdits, previewMode]
+  );
   const designDetails = useMemo(
     () =>
-      detailsWithConfigEdits
-        ? deriveDesignDetails(detailsWithConfigEdits, design)
+      modeSourceDetails
+        ? deriveDesignDetails(modeSourceDetails, design)
         : null,
     [
-      detailsWithConfigEdits,
+      modeSourceDetails,
       design.metricChanges,
       design.metricStyles,
       design.selectableMetricStyle,
@@ -1256,12 +1330,7 @@ export function WatchfaceEditor({
     ]
   );
   const basePreviewDetails = designDetails?.previewDetails ?? null;
-  const previewDetails = useMemo(
-    () => basePreviewDetails
-      ? detailsForPreviewMode(basePreviewDetails, previewMode)
-      : null,
-    [basePreviewDetails, previewMode]
-  );
+  const previewDetails = basePreviewDetails;
   const previewResolution = useMemo(
     () => (previewDetails ? pickPreviewResolution(previewDetails) : null),
     [previewDetails]
@@ -1355,23 +1424,27 @@ export function WatchfaceEditor({
     return base ? computeLayoutGroupBounds(base) : [];
   }, [designDetails]);
   const layers = useMemo(() => {
-    if (!detailsWithConfigEdits) return [];
-    return deriveEditorLayers(detailsWithConfigEdits, design).filter((layer) =>
-      previewMode === "current"
-        ? !layer.configAssetId || layer.configAssetId.startsWith("config:")
-        : layer.configAssetId?.startsWith("aod:")
-    );
-  }, [detailsWithConfigEdits, design, previewMode]);
+    if (!modeSourceDetails) return [];
+    return deriveEditorLayers(modeSourceDetails, design).filter((layer) => {
+      if (layer.configAssetId) {
+        return layer.configAssetId.startsWith("config:");
+      }
+      return previewMode === "current" || layer.present ||
+        layer.kind === "background" ||
+        layer.kind === "backgroundElement" ||
+        layer.kind === "customSprite";
+    });
+  }, [modeSourceDetails, design, previewMode]);
   const configAssetReferences = useMemo(
     () => {
-      if (!detailsWithConfigEdits) return [];
+      if (!modeSourceDetails) return [];
       const enabledControlIcons = previewMode === "current"
         ? WATCHFACE_COMPLICATIONS
             .filter(
               (complication) =>
                 complication.id !== "battery" &&
                 isControlComplicationEnabled(
-                  detailsWithConfigEdits,
+                  modeSourceDetails,
                   design,
                   complication.id
                 )
@@ -1379,16 +1452,14 @@ export function WatchfaceEditor({
             .map((complication) => complication.id)
         : [];
       return listWatchfaceConfigAssets(
-        previewMode === "current"
-          ? previewDetails ?? detailsWithConfigEdits
-          : detailsWithConfigEdits,
+        previewDetails ?? modeSourceDetails,
         undefined,
         enabledControlIcons
       ).filter(
-          (reference) => reference.scope === (previewMode === "aod" ? "aod" : "config")
+          (reference) => reference.scope === "config"
         );
     },
-    [detailsWithConfigEdits, design, previewDetails, previewMode]
+    [detailsWithConfigEdits, design, modeSourceDetails, previewDetails, previewMode]
   );
   const configAssetsById = useMemo(
     () => new Map(configAssetReferences.map((reference) => [reference.id, reference])),
@@ -1441,7 +1512,7 @@ export function WatchfaceEditor({
       )
     : null;
   const multiFreeformCanTransform = Boolean(
-    previewMode === "current" &&
+    canEditActiveMode &&
     selectedIds.length > 1 &&
     selectedFreeformTransformItems.length === selectedIds.length &&
     selectedFreeformBounds &&
@@ -1479,17 +1550,30 @@ export function WatchfaceEditor({
       selectedLayer &&
       selectedSprite &&
       selectedIds.length === 1 &&
-      previewMode === "current" &&
+      canEditActiveMode &&
       !isMovementLockedForId(selectedLayer.id)
     )
   );
 
   useEffect(() => {
-    setSelectedId(previewMode === "current" ? "background" : "");
-    setSelectedIds(previewMode === "current" ? ["background"] : []);
+    const previousMode = previousPreviewModeRef.current;
+    selectionByModeRef.current[previousMode] = {
+      selectedId,
+      selectedIds: [...selectedIds]
+    };
+    const saved = selectionByModeRef.current[previewMode];
+    const fallback = canEditActiveMode
+      ? { selectedId: "background", selectedIds: ["background"] }
+      : { selectedId: "", selectedIds: [] };
+    const restored = canEditActiveMode ? saved ?? fallback : fallback;
+    setSelectedId(restored.selectedId);
+    setSelectedIds(restored.selectedIds);
+    previousPreviewModeRef.current = previewMode;
     setHoveredId(null);
     setPlacementMenuOpen(false);
     clearSnapGuides();
+    // Selection is intentionally restored per display mode.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [previewMode]);
 
   useEffect(() => {
@@ -1500,12 +1584,12 @@ export function WatchfaceEditor({
         backgroundElements
       )
     ) return;
-    const nextId = previewMode === "current"
+    const nextId = canEditActiveMode
       ? layers.find((layer) => layer.id === "background")?.id ?? layers[0]?.id ?? ""
       : layers[0]?.id ?? "";
     setSelectedId(nextId);
     setSelectedIds(nextId ? [nextId] : []);
-  }, [backgroundElements, layers, previewMode, selectedId]);
+  }, [backgroundElements, canEditActiveMode, layers, selectedId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1534,56 +1618,6 @@ export function WatchfaceEditor({
     };
   }, [configAssetReferences, loadAssets, sessionId]);
 
-  useEffect(() => {
-    if (previewMode !== "aod" || !supportsAod) {
-      setAodBackgroundDataUrl("");
-      return;
-    }
-    const resolution = watchPreviewResolution;
-    if (!resolution) {
-      setAodBackgroundDataUrl("");
-      return;
-    }
-    const fallback = solidPreviewBackground(resolution.config.bg_color);
-    const override = design.configAssetOverrides?.["aod:background_icon"];
-    if (override?.enabled === false) {
-      setAodBackgroundDataUrl(fallback);
-      return;
-    }
-    if (override?.replacement) {
-      setAodBackgroundDataUrl(override.replacement.dataUrl);
-      return;
-    }
-    const relativePath = resolution.config.background_icon
-      ?.trim()
-      .replace(/\\/g, "/")
-      .replace(/^\.\//, "");
-    if (!relativePath) {
-      setAodBackgroundDataUrl(fallback);
-      return;
-    }
-    let cancelled = false;
-    setAodBackgroundDataUrl(fallback);
-    void loadAssets([`${resolution.directory}/${relativePath}`])
-      .then(([asset]) => {
-        if (!cancelled && asset) {
-          setAodBackgroundDataUrl(asset.dataUrl);
-        }
-      })
-      .catch(() => {
-        // The configured background may be optional; retain the config color.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    design.configAssetOverrides,
-    loadAssets,
-    previewMode,
-    sessionId,
-    supportsAod,
-    watchPreviewResolution
-  ]);
   const selectorIconTarget = useMemo(() => {
     const resolution = watchPreviewResolution ?? previewResolution;
     if (!previewDetails || !resolution) {
@@ -1663,18 +1697,14 @@ export function WatchfaceEditor({
     previewWidth,
     watchPreviewResolution
   ]);
-  const activeBackgroundElements = previewMode === "current"
-    ? backgroundElements.filter((element) => element.visible !== false)
-    : [];
-  const visibleEditorGroups = previewMode === "current"
-    ? design.editorGroups ?? []
-    : [];
+  const activeBackgroundElements = backgroundElements.filter(
+    (element) => element.visible !== false
+  );
+  const visibleEditorGroups = design.editorGroups ?? [];
   const groupedEditorLayerIds = new Set(
     visibleEditorGroups.flatMap((group) => group.layerIds)
   );
-  const previewBackgroundDataUrl = previewMode === "aod" && supportsAod
-    ? aodBackgroundDataUrl
-    : backgroundDataUrl;
+  const previewBackgroundDataUrl = backgroundDataUrl;
   const selectedElementId = selectedId.startsWith("bgel:")
     ? selectedId.slice("bgel:".length)
     : null;
@@ -2298,7 +2328,7 @@ export function WatchfaceEditor({
   }
 
   useEffect(() => {
-    if (!details || previewMode !== "current") {
+    if (!details || !canEditActiveMode) {
       precomposedDragRef.current = null;
       return;
     }
@@ -2493,7 +2523,7 @@ export function WatchfaceEditor({
     control: "rotate" | WatchfaceSpriteResizeHandle
   ) {
     if (
-      previewMode === "aod" ||
+      !canEditActiveMode ||
       event.button !== 0 ||
       !selectedSpriteCanTransform ||
       !spriteTransform ||
@@ -2926,7 +2956,7 @@ export function WatchfaceEditor({
     );
     context.clip();
 
-    if (previewMode === "current" && placementPreferences.gridVisible) {
+    if (canEditActiveMode && placementPreferences.gridVisible) {
       const gridStep = placementPreferences.gridStep / watchCoordinateScale;
       context.beginPath();
       for (let x = gridStep; x < previewWidth; x += gridStep) {
@@ -2943,7 +2973,7 @@ export function WatchfaceEditor({
       context.stroke();
     }
 
-    if (previewMode === "current" && placementPreferences.guidesVisible) {
+    if (canEditActiveMode && placementPreferences.guidesVisible) {
       const safeArea = watchfaceSafeAreaBounds(
         previewWidth,
         previewHeight,
@@ -3098,7 +3128,7 @@ export function WatchfaceEditor({
     event: React.PointerEvent<HTMLElement>,
     existingId?: string
   ) {
-    if (previewMode !== "current" || event.button !== 0) return;
+    if (!canEditActiveMode || event.button !== 0) return;
     event.preventDefault();
     event.stopPropagation();
     const id = existingId ?? `guide-${Date.now().toString(36)}`;
@@ -3282,7 +3312,7 @@ export function WatchfaceEditor({
   }
 
   function handleCanvasContextMenu(event: React.MouseEvent<HTMLCanvasElement>) {
-    if (previewMode === "aod") return;
+    if (!canEditActiveMode) return;
     const point = toResolutionPoint(event);
     const hitId = point ? editorItemAtPoint(point) : null;
     if (!hitId) return;
@@ -3398,7 +3428,7 @@ export function WatchfaceEditor({
   }
 
   function handlePointerDown(event: React.PointerEvent<HTMLCanvasElement>) {
-    if (previewMode === "aod" || event.button !== 0) return;
+    if (!canEditActiveMode || event.button !== 0) return;
     const point = toResolutionPoint(event);
     if (!point) {
       return;
@@ -4028,7 +4058,7 @@ export function WatchfaceEditor({
   };
 
   function handlePointerMove(event: React.PointerEvent<Element>) {
-    if (previewMode === "aod") {
+    if (!canEditActiveMode) {
       setHoveredId(null);
       return;
     }
@@ -4453,7 +4483,8 @@ export function WatchfaceEditor({
     id: WatchfaceComplicationId,
     enabled: boolean
   ) {
-    if (!details) return;
+    const sourceDetails = modeSourceDetails ?? details;
+    if (!sourceDetails) return;
     setDesign((current) => {
       const controlComplicationEnabled = {
         ...(current.controlComplicationEnabled ?? {}),
@@ -4463,10 +4494,13 @@ export function WatchfaceEditor({
         ...current,
         controlComplicationEnabled
       };
-      const fallbackComplication = WATCHFACE_COMPLICATIONS.find(
+      const candidates = previewMode === "aod"
+        ? getAvailableComplications(sourceDetails)
+        : WATCHFACE_COMPLICATIONS;
+      const fallbackComplication = candidates.find(
         (complication) =>
           complication.id !== id &&
-          isControlComplicationEnabled(details, next, complication.id)
+          isControlComplicationEnabled(sourceDetails, next, complication.id)
       )?.id ?? "";
       return {
         ...next,
@@ -4868,7 +4902,7 @@ export function WatchfaceEditor({
   }
 
   function handleCanvasDoubleClick(event: React.MouseEvent<HTMLCanvasElement>) {
-    if (previewMode !== "current") return;
+    if (!canEditActiveMode) return;
     const point = toResolutionPoint(event);
     const id = point ? editorItemAtPoint(point) : null;
     const layer = layers.find((candidate) => candidate.id === id);
@@ -4936,36 +4970,51 @@ export function WatchfaceEditor({
   }
 
   async function renderExportPreview(
-    designSnapshot: CorosWatchfaceDesignState,
+    rootDesignSnapshot: CorosWatchfaceDesignState,
+    mode: WatchfacePreviewMode = "current",
     snapshotBackgroundDataUrl?: string
   ): Promise<string> {
     if (!details) {
       throw new Error("The editor is still loading. Try again in a moment.");
     }
-    const renderedBackground =
-      snapshotBackgroundDataUrl ??
-      (await renderDesignBackground(designSnapshot, previewWidth));
-    const archivePreview = document.createElement("canvas");
-    archivePreview.width = 800;
-    archivePreview.height = 800;
-    // The archive/phone thumbnail always represents the current face, even if
-    // the editor happens to be displaying the Always-on tab when previewed.
+    const designSnapshot = resolveWatchfaceModeDesign(rootDesignSnapshot, mode);
+    const snapshotSourceDetails = detailsForCompositionMode(
+      applyConfigTextEditsToDetails(
+        details,
+        rootDesignSnapshot.configTextEdits
+      ),
+      mode
+    );
     const snapshotDetails = deriveDesignDetails(
-      applyConfigTextEditsToDetails(details, designSnapshot.configTextEdits),
+      snapshotSourceDetails,
       designSnapshot
     );
     const snapshotPreviewDetails = snapshotDetails.previewDetails;
-    const exportDetails = snapshotPreviewDetails
-      ? watchPreviewResolution
+    const snapshotBaseResolution = pickPreviewResolution(snapshotPreviewDetails);
+    const snapshotTargetResolution =
+      snapshotPreviewDetails?.resolutions.find(
+        (resolution) => resolution.directory === watchPreviewDirectory
+      ) ??
+      (snapshotPreviewDetails
+        ? pickWatchPreviewResolution(snapshotPreviewDetails)
+        : null);
+    const exportDetails =
+      snapshotPreviewDetails && snapshotTargetResolution
         ? detailsForPreviewResolution(
             snapshotPreviewDetails,
-            watchPreviewResolution.directory
+            snapshotTargetResolution.directory
           )
-        : snapshotPreviewDetails
-      : details;
+        : snapshotPreviewDetails ?? snapshotSourceDetails;
+    const renderedBackground =
+      snapshotBackgroundDataUrl ??
+      (await renderDesignBackground(
+        designSnapshot,
+        snapshotBaseResolution?.width ?? previewWidth
+      ));
+    const archivePreview = document.createElement("canvas");
+    archivePreview.width = 800;
+    archivePreview.height = 800;
     const snapshotOptions = toStudioOptions(designSnapshot);
-    const snapshotBaseResolution = pickPreviewResolution(snapshotPreviewDetails);
-    const snapshotTargetResolution = pickPreviewResolution(exportDetails);
     const resolutionScale =
       snapshotBaseResolution && snapshotTargetResolution
         ? snapshotTargetResolution.width / snapshotBaseResolution.width
@@ -4996,13 +5045,15 @@ export function WatchfaceEditor({
     );
     if (designSnapshot.weatherIndicator?.enabled) {
       const url = await weatherPreviewDataUrl(
-        previewWidth,
+        snapshotBaseResolution?.width ?? previewWidth,
         designSnapshot.weatherIndicator.color
       );
       if (url) {
         const image = await loadStudioImage(url);
         const context = archivePreview.getContext("2d");
-        const scale = archivePreview.width / previewWidth;
+        const scale =
+          archivePreview.width /
+          (snapshotBaseResolution?.width ?? previewWidth);
         context?.drawImage(
           image,
           designSnapshot.weatherIndicator.x * scale,
@@ -5047,7 +5098,11 @@ export function WatchfaceEditor({
     const designSnapshot = historyRef.current.present.value.design;
     setPreviewingExport(true);
     try {
-      setExportPreviewDataUrl(await renderExportPreview(designSnapshot));
+      const [current, aod] = await Promise.all([
+        renderExportPreview(designSnapshot, "current"),
+        renderExportPreview(designSnapshot, "aod")
+      ]);
+      setExportPreviewImages({ current, aod });
     } catch (caught) {
       onError(caught instanceof Error ? caught.message : "Could not render the export preview.");
     } finally {
@@ -5074,7 +5129,7 @@ export function WatchfaceEditor({
         name,
         ...(targetFirmwareType ? { firmwareType: targetFirmwareType } : {}),
         design: designSnapshot,
-        previewDataUrl: await renderExportPreview(designSnapshot)
+        previewDataUrl: await renderExportPreview(designSnapshot, "current")
       });
       if (result.saved) {
         onNotice(`Exported “${name}” as an editable website ZIP.`);
@@ -5137,16 +5192,82 @@ export function WatchfaceEditor({
         details,
         designSnapshot.configTextEdits
       );
-      const [composition, snapshotBackground] = await Promise.all([
+      const currentDesign = resolveWatchfaceModeDesign(
+        designSnapshot,
+        "current"
+      );
+      const currentDetails = detailsForCompositionMode(
+        exportSourceDetails,
+        "current"
+      );
+      const [rawCurrentComposition, snapshotBackground] = await Promise.all([
         composeWatchfaceReplacements(
-          exportSourceDetails,
-          designSnapshot,
+          currentDetails,
+          currentDesign,
           loadAssets
         ),
-        renderDesignBackground(designSnapshot, previewWidth)
+        renderDesignBackground(
+          currentDesign,
+          pickPreviewResolution(currentDetails)?.width ?? previewWidth
+        )
       ]);
+      const currentComposition = hasWatchfaceAod(exportSourceDetails)
+        ? retargetWatchfaceCompositionToCurrent(
+            currentDetails,
+            rawCurrentComposition
+          )
+        : rawCurrentComposition;
+      let aodComposition:
+        | Awaited<ReturnType<typeof composeWatchfaceReplacements>>
+        | undefined;
+      if (hasWatchfaceAod(exportSourceDetails) && designSnapshot.modeDesigns?.aod) {
+        const aodDetails = detailsForCompositionMode(
+          exportSourceDetails,
+          "aod"
+        );
+        const aodDesign = resolveWatchfaceModeDesign(designSnapshot, "aod");
+        aodComposition = retargetWatchfaceCompositionToAod(
+          aodDetails,
+          await composeWatchfaceReplacements(aodDetails, aodDesign, loadAssets)
+        );
+        if (designSnapshot.modeDesigns.aod.backgroundEdited) {
+          const aodBackground = await renderDesignBackground(
+            aodDesign,
+            pickPreviewResolution(aodDetails)?.width ?? previewWidth
+          );
+          const backgroundComposition = await buildAodBackgroundComposition(
+            aodDetails,
+            aodBackground
+          );
+          aodComposition = {
+            ...aodComposition,
+            assetReplacements: mergeAssetReplacements(
+              aodComposition.assetReplacements,
+              backgroundComposition.assetReplacements
+            ),
+            configOverrides: mergeConfigOverrides(
+              aodComposition.configOverrides,
+              backgroundComposition.configOverrides
+            )
+          };
+        }
+      }
+      const composition = {
+        assetReplacements: mergeAssetReplacements(
+          currentComposition.assetReplacements,
+          aodComposition?.assetReplacements ?? []
+        ),
+        configOverrides: mergeConfigOverrides(
+          currentComposition.configOverrides,
+          aodComposition?.configOverrides ?? []
+        ),
+        minWatchFaceVersion: Math.max(
+          currentComposition.minWatchFaceVersion ?? 0,
+          aodComposition?.minWatchFaceVersion ?? 0
+        ) || undefined
+      };
       const [exportPreview, exportBackground] = await Promise.all([
-        renderExportPreview(designSnapshot, snapshotBackground),
+        renderExportPreview(designSnapshot, "current", snapshotBackground),
         renderExportBackground(snapshotBackground)
       ]);
       const {
@@ -5162,12 +5283,12 @@ export function WatchfaceEditor({
       const configOverrides = mergeConfigOverrides(
         composedConfigOverrides,
         buildDisabledWatchfaceConfigAssetOverrides(
-          exportSourceDetails,
-          designSnapshot.configAssetOverrides ?? {}
+          currentDetails,
+          currentDesign.configAssetOverrides ?? {}
         ),
         buildDisabledControlComplicationOverrides(
-          exportSourceDetails,
-          designSnapshot
+          currentDetails,
+          currentDesign
         )
       );
       const archive = await api.createCorosWatchfaceArchive({
@@ -5635,7 +5756,7 @@ export function WatchfaceEditor({
                   : `${layers.length + activeBackgroundElements.length} items`}
               </span>
             </div>
-            {previewMode === "current" ? <div className="wf-add-menu">
+            {canEditActiveMode ? <div className="wf-add-menu">
               <button
                 type="button"
                 className="watchface-add-sprite"
@@ -5906,7 +6027,7 @@ export function WatchfaceEditor({
                 </select>
               </label>
             ) : null}
-            {previewMode === "current" ? <div className="wf-placement-menu" ref={placementMenuRef}>
+            {canEditActiveMode ? <div className="wf-placement-menu" ref={placementMenuRef}>
               <button
                 className={`wf-placement-trigger${
                   placementPreferences.snapEnabled ||
@@ -6012,7 +6133,7 @@ export function WatchfaceEditor({
               </span>
             )}
           </div>
-          {previewMode === "current" && selectedMovableIds.some((id) => !isPositionLocked(id)) ? (
+          {canEditActiveMode && selectedMovableIds.some((id) => !isPositionLocked(id)) ? (
             <div className="wf-contextual-align-bar" role="toolbar" aria-label="Align and distribute selection">
               <button type="button" title="Align left" aria-label="Align left" onClick={() => alignSelection("left")}><AlignHorizontalJustifyStart size={15} /></button>
               <button type="button" title="Align horizontal centers" aria-label="Align horizontal centers" onClick={() => alignSelection("center-x")}><AlignHorizontalJustifyCenter size={15} /></button>
@@ -6034,7 +6155,7 @@ export function WatchfaceEditor({
             className={`watchface-preview-stack watchface-editor-device${stageZoom === "fit" ? " is-fit" : ""}`}
             style={{ "--wf-stage-scale": stageZoom === "fit" ? 1 : stageZoom } as CSSProperties}
           >
-            {previewMode === "current" && placementPreferences.guidesVisible ? (
+            {canEditActiveMode && placementPreferences.guidesVisible ? (
               <>
                 <div
                   className="wf-stage-ruler is-horizontal"
@@ -6097,7 +6218,7 @@ export function WatchfaceEditor({
               onDoubleClick={handleCanvasDoubleClick}
               onContextMenu={handleCanvasContextMenu}
             />
-            {spriteTransform && selectedSpriteCanTransform && previewMode === "current" ? (
+            {spriteTransform && selectedSpriteCanTransform && canEditActiveMode ? (
               <svg
                 className={`wf-sprite-transform${selectedSpriteCanTransform ? "" : " is-locked"}`}
                 viewBox={`0 0 ${previewWidth} ${previewHeight}`}
@@ -6543,7 +6664,7 @@ export function WatchfaceEditor({
         <button className="wf-sheet-scrim is-open" type="button" aria-label="Close editor panel" onClick={() => { setLayersOpen(false); setPropertiesOpen(false); }} />
       ) : null}
 
-      {exportPreviewDataUrl ? (
+      {exportPreviewImages ? (
         <div className="wf-modal-backdrop" role="presentation">
           <section
             className="wf-modal wf-export-preview-modal"
@@ -6565,23 +6686,37 @@ export function WatchfaceEditor({
                   <span>Archive preview</span>
                 </div>
                 <div className="wf-export-phone-preview">
-                  <img src={exportPreviewDataUrl} alt="COROS app archive preview" />
+                  <img src={exportPreviewImages.current} alt="COROS app archive preview" />
                 </div>
-                <p>The exact 800 × 800 <code>watchface_customize.png</code> included in the archive.</p>
+                <p>The exact 800 × 800 <code>watchface_customize.png</code> included in the archive, rendered from Current.</p>
               </article>
               <article>
                 <div className="wf-export-preview-label">
-                  <strong>On watch</strong>
-                  <span>Circular display</span>
+                  <strong>Current</strong>
+                  <span>On-watch display</span>
                 </div>
                 <div className="wf-export-watch-preview">
-                  <img src={exportPreviewDataUrl} alt="Circular on-watch preview" />
+                  <img src={exportPreviewImages.current} alt="Current on-watch preview" />
                 </div>
-                <p>How the same rendered face is cropped on the selected watch display.</p>
+                <p>How Current is cropped on the selected watch display.</p>
+              </article>
+              <article>
+                <div className="wf-export-preview-label">
+                  <strong>Always-on</strong>
+                  <span>{supportsAod ? "AODconfig.txt" : "Uses Current"}</span>
+                </div>
+                <div className="wf-export-watch-preview">
+                  <img src={exportPreviewImages.aod} alt="Always-on display preview" />
+                </div>
+                <p>
+                  {supportsAod
+                    ? "The independent always-on layout rendered from AODconfig.txt."
+                    : "This template has no separate AODconfig.txt, so Current remains visible."}
+                </p>
               </article>
             </div>
             <div className="wf-modal-actions">
-              <button type="button" className="secondary-button" onClick={() => setExportPreviewDataUrl(null)}>
+              <button type="button" className="secondary-button" onClick={() => setExportPreviewImages(null)}>
                 Close
               </button>
               <button
@@ -6589,7 +6724,7 @@ export function WatchfaceEditor({
                 className="secondary-button"
                 disabled={spriteImportPending || exporting}
                 onClick={() => {
-                  setExportPreviewDataUrl(null);
+                  setExportPreviewImages(null);
                   void exportEditableProject();
                 }}
               >
@@ -6601,7 +6736,7 @@ export function WatchfaceEditor({
                 className="primary-button"
                 disabled={spriteImportPending || creating}
                 onClick={() => {
-                  setExportPreviewDataUrl(null);
+                  setExportPreviewImages(null);
                   void createArchive();
                 }}
               >
@@ -6769,7 +6904,7 @@ export function WatchfaceEditor({
   }
 
   function layerEffectKey(layerId: string): string {
-    return previewMode === "aod" ? `aod:${layerId}` : layerId;
+    return layerId;
   }
 
   function writeLayerEffects(
@@ -6806,22 +6941,14 @@ export function WatchfaceEditor({
       const layerEffects = { ...(current.layerEffects ?? {}) };
       if (styleId) layerEffects[key] = { kind: "style", styleId };
       else layerEffects[key] = localWatchfaceEffectBinding(
-        resolveWatchfaceLayerEffects(
-          current,
-          layerId,
-          previewMode === "aod" ? "aod" : "current"
-        )
+        resolveWatchfaceLayerEffects(current, layerId)
       );
       return { ...current, layerEffects };
     });
   }
 
   function detachLayerEffectStyle(layerId: string) {
-    const effects = resolveWatchfaceLayerEffects(
-      design,
-      layerId,
-      previewMode === "aod" ? "aod" : "current"
-    );
+    const effects = resolveWatchfaceLayerEffects(design, layerId);
     const key = layerEffectKey(layerId);
     setDesign((current) => ({
       ...current,
@@ -6833,11 +6960,7 @@ export function WatchfaceEditor({
   }
 
   function saveLayerEffectStyle(layerId: string) {
-    const effects = resolveWatchfaceLayerEffects(
-      design,
-      layerId,
-      previewMode === "aod" ? "aod" : "current"
-    );
+    const effects = resolveWatchfaceLayerEffects(design, layerId);
     if (effects.length === 0) return;
     const id = `effect-style-${Date.now().toString(36)}`;
     setDesign((current) => ({
@@ -6880,7 +7003,7 @@ export function WatchfaceEditor({
 
   function renderEffectsInspector(layerId: string, warning?: string) {
     const scope = previewMode === "aod" ? "aod" : "current";
-    const effects = resolveWatchfaceLayerEffects(design, layerId, scope);
+    const effects = resolveWatchfaceLayerEffects(design, layerId);
     const binding = design.layerEffects?.[layerEffectKey(layerId)];
     const patchEffect = (id: string, patch: Partial<CorosWatchfaceShadowEffect>) =>
       writeLayerEffects(layerId, effects.map((effect) =>
@@ -8378,12 +8501,14 @@ export function WatchfaceEditor({
   }
 
   function renderComplicationPicker() {
-    if (!details) {
+    if (!details || !modeSourceDetails) {
       return null;
     }
-    const supported = WATCHFACE_COMPLICATIONS;
+    const supported = previewMode === "aod"
+      ? getAvailableComplications(modeSourceDetails)
+      : WATCHFACE_COMPLICATIONS;
     const previewChoices = supported.filter((complication) =>
-      isControlComplicationEnabled(details, design, complication.id)
+      isControlComplicationEnabled(modeSourceDetails, design, complication.id)
     );
     const selected = previewChoices.some(
       (complication) => complication.id === design.previewComplication
@@ -8456,12 +8581,12 @@ export function WatchfaceEditor({
           <div className="wf-selectable-component-list">
             {supported.map((complication) => {
               const enabled = isControlComplicationEnabled(
-                details,
+                modeSourceDetails,
                 design,
                 complication.id
               );
               const imported = hasControlComplication(
-                details,
+                modeSourceDetails,
                 complication.id
               );
               return (

--- a/src/watchfaces/WatchfaceEditor.tsx
+++ b/src/watchfaces/WatchfaceEditor.tsx
@@ -7026,12 +7026,12 @@ export function WatchfaceEditor({
       return {
         label,
         layers: [
-          ...orderedAuthoredLayers,
           ...groupLayers.filter(
             (layer) =>
               layer.kind !== "customSprite" &&
               layer.kind !== "backgroundElement"
-          )
+          ),
+          ...orderedAuthoredLayers
         ]
       };
     });

--- a/src/watchfaces/WatchfaceEditor.tsx
+++ b/src/watchfaces/WatchfaceEditor.tsx
@@ -238,6 +238,7 @@ import {
   pickPreviewResolution,
   pickWatchPreviewResolution,
   rasterFontSupportsText,
+  removeWatchfaceDateFontOverride,
   retargetWatchfaceCompositionToAod,
   retargetWatchfaceCompositionToCurrent,
   supportsWatchfaceSpriteRotation,
@@ -1415,14 +1416,24 @@ export function WatchfaceEditor({
     const base = designDetails
       ? pickPreviewResolution(designDetails.styledMetricDetails)
       : null;
-    return base ? computeLayoutOffsetLimits(base) : {};
-  }, [designDetails]);
+    return base
+      ? computeLayoutOffsetLimits(base, {
+          timeStyles: design.timeStyles,
+          letterSpacing: design.letterSpacing
+        })
+      : {};
+  }, [designDetails, design.timeStyles, design.letterSpacing]);
   const baseLayoutBounds = useMemo(() => {
     const base = designDetails
       ? pickPreviewResolution(designDetails.styledMetricDetails)
       : null;
-    return base ? computeLayoutGroupBounds(base) : [];
-  }, [designDetails]);
+    return base
+      ? computeLayoutGroupBounds(base, {
+          timeStyles: design.timeStyles,
+          letterSpacing: design.letterSpacing
+        })
+      : [];
+  }, [designDetails, design.timeStyles, design.letterSpacing]);
   const layers = useMemo(() => {
     if (!modeSourceDetails) return [];
     return deriveEditorLayers(modeSourceDetails, design).filter((layer) => {
@@ -4696,6 +4707,26 @@ export function WatchfaceEditor({
     });
   }
 
+  /**
+   * Returning a date component to its template font must also remove the
+   * natural-size mode that was coupled to rasterization. If no independent
+   * visual edits remain, drop the style entry completely so the original PNG
+   * bypasses the trim-and-fit sprite pipeline.
+   */
+  function restoreDateTemplateFont(partId: WatchfaceDatePartId) {
+    setDesign((prev) => {
+      const dateStyles = { ...prev.dateStyles };
+      if (!dateStyles[partId]) return prev;
+      const restored = removeWatchfaceDateFontOverride(dateStyles[partId]);
+      if (restored) {
+        dateStyles[partId] = restored;
+      } else {
+        delete dateStyles[partId];
+      }
+      return { ...prev, dateStyles };
+    });
+  }
+
   function clearDateColor(partId: WatchfaceDatePartId) {
     setDesign((prev) => {
       const current = prev.dateStyles?.[partId] ?? { scale: 1 };
@@ -7939,14 +7970,20 @@ export function WatchfaceEditor({
             label="Font"
             value={style?.fontFamily ?? design.fontFamily}
             emptyLabel="Keep template font"
-            onChange={(fontFamily) =>
+            onChange={(fontFamily) => {
+              if (!fontFamily) {
+                restoreDateTemplateFont(partId);
+                return;
+              }
               setDateStyle(partId, {
                 fontFamily,
-                ...(supportsNativeSize && fontFamily
-                  ? { nativeSize: true }
+                rasterFont: undefined,
+                ...(supportsNativeSize ? { nativeSize: true } : {}),
+                ...(partId === "dateMonth"
+                  ? { monthFormat: undefined }
                   : {})
-              })
-            }
+              });
+            }}
             rasterFont={design.rasterFont}
             rasterFontRequiredText={partId === "weekday"
               ? "MON"
@@ -7972,29 +8009,31 @@ export function WatchfaceEditor({
             componentLabel={layer.label}
             onActivate={() =>
               setDateStyle(partId, {
-                fontFamily: "",
-                ...(supportsNativeSize ? { nativeSize: true } : {})
+                fontFamily: ""
               })
             }
             onRasterFontChange={setRasterFont}
-            onComponentRasterFontChange={(rasterFont) =>
+            onComponentRasterFontChange={(rasterFont) => {
+              if (!rasterFont) {
+                restoreDateTemplateFont(partId);
+                return;
+              }
               setDateStyle(partId, {
                 rasterFont,
                 ...(supportsNativeSize ? { nativeSize: true } : {}),
                 ...(partId === "dateMonth"
                   ? {
-                      monthFormat: rasterFont && WATCHFACE_MONTH_LABELS.every(
+                      monthFormat: WATCHFACE_MONTH_LABELS.every(
                         (label) => rasterFontSupportsText(rasterFont, label)
                       )
                         ? "labels"
-                        : rasterFont &&
-                            rasterFontSupportsText(rasterFont, "0123456789")
+                        : rasterFontSupportsText(rasterFont, "0123456789")
                           ? "digits"
                           : undefined
                     }
                   : {})
-              })
-            }
+              });
+            }}
           />
           <label className="field">
             Tint
@@ -8692,7 +8731,7 @@ export function WatchfaceEditor({
             setSelectableMetricStyle({
               fontFamily,
               rasterFont: undefined,
-              ...(fontFamily ? { nativeSize: true } : {})
+              nativeSize: Boolean(fontFamily)
             })
           }
           rasterFont={design.rasterFont}
@@ -8717,13 +8756,13 @@ export function WatchfaceEditor({
           componentRasterFont={design.selectableMetricStyle?.rasterFont}
           componentLabel="Selectable metric"
           onActivate={() =>
-            setSelectableMetricStyle({ fontFamily: "", nativeSize: true })
+            setSelectableMetricStyle({ fontFamily: "" })
           }
           onRasterFontChange={setRasterFont}
           onComponentRasterFontChange={(rasterFont) =>
             setSelectableMetricStyle({
               rasterFont,
-              ...(rasterFont ? { nativeSize: true } : {})
+              nativeSize: Boolean(rasterFont)
             })
           }
         />

--- a/src/watchfaces/WatchfaceEditor.tsx
+++ b/src/watchfaces/WatchfaceEditor.tsx
@@ -177,6 +177,10 @@ import {
   type EditorLayer
 } from "./watchfaceEditorModel";
 import {
+  listWatchfaceEditorConfigAssets,
+  watchfaceEditorLayerIsListed
+} from "./watchfaceEditorVisibility";
+import {
   watchfaceEditorSelectionExists,
   type WatchfaceEditorBounds
 } from "./watchfaceEditorGeometry";
@@ -230,7 +234,6 @@ import {
   hasControlComplication,
   hasWatchfaceAod,
   inferStaticSeparators,
-  listWatchfaceConfigAssets,
   loadStudioImage,
   mergeAssetReplacements,
   mergeConfigOverrides,
@@ -706,6 +709,9 @@ export function WatchfaceEditor({
   const [exportMenuOpen, setExportMenuOpen] = useState(false);
   const exportMenuRef = useRef<HTMLDivElement>(null);
   const [layersOpen, setLayersOpen] = useState(false);
+  const [collapsedLayerSections, setCollapsedLayerSections] = useState(
+    () => new Set<string>(["Template assets", "Always-on assets"])
+  );
   const [propertiesOpen, setPropertiesOpen] = useState(false);
   const [stageZoom, setStageZoom] = useState<"fit" | number>("fit");
   const [watchPreviewDirectory, setWatchPreviewDirectory] = useState("");
@@ -1438,12 +1444,12 @@ export function WatchfaceEditor({
     if (!modeSourceDetails) return [];
     return deriveEditorLayers(modeSourceDetails, design).filter((layer) => {
       if (layer.configAssetId) {
-        return layer.configAssetId.startsWith("config:");
+        return (
+          layer.configAssetId.startsWith("config:") &&
+          watchfaceEditorLayerIsListed(layer, previewMode, design)
+        );
       }
-      return previewMode === "current" || layer.present ||
-        layer.kind === "background" ||
-        layer.kind === "backgroundElement" ||
-        layer.kind === "customSprite";
+      return watchfaceEditorLayerIsListed(layer, previewMode, design);
     });
   }, [modeSourceDetails, design, previewMode]);
   const configAssetReferences = useMemo(
@@ -1462,9 +1468,9 @@ export function WatchfaceEditor({
             )
             .map((complication) => complication.id)
         : [];
-      return listWatchfaceConfigAssets(
+      return listWatchfaceEditorConfigAssets(
+        modeSourceDetails,
         previewDetails ?? modeSourceDetails,
-        undefined,
         enabledControlIcons
       ).filter(
           (reference) => reference.scope === "config"
@@ -1766,6 +1772,15 @@ export function WatchfaceEditor({
     }
     const primaryId = drag.kind === "selectorIcon" ? "complication" : drag.snapId;
     return drag.selectionIds?.length ? drag.selectionIds : linkedIdsFor(primaryId);
+  }
+
+  function dragBoundsForId(
+    drag: WatchfaceDragState,
+    id: string
+  ): WatchfaceEditorBounds | null {
+    return drag.kind === "selectorIcon" && id === "complication"
+      ? drag.baseBounds
+      : selectionBoundsForId(id);
   }
 
   function selectEditorItem(id: string, additive = false) {
@@ -2081,12 +2096,9 @@ export function WatchfaceEditor({
     }
     context.restore();
 
-    const primaryId = visual.drag.kind === "selectorIcon"
-      ? "complication"
-      : visual.drag.snapId;
     const movedIds = dragMovementIds(visual.drag);
     const linkedBounds = movedIds
-      .map(selectionBoundsForId)
+      .map((id) => dragBoundsForId(visual.drag, id))
       .filter((box): box is WatchfaceEditorBounds => Boolean(box));
     const baseBounds = linkedBounds.length > 1
       ? linkedBounds.reduce((result, box) => ({
@@ -2120,7 +2132,6 @@ export function WatchfaceEditor({
     moving: CorosWatchfaceDesignState;
     clipBounds: WatchfaceEditorBounds;
   } {
-    const primaryId = drag.kind === "selectorIcon" ? "complication" : drag.snapId;
     const movingIds = dragMovementIds(drag);
     const movingIdSet = new Set(movingIds);
     const movingElementIds = new Set(
@@ -2129,6 +2140,9 @@ export function WatchfaceEditor({
         .map((id) => id.slice("bgel:".length))
     );
     const movingLayers = layers.filter((layer) => movingIdSet.has(layer.id));
+    const baseMovingLayers = drag.kind === "selectorIcon"
+      ? movingLayers.filter((layer) => layer.id !== "complication")
+      : movingLayers;
     const movingSpriteIds = new Set(
       movingLayers
         .map((layer) => layer.spriteId)
@@ -2181,7 +2195,7 @@ export function WatchfaceEditor({
       layerVisibility: {
         ...design.layerVisibility,
         ...Object.fromEntries(
-          movingLayers
+          baseMovingLayers
             .map((layer) => layer.layoutGroupId)
             .filter((id): id is string => Boolean(id))
             .map((id) => [id, false])
@@ -2235,7 +2249,7 @@ export function WatchfaceEditor({
     };
 
     const linkedBounds = movingIds
-      .map(selectionBoundsForId)
+      .map((id) => dragBoundsForId(drag, id))
       .filter((box): box is WatchfaceEditorBounds => Boolean(box));
     const movingBounds = linkedBounds.length > 0
       ? linkedBounds.reduce((result, box) => ({
@@ -2259,7 +2273,8 @@ export function WatchfaceEditor({
   }
 
   async function renderDragFrame(
-    frameDesign: CorosWatchfaceDesignState
+    frameDesign: CorosWatchfaceDesignState,
+    previewComplicationContent: WatchfaceStudioOptions["previewComplicationContent"] = "all"
   ): Promise<HTMLCanvasElement> {
     if (!details) {
       throw new Error("Watch face details are not ready.");
@@ -2285,7 +2300,13 @@ export function WatchfaceEditor({
       frame,
       frameBackground,
       frameDetails,
-      studioOptionsForResolution(toStudioOptions(frameDesign), frameDetails),
+      studioOptionsForResolution(
+        {
+          ...toStudioOptions(frameDesign),
+          previewComplicationContent
+        },
+        frameDetails
+      ),
       loadAssets
     );
     if (frameDesign.weatherIndicator?.enabled) {
@@ -2316,6 +2337,7 @@ export function WatchfaceEditor({
     const selectionKey = dragMovementIds(drag).slice().sort().join("|");
     const cached = precomposedDragRef.current;
     const cacheMatches = Boolean(
+      drag.kind !== "selectorIcon" &&
       cached &&
       cached.design === design &&
       cached.selectionKey === selectionKey &&
@@ -2335,7 +2357,34 @@ export function WatchfaceEditor({
       canvas.style.visibility = "hidden";
     }
     setDragVisualActive(true);
-    if (cacheMatches) drawDragVisual();
+    if (cacheMatches) {
+      drawDragVisual();
+      return;
+    }
+    if (drag.kind !== "selectorIcon") {
+      return;
+    }
+    void Promise.all([
+      renderDragFrame(isolated.base),
+      renderDragFrame(isolated.moving, "icon")
+    ]).then(([baseFrame, movingFrame]) => {
+      const active = dragVisualRef.current;
+      if (
+        !mountedRef.current ||
+        previewSessionRef.current !== sessionId ||
+        dragRef.current !== drag ||
+        active?.drag !== drag ||
+        active.preparationId !== preparationId
+      ) {
+        return;
+      }
+      active.baseFrame = baseFrame;
+      active.movingFrame = movingFrame;
+      active.clipBounds = isolated.clipBounds;
+      drawDragVisual();
+    }).catch(() => {
+      // Keep the accurate main preview visible if drag isolation fails.
+    });
   }
 
   useEffect(() => {
@@ -2396,6 +2445,8 @@ export function WatchfaceEditor({
       const active = dragVisualRef.current;
       if (
         active &&
+        active.drag.kind !== "selectorIcon" &&
+        dragRef.current === active.drag &&
         active.baseFrame === null &&
         dragMovementIds(active.drag).slice().sort().join("|") === selectionKey
       ) {
@@ -3392,10 +3443,9 @@ export function WatchfaceEditor({
       previewWidth,
       renderedWidth
     );
-    const primaryId = drag.kind === "selectorIcon" ? "complication" : drag.snapId;
     const linkedIds = dragMovementIds(drag);
     const linkedBounds = linkedIds
-      .map(selectionBoundsForId)
+      .map((id) => dragBoundsForId(drag, id))
       .filter((box): box is WatchfaceEditorBounds => Boolean(box));
     const baseBounds = linkedBounds.length > 1
       ? linkedBounds.reduce((result, box) => ({
@@ -5812,9 +5862,27 @@ export function WatchfaceEditor({
           {details ? (
             <ul className="wf-layer-list">
               {visibleEditorGroups.length > 0 ? (
-                <li className="wf-layer-group">Groups</li>
+                <li className="wf-layer-group">
+                  <button
+                    type="button"
+                    className="wf-layer-section-toggle"
+                    aria-expanded={!collapsedLayerSections.has("Groups")}
+                    onClick={() => toggleLayerSection("Groups")}
+                  >
+                    <ChevronDown
+                      className={collapsedLayerSections.has("Groups") ? "is-collapsed" : ""}
+                      size={13}
+                      aria-hidden="true"
+                    />
+                    <span>Groups</span>
+                    <span className="wf-layer-section-count">
+                      {visibleEditorGroups.length}
+                    </span>
+                  </button>
+                </li>
               ) : null}
-              {visibleEditorGroups.map((group) => {
+              {!collapsedLayerSections.has("Groups")
+                ? visibleEditorGroups.map((group) => {
                 const locked = group.layerIds.some(isPositionLocked);
                 const visible = editorGroupVisible(group.id);
                 return (
@@ -5878,13 +5946,33 @@ export function WatchfaceEditor({
                     </ul>
                   </li>
                 );
-              })}
+                })
+                : null}
               {groupLayersForDisplay(
                 layers.filter((layer) => !groupedEditorLayerIds.has(layer.id))
-              ).map(({ label: group, layers: groupedLayers }) => (
-                <Fragment key={group}>
-                  <li className="wf-layer-group">{group}</li>
-                  {groupedLayers.map((layer) => {
+              ).map(({ label: group, layers: groupedLayers }) => {
+                const collapsed = collapsedLayerSections.has(group);
+                return (
+                  <Fragment key={group}>
+                    <li className="wf-layer-group">
+                      <button
+                        type="button"
+                        className="wf-layer-section-toggle"
+                        aria-expanded={!collapsed}
+                        onClick={() => toggleLayerSection(group)}
+                      >
+                        <ChevronDown
+                          className={collapsed ? "is-collapsed" : ""}
+                          size={13}
+                          aria-hidden="true"
+                        />
+                        <span>{group}</span>
+                        <span className="wf-layer-section-count">
+                          {groupedLayers.length}
+                        </span>
+                      </button>
+                    </li>
+                    {collapsed ? null : groupedLayers.map((layer) => {
                     const authoredLayer =
                       layer.kind === "customSprite" ||
                       layer.kind === "backgroundElement";
@@ -5997,9 +6085,10 @@ export function WatchfaceEditor({
                       ) : null}
                     </li>
                     );
-                  })}
-                </Fragment>
-              ))}
+                    })}
+                  </Fragment>
+                );
+              })}
             </ul>
           ) : (
             <div className="wf-pane-loading" role="status"><Loader2 className="spin" size={16} /> Reading template</div>
@@ -6803,22 +6892,31 @@ export function WatchfaceEditor({
       layer.kind === "backgroundElement" ||
       layer.kind === "customSprite"
     ) return "Artwork";
-    if (
-      layer.kind === "configAsset" ||
-      layer.kind === "controlBatteryIcon"
-    ) {
+    if (layer.kind === "configAsset") {
       return previewMode === "aod" ? "Always-on assets" : "Template assets";
+    }
+    if (
+      layer.kind === "date" ||
+      layer.kind === "weekday" ||
+      layer.id === "staticDateSlash"
+    ) {
+      return "Date";
     }
     if (
       layer.kind === "time" ||
       layer.kind === "seconds" ||
-      layer.kind === "date" ||
-      layer.kind === "weekday" ||
       layer.kind === "separators"
     ) {
-      return "Time and date";
+      return "Time";
     }
-    return "Data";
+    if (
+      layer.kind === "batteryIcon" ||
+      layer.kind === "controlBatteryIcon" ||
+      layer.kind === "weather"
+    ) {
+      return "Indicators";
+    }
+    return "Metrics";
   }
 
   function groupLayersForDisplay(
@@ -6834,7 +6932,7 @@ export function WatchfaceEditor({
         groups.set(label, [layer]);
       }
     }
-    return [...groups].map(([label, groupLayers]) => {
+    const sections = [...groups].map(([label, groupLayers]) => {
       if (label === "Template assets" || label === "Always-on assets") {
         return {
           label,
@@ -6843,7 +6941,47 @@ export function WatchfaceEditor({
           )
         };
       }
-      if (label !== "Artwork") return { label, layers: groupLayers };
+      if (label !== "Artwork") {
+        const layerOrder: Record<string, string[]> = {
+          Time: [
+            "autoTime",
+            "hours",
+            "minutes",
+            "seconds",
+            "ampm",
+            "separators",
+            "staticColon"
+          ],
+          Date: ["weekday", "dateMonth", "dateDay", "staticDateSlash"],
+          Metrics: [
+            "complication",
+            "battery",
+            "heartRate",
+            "steps",
+            "calories",
+            "elevation",
+            "temperature"
+          ],
+          Indicators: ["weather", "batteryIcon", "controlBatteryIcon"]
+        };
+        const order = layerOrder[label] ?? [];
+        return {
+          label,
+          layers: groupLayers
+            .map((layer, sourceIndex) => ({ layer, sourceIndex }))
+            .sort((left, right) => {
+              const leftIndex = order.indexOf(left.layer.id);
+              const rightIndex = order.indexOf(right.layer.id);
+              if (leftIndex < 0 && rightIndex < 0) {
+                return left.sourceIndex - right.sourceIndex;
+              }
+              if (leftIndex < 0) return 1;
+              if (rightIndex < 0) return -1;
+              return leftIndex - rightIndex;
+            })
+            .map(({ layer }) => layer)
+        };
+      }
       const authoredLayers = [
         ...groupLayers.filter((layer) => layer.kind === "customSprite"),
         ...backgroundElements
@@ -6896,6 +7034,28 @@ export function WatchfaceEditor({
           )
         ]
       };
+    });
+    const sectionOrder = [
+      "Time",
+      "Date",
+      "Metrics",
+      "Indicators",
+      "Artwork",
+      "Template assets",
+      "Always-on assets"
+    ];
+    return sections.sort(
+      (left, right) =>
+        sectionOrder.indexOf(left.label) - sectionOrder.indexOf(right.label)
+    );
+  }
+
+  function toggleLayerSection(section: string) {
+    setCollapsedLayerSections((current) => {
+      const next = new Set(current);
+      if (next.has(section)) next.delete(section);
+      else next.add(section);
+      return next;
     });
   }
 

--- a/src/watchfaces/WatchfaceEditor.tsx
+++ b/src/watchfaces/WatchfaceEditor.tsx
@@ -5763,12 +5763,14 @@ export function WatchfaceEditor({
             <PanelRight size={17} />
           </button>
           <span className="wf-command-separator" aria-hidden="true" />
-          <button className="wf-icon-button" type="button" disabled={!canUndo} aria-label="Undo" title="Undo" onClick={undo}>
-            <Undo2 size={17} />
-          </button>
-          <button className="wf-icon-button" type="button" disabled={!canRedo} aria-label="Redo" title="Redo" onClick={redo}>
-            <Redo2 size={17} />
-          </button>
+          <div className="wf-history-controls" role="group" aria-label="Edit history">
+            <button className="wf-icon-button" type="button" disabled={!canUndo} aria-label="Undo" title="Undo" onClick={undo}>
+              <Undo2 size={17} />
+            </button>
+            <button className="wf-icon-button" type="button" disabled={!canRedo} aria-label="Redo" title="Redo" onClick={redo}>
+              <Redo2 size={17} />
+            </button>
+          </div>
           <button className="secondary-button wf-save-button" type="button" disabled={saving || spriteImportPending || !isDirty} onClick={() => void saveProject()}>
             {saving ? <Loader2 className="spin" size={15} /> : <Save size={15} />}
             Save

--- a/src/watchfaces/WatchfaceEditor.tsx
+++ b/src/watchfaces/WatchfaceEditor.tsx
@@ -210,6 +210,8 @@ import {
   configAssetSupportsNativeSize,
   AOD_DIM_FACTOR,
   applyConfigTextEditsToDetails,
+  buildDisabledControlComplicationOverrides,
+  buildDisabledWatchfaceConfigAssetOverrides,
   buildWatchfaceConfigAssetOverrides,
   detailsForPreviewMode,
   detailsForPreviewResolution,
@@ -221,7 +223,7 @@ import {
   scaleAmPmStyleForResolution,
   getAvailableComplications,
   getTemplateBackgroundAssetPaths,
-  hasControlBattery,
+  hasControlComplication,
   hasWatchfaceAod,
   inferStaticSeparators,
   listWatchfaceConfigAssets,
@@ -232,10 +234,14 @@ import {
   pickWatchPreviewResolution,
   rasterFontSupportsText,
   supportsWatchfaceSpriteRotation,
+  virtualControlIconCanvasSize,
+  isControlComplicationEnabled,
+  WATCHFACE_COMPLICATIONS,
   WATCHFACE_MONTH_LABELS,
   type WatchfaceDatePartId,
   type WatchfaceAssetLoader,
   type WatchfaceConfigAssetReference,
+  type WatchfaceComplicationId,
   type WatchfaceMetricId,
   type WatchfacePreviewMode,
   type WatchfaceStudioOptions,
@@ -534,6 +540,7 @@ function normalizeEditorDesign(
     artworkVisible:
       design.artworkVisible ?? legacyBackgroundOverride?.enabled !== false,
     configAssetOverrides: design.configAssetOverrides ?? {},
+    controlComplicationEnabled: design.controlComplicationEnabled ?? {},
     editorGroups: normalizeWatchfaceEditorGroups(
       design.editorGroups,
       design.linkedLayerGroups
@@ -1154,7 +1161,9 @@ export function WatchfaceEditor({
       design.designSprites,
       design.configAssetOverrides,
       design.staticSeparators,
-      design.fontFamily
+      design.fontFamily,
+      design.effectStyles,
+      design.layerEffects
     ]
   );
   const supportsAod = useMemo(
@@ -1176,6 +1185,7 @@ export function WatchfaceEditor({
       design.previewComplication,
       design.metricStyles,
       design.selectableMetricStyle,
+      design.controlComplicationEnabled,
       design.controlBatteryEnabled,
       design.controlSunriseEnabled,
       design.controlSunsetEnabled,
@@ -1186,7 +1196,9 @@ export function WatchfaceEditor({
       design.dateStyles,
       design.layerColors,
       design.configAssetOverrides,
-      design.ampmIndicator
+      design.ampmIndicator,
+      design.effectStyles,
+      design.layerEffects
     ]
   );
   const previewStudioOptions = useMemo(
@@ -1224,7 +1236,12 @@ export function WatchfaceEditor({
       design.metricChanges,
       design.metricStyles,
       design.selectableMetricStyle,
+      design.controlComplicationEnabled,
       design.controlBatteryEnabled,
+      design.controlSunriseEnabled,
+      design.controlSunsetEnabled,
+      design.controlFloorEnabled,
+      design.controlTemperatureEnabled,
       design.separateAutoTime,
       design.timeStyles,
       design.dateStyles,
@@ -1346,12 +1363,32 @@ export function WatchfaceEditor({
     );
   }, [detailsWithConfigEdits, design, previewMode]);
   const configAssetReferences = useMemo(
-    () => (detailsWithConfigEdits
-      ? listWatchfaceConfigAssets(detailsWithConfigEdits).filter(
+    () => {
+      if (!detailsWithConfigEdits) return [];
+      const enabledControlIcons = previewMode === "current"
+        ? WATCHFACE_COMPLICATIONS
+            .filter(
+              (complication) =>
+                complication.id !== "battery" &&
+                isControlComplicationEnabled(
+                  detailsWithConfigEdits,
+                  design,
+                  complication.id
+                )
+            )
+            .map((complication) => complication.id)
+        : [];
+      return listWatchfaceConfigAssets(
+        previewMode === "current"
+          ? previewDetails ?? detailsWithConfigEdits
+          : detailsWithConfigEdits,
+        undefined,
+        enabledControlIcons
+      ).filter(
           (reference) => reference.scope === (previewMode === "aod" ? "aod" : "config")
-        )
-      : []),
-    [detailsWithConfigEdits, previewMode]
+        );
+    },
+    [detailsWithConfigEdits, design, previewDetails, previewMode]
   );
   const configAssetsById = useMemo(
     () => new Map(configAssetReferences.map((reference) => [reference.id, reference])),
@@ -1590,10 +1627,18 @@ export function WatchfaceEditor({
     const baseWidth = icon?.width ?? state?.width ?? Math.round(resolution.width * 0.05);
     const baseHeight = icon?.height ?? state?.height ?? Math.round(resolution.width * 0.04);
     const configKey = `control_${complication.controlPrefix}_icon`;
+    const configOverride =
+      design.configAssetOverrides?.[`config:${configKey}`];
+    const virtualIcon = !icon && !state && Boolean(configOverride?.replacement);
+    const virtualCanvas = virtualIcon
+      ? virtualControlIconCanvasSize(resolution)
+      : null;
     const canvasSize = configAssetCanvasSize(
       configKey,
-      design.configAssetOverrides?.[`config:${configKey}`],
-      { width: baseWidth, height: baseHeight },
+      virtualIcon && configOverride
+        ? { ...configOverride, nativeSize: false }
+        : configOverride,
+      virtualCanvas ?? { width: baseWidth, height: baseHeight },
       previewResolution ? resolution.width / previewResolution.width : 1
     );
     // The preview frame is rendered from the selected watch's native tree,
@@ -4264,7 +4309,7 @@ export function WatchfaceEditor({
         enabled: true,
         replacement: await downscaleArtwork(selected),
         ...(configAssetSupportsNativeSize(reference.configKey)
-          ? { nativeSize: true }
+          ? { nativeSize: Boolean(reference.source) }
           : {})
       });
       onNotice(`${reference.label} replaced for every supported resolution.`);
@@ -4404,45 +4449,38 @@ export function WatchfaceEditor({
     }));
   }
 
-  function setControlBatteryEnabled(enabled: boolean) {
-    const fallbackComplication = details
-      ? getAvailableComplications(details).find(
-          (complication) => complication.id !== "battery"
-        )?.id ?? ""
-      : "";
-    setDesign((current) => ({
-      ...current,
-      controlBatteryEnabled: enabled,
-      ...(!enabled && current.previewComplication === "battery"
-        ? { previewComplication: fallbackComplication }
-        : {})
-    }));
-  }
-
   function setControlComplicationEnabled(
-    id: "sunrise" | "sunset" | "floors" | "temperature",
+    id: WatchfaceComplicationId,
     enabled: boolean
   ) {
-    const flagKey =
-      id === "sunrise"
-        ? "controlSunriseEnabled"
-        : id === "sunset"
-          ? "controlSunsetEnabled"
-          : id === "floors"
-            ? "controlFloorEnabled"
-            : "controlTemperatureEnabled";
-    const fallbackComplication = details
-      ? getAvailableComplications(details).find(
-          (complication) => complication.id !== id
-        )?.id ?? ""
-      : "";
-    setDesign((current) => ({
-      ...current,
-      [flagKey]: enabled,
-      ...(!enabled && current.previewComplication === id
-        ? { previewComplication: fallbackComplication }
-        : {})
-    }));
+    if (!details) return;
+    setDesign((current) => {
+      const controlComplicationEnabled = {
+        ...(current.controlComplicationEnabled ?? {}),
+        [id]: enabled
+      };
+      const next = {
+        ...current,
+        controlComplicationEnabled
+      };
+      const fallbackComplication = WATCHFACE_COMPLICATIONS.find(
+        (complication) =>
+          complication.id !== id &&
+          isControlComplicationEnabled(details, next, complication.id)
+      )?.id ?? "";
+      return {
+        ...next,
+        ...(enabled
+          ? { previewComplication: id }
+          : current.previewComplication === id
+            ? { previewComplication: fallbackComplication }
+            : {})
+      };
+    });
+  }
+
+  function setControlBatteryEnabled(enabled: boolean) {
+    setControlComplicationEnabled("battery", enabled);
   }
 
   function updateAmPmIndicator(
@@ -4898,11 +4936,15 @@ export function WatchfaceEditor({
   }
 
   async function renderExportPreview(
-    designSnapshot: CorosWatchfaceDesignState
+    designSnapshot: CorosWatchfaceDesignState,
+    snapshotBackgroundDataUrl?: string
   ): Promise<string> {
-    if (!details || !backgroundDataUrl) {
+    if (!details) {
       throw new Error("The editor is still loading. Try again in a moment.");
     }
+    const renderedBackground =
+      snapshotBackgroundDataUrl ??
+      (await renderDesignBackground(designSnapshot, previewWidth));
     const archivePreview = document.createElement("canvas");
     archivePreview.width = 800;
     archivePreview.height = 800;
@@ -4947,7 +4989,7 @@ export function WatchfaceEditor({
     };
     await drawStudioPreview(
       archivePreview,
-      backgroundDataUrl,
+      renderedBackground,
       exportDetails,
       exportOptions,
       loadAssets
@@ -4974,10 +5016,9 @@ export function WatchfaceEditor({
     return archivePreview.toDataURL("image/png");
   }
 
-  async function renderExportBackground(): Promise<string> {
-    if (!backgroundDataUrl) {
-      throw new Error("The editor is still loading. Try again in a moment.");
-    }
+  async function renderExportBackground(
+    snapshotBackgroundDataUrl: string
+  ): Promise<string> {
     const exportBackground = document.createElement("canvas");
     exportBackground.width = 800;
     exportBackground.height = 800;
@@ -4988,7 +5029,7 @@ export function WatchfaceEditor({
       throw new Error("Could not render the circular watch background.");
     }
     context.drawImage(
-      await loadStudioImage(backgroundDataUrl, false),
+      await loadStudioImage(snapshotBackgroundDataUrl, false),
       0,
       0,
       exportBackground.width,
@@ -5096,14 +5137,17 @@ export function WatchfaceEditor({
         details,
         designSnapshot.configTextEdits
       );
-      const [composition, exportPreview, exportBackground] = await Promise.all([
+      const [composition, snapshotBackground] = await Promise.all([
         composeWatchfaceReplacements(
           exportSourceDetails,
           designSnapshot,
           loadAssets
         ),
-        renderExportPreview(designSnapshot),
-        renderExportBackground()
+        renderDesignBackground(designSnapshot, previewWidth)
+      ]);
+      const [exportPreview, exportBackground] = await Promise.all([
+        renderExportPreview(designSnapshot, snapshotBackground),
+        renderExportBackground(snapshotBackground)
       ]);
       const {
         assetReplacements,
@@ -5117,9 +5161,13 @@ export function WatchfaceEditor({
       // those deletion sentinels before the archive service receives them.
       const configOverrides = mergeConfigOverrides(
         composedConfigOverrides,
-        buildWatchfaceConfigAssetOverrides(
+        buildDisabledWatchfaceConfigAssetOverrides(
           exportSourceDetails,
           designSnapshot.configAssetOverrides ?? {}
+        ),
+        buildDisabledControlComplicationOverrides(
+          exportSourceDetails,
+          designSnapshot
         )
       );
       const archive = await api.createCorosWatchfaceArchive({
@@ -6986,6 +7034,7 @@ export function WatchfaceEditor({
     const enabled = override?.enabled !== false;
     const artworkZoom = override?.scale ?? 1;
     const supportsNativeSize =
+      Boolean(reference.source) &&
       configAssetSupportsNativeSize(reference.configKey);
     const nativeSize = supportsNativeSize && override?.nativeSize === true;
     const templatePreview = configAssetPreviews.get(reference.archivePath);
@@ -7127,18 +7176,38 @@ export function WatchfaceEditor({
   }
 
   function renderControlBatteryInspector(layer: EditorLayer) {
+    if (!layer.visible) {
+      return (
+        <div className="watchface-inspector-group">
+          <p className="watchface-studio-summary">
+            Battery is off. Turn it on in Selectable components to add its
+            configuration and show these settings.
+          </p>
+        </div>
+      );
+    }
     const override =
       design.configAssetOverrides?.["config:control_battery_icon"];
     const stateCount = Object.keys(
       override?.stateReplacements ?? {}
     ).length;
     const iconScale = override?.scale ?? 1;
-    const sourceResolution = details ? pickPreviewResolution(details) : null;
-    const baseIconPosition = parseConfigPos(
-      sourceResolution?.config.control_battery_icon_pos
-    );
+    const sourceResolution = previewDetails
+      ? pickPreviewResolution(previewDetails)
+      : details
+        ? pickPreviewResolution(details)
+        : null;
     const iconOffset =
       design.controlIconOffsets?.battery ?? { dx: 0, dy: 0 };
+    const configuredIconPosition = parseConfigPos(
+      sourceResolution?.config.control_battery_icon_pos
+    );
+    const baseIconPosition = configuredIconPosition
+      ? {
+          x: configuredIconPosition.x - iconOffset.dx,
+          y: configuredIconPosition.y - iconOffset.dy
+        }
+      : null;
     const controlOriginKey = sourceResolution
       ? Object.keys(sourceResolution.config).find((key) =>
           /^rect_control\d+_pos$/.test(key)
@@ -7180,16 +7249,6 @@ export function WatchfaceEditor({
 
     return (
       <div className="watchface-inspector-group">
-        <label className="watchface-studio-toggle">
-          <input
-            type="checkbox"
-            checked={layer.visible}
-            onChange={(event) =>
-              setControlBatteryEnabled(event.target.checked)
-            }
-          />
-          Include Battery in selectable metrics
-        </label>
         <h3 className="wf-inspector-heading">Control battery sprite folder</h3>
         <div className="wf-config-asset-actions">
           <button
@@ -8319,43 +8378,40 @@ export function WatchfaceEditor({
   }
 
   function renderComplicationPicker() {
-    const available = getAvailableComplications(previewDetails ?? details!);
-    if (available.length === 0) {
+    if (!details) {
       return null;
     }
-    const controlBatteryEnabled =
-      design.controlBatteryEnabled ?? hasControlBattery(details!);
-    const previewChoices = available.filter(
-      (complication) =>
-        (complication.id !== "battery" || controlBatteryEnabled) &&
-        (complication.id !== "sunrise" ||
-          design.controlSunriseEnabled !== false) &&
-        (complication.id !== "sunset" ||
-          design.controlSunsetEnabled !== false) &&
-        (complication.id !== "floors" ||
-          design.controlFloorEnabled !== false) &&
-        (complication.id !== "temperature" ||
-          design.controlTemperatureEnabled !== false)
+    const supported = WATCHFACE_COMPLICATIONS;
+    const previewChoices = supported.filter((complication) =>
+      isControlComplicationEnabled(details, design, complication.id)
     );
     const selected = previewChoices.some(
       (complication) => complication.id === design.previewComplication
     )
       ? design.previewComplication
       : previewChoices[0]?.id ?? "";
-    const selectedComplication = available.find(
+    const selectedComplication = supported.find(
       (complication) => complication.id === selected
     );
     const controlColonReference = configAssetsById.get("config:control_colon_icon");
     const controlColonEnabled =
       design.configAssetOverrides?.["config:control_colon_icon"]?.enabled !== false;
-    const sourceResolution = details ? pickPreviewResolution(details) : null;
+    const sourceResolution = previewDetails
+      ? pickPreviewResolution(previewDetails)
+      : pickPreviewResolution(details);
     const iconPositionKey = selectedComplication
       ? `control_${selectedComplication.controlPrefix}_icon_pos`
       : "";
-    const baseIconPosition = iconPositionKey
+    const iconOffset = design.controlIconOffsets?.[selected] ?? { dx: 0, dy: 0 };
+    const configuredIconPosition = iconPositionKey
       ? parseConfigPos(sourceResolution?.config[iconPositionKey])
       : null;
-    const iconOffset = design.controlIconOffsets?.[selected] ?? { dx: 0, dy: 0 };
+    const baseIconPosition = configuredIconPosition
+      ? {
+          x: configuredIconPosition.x - iconOffset.dx,
+          y: configuredIconPosition.y - iconOffset.dy
+        }
+      : null;
     const controlOriginKey = sourceResolution
       ? Object.keys(sourceResolution.config).find((key) =>
           /^rect_control\d+_pos$/.test(key)
@@ -8387,6 +8443,61 @@ export function WatchfaceEditor({
     };
     return (
       <>
+        <section
+          className="wf-selectable-components"
+          aria-labelledby="wf-selectable-components-title"
+        >
+          <div className="wf-selectable-components-heading">
+            <h3 id="wf-selectable-components-title">Selectable components</h3>
+            <span>
+              {previewChoices.length}/{supported.length} on
+            </span>
+          </div>
+          <div className="wf-selectable-component-list">
+            {supported.map((complication) => {
+              const enabled = isControlComplicationEnabled(
+                details,
+                design,
+                complication.id
+              );
+              const imported = hasControlComplication(
+                details,
+                complication.id
+              );
+              return (
+                <label
+                  key={complication.id}
+                  className={`wf-selectable-component${enabled ? " is-enabled" : ""}`}
+                >
+                  <span>
+                    <strong>{complication.label}</strong>
+                    <small>
+                      {enabled
+                        ? imported
+                          ? "Loaded from template"
+                          : "Added on export"
+                        : imported
+                          ? "Disabled"
+                          : "Not in template"}
+                    </small>
+                  </span>
+                  <input
+                    type="checkbox"
+                    role="switch"
+                    checked={enabled}
+                    aria-label={`${enabled ? "Disable" : "Enable"} ${complication.label}`}
+                    onChange={(event) =>
+                      setControlComplicationEnabled(
+                        complication.id,
+                        event.target.checked
+                      )
+                    }
+                  />
+                </label>
+              );
+            })}
+          </div>
+        </section>
         <label className="field">
           Preview data
           <select
@@ -8408,6 +8519,9 @@ export function WatchfaceEditor({
               }));
             }}
           >
+            {previewChoices.length === 0 ? (
+              <option value="">No components enabled</option>
+            ) : null}
             {previewChoices.map((complication) => (
               <option key={complication.id} value={complication.id}>
                 {complication.label}
@@ -8415,32 +8529,8 @@ export function WatchfaceEditor({
             ))}
           </select>
         </label>
-        {(
-          [
-            ["sunrise", "Sunrise", design.controlSunriseEnabled],
-            ["sunset", "Sunset", design.controlSunsetEnabled],
-            ["floors", "Floors", design.controlFloorEnabled],
-            ["temperature", "Temperature", design.controlTemperatureEnabled]
-          ] as const
-        ).map(([complicationId, label, flag]) =>
-          available.some(
-            (complication) => complication.id === complicationId
-          ) ? (
-            <label key={complicationId} className="watchface-studio-toggle">
-              <input
-                type="checkbox"
-                checked={flag !== false}
-                onChange={(event) =>
-                  setControlComplicationEnabled(
-                    complicationId,
-                    event.target.checked
-                  )
-                }
-              />
-              Include {label} in selectable metrics
-            </label>
-          ) : null
-        )}
+        {selectedComplication ? (
+          <>
         {selectedComplication?.valueParts && controlColonReference ? (
           <div className="wf-inline-config-asset">
             <label className="watchface-studio-toggle">
@@ -8621,6 +8711,13 @@ export function WatchfaceEditor({
           control_negative_sign_icon. Move this Selectable metric layer to
           position the control slot on the face.
         </p>
+          </>
+        ) : (
+          <p className="watchface-studio-summary">
+            Turn on a selectable component to add its configuration and edit
+            its value, icon, and position settings.
+          </p>
+        )}
       </>
     );
   }

--- a/src/watchfaces/WatchfaceEditor.tsx
+++ b/src/watchfaces/WatchfaceEditor.tsx
@@ -88,6 +88,7 @@ import {
   RotateCcw,
   Save,
   Send,
+  SlidersHorizontal,
   SunMedium,
   Square,
   Trash2,
@@ -5829,14 +5830,26 @@ export function WatchfaceEditor({
       <div className="watchface-editor-grid wf-studio-grid">
         <aside className={`watchface-editor-layers wf-pane wf-layers-pane${layersOpen ? " is-open" : ""}`} aria-label="Layers">
           <div className="watchface-editor-pane-heading wf-pane-heading">
-            <div>
+            <div className="wf-pane-heading-main">
+              <span className="wf-pane-heading-icon" aria-hidden="true">
+                <Layers size={14} />
+              </span>
               <p className="watchface-editor-pane-title">Layers</p>
-              <span>
+              <span
+                className="wf-pane-count"
+                aria-label={
+                  previewMode === "aod"
+                    ? supportsAod
+                      ? `${layers.length} always-on assets`
+                      : "Uses the current face"
+                    : `${layers.length + activeBackgroundElements.length} items`
+                }
+              >
                 {previewMode === "aod"
                   ? supportsAod
-                    ? `${layers.length} always-on assets`
-                    : "Uses the current face"
-                  : `${layers.length + activeBackgroundElements.length} items`}
+                    ? layers.length
+                    : "Current"
+                  : layers.length + activeBackgroundElements.length}
               </span>
             </div>
             {canEditActiveMode ? <div className="wf-add-menu">
@@ -6483,10 +6496,18 @@ export function WatchfaceEditor({
           onPointerCancel={endDesignTransaction}
         >
           <div className="wf-pane-heading">
-            <div>
+            <div className="wf-pane-heading-main">
+              <span className="wf-pane-heading-icon" aria-hidden="true">
+                <SlidersHorizontal size={14} />
+              </span>
               <p className="watchface-editor-pane-title">Properties</p>
-              <strong>{selectedElement ? backgroundElementLabel(selectedElement) : selectedLayer?.label ?? "Inspector"}</strong>
             </div>
+            <strong
+              className="wf-pane-context"
+              title={selectedElement ? backgroundElementLabel(selectedElement) : selectedLayer?.label ?? "Inspector"}
+            >
+              {selectedElement ? backgroundElementLabel(selectedElement) : selectedLayer?.label ?? "Inspector"}
+            </strong>
           </div>
           {selectedElement ? renderElementInspector(selectedElement) : selectedLayer ? renderInspector(selectedLayer) : previewMode === "aod" ? (
             <div className="watchface-inspector-group wf-aod-empty-inspector">

--- a/src/watchfaces/watchfaceBackground.ts
+++ b/src/watchfaces/watchfaceBackground.ts
@@ -52,6 +52,7 @@ export function makeDefaultDesign(): CorosWatchfaceDesignState {
     previewComplication: "heartRate",
     metricChanges: {},
     metricStyles: {},
+    controlComplicationEnabled: {},
     controlIconOffsets: {},
     separateAutoTime: false,
     timeStyles: {},

--- a/src/watchfaces/watchfaceCompose.ts
+++ b/src/watchfaces/watchfaceCompose.ts
@@ -35,6 +35,7 @@ import {
   buildTimeStyleOverrides,
   getAmPmCapability,
   isControlComplicationEnabled,
+  loadStudioImage,
   mergeAssetReplacements,
   mergeConfigOverrides,
   pickPreviewResolution,
@@ -79,6 +80,41 @@ export interface WatchfaceComposeResult {
    * template announces a high-enough version, so those features raise it to 4.
    */
   minWatchFaceVersion?: number;
+}
+
+/** Builds the flattened authored AOD background at every native resolution. */
+export async function buildAodBackgroundComposition(
+  aodDetails: CorosWatchfaceTemplateDetails,
+  backgroundDataUrl: string
+): Promise<Pick<WatchfaceComposeResult, "assetReplacements" | "configOverrides">> {
+  const image = await loadStudioImage(backgroundDataUrl, false);
+  const assetReplacements: CorosWatchfaceAssetReplacement[] = [];
+  const configOverrides: CorosWatchfaceConfigOverride[] = [];
+  for (const resolution of aodDetails.resolutions) {
+    const canvas = document.createElement("canvas");
+    canvas.width = resolution.width;
+    canvas.height = resolution.height;
+    const context = canvas.getContext("2d", { colorSpace: "display-p3" });
+    if (!context) {
+      throw new Error("Could not render the always-on background.");
+    }
+    context.imageSmoothingEnabled = true;
+    context.imageSmoothingQuality = "high";
+    context.drawImage(image, 0, 0, canvas.width, canvas.height);
+    assetReplacements.push({
+      path: `${resolution.directory}/studio/aod_background/00.png`,
+      dataUrl: canvas.toDataURL("image/png"),
+      create: true,
+      allowDimensionOverride: true
+    });
+    configOverrides.push({
+      path: `${resolution.directory}/AODconfig.txt`,
+      values: {
+        background_icon: "studio\\aod_background\\00.png"
+      }
+    });
+  }
+  return { assetReplacements, configOverrides };
 }
 
 /** Official weather-bearing COROS faces ship this watchface version. */

--- a/src/watchfaces/watchfaceCompose.ts
+++ b/src/watchfaces/watchfaceCompose.ts
@@ -11,8 +11,8 @@ import {
   buildAmPmSpriteReplacements,
   buildControlTemperatureOverrides,
   buildControlTemperatureSpriteReplacements,
-  buildControlBatteryVisibilityOverrides,
-  buildControlComplicationVisibilityOverrides,
+  buildControlComplicationConfigurationOverrides,
+  buildDisabledControlComplicationOverrides,
   buildSelectableMetricSpriteComposition,
   buildSelectableMetricStyleOverrides,
   buildControlIconPositionOverrides,
@@ -34,7 +34,7 @@ import {
   buildTimeTrackingOverrides,
   buildTimeStyleOverrides,
   getAmPmCapability,
-  getAvailableComplications,
+  isControlComplicationEnabled,
   mergeAssetReplacements,
   mergeConfigOverrides,
   pickPreviewResolution,
@@ -306,22 +306,38 @@ export function deriveDesignDetails(
     timeFormatDetails,
     metricOverrides
   );
+  const controlComplicationOverrides =
+    buildControlComplicationConfigurationOverrides(metricDetails, design);
+  const controlMetricDetails = applyConfigOverridesToDetails(
+    metricDetails,
+    controlComplicationOverrides
+  );
   const controlTemperatureStyle = metricStylesOf(design).temperature ?? {
     color: design.digitColor,
     scale: 1
   };
   const controlTemperatureOverrides =
-    design.controlTemperatureEnabled !== false &&
-    getAvailableComplications(metricDetails)
-      .some((item) => item.id === "temperature")
-      ? buildControlTemperatureOverrides(metricDetails, controlTemperatureStyle)
+    isControlComplicationEnabled(details, design, "temperature")
+      ? buildControlTemperatureOverrides(
+          controlMetricDetails,
+          controlTemperatureStyle
+        )
       : [];
   const selectableMetricDetails = applyConfigOverridesToDetails(
-    metricDetails,
+    controlMetricDetails,
     controlTemperatureOverrides
+  );
+  const selectableAssetOverrides = buildWatchfaceConfigAssetOverrides(
+    selectableMetricDetails,
+    design.configAssetOverrides ?? {}
+  );
+  const selectableAssetDetails = applyConfigOverridesToDetails(
+    selectableMetricDetails,
+    selectableAssetOverrides
   );
   const componentStyleOverrides = mergeConfigOverrides(
     buildMetricStyleOverrides(metricDetails, metricStylesOf(design)),
+    controlComplicationOverrides,
     controlTemperatureOverrides,
     design.selectableMetricStyle
       ? buildSelectableMetricStyleOverrides(
@@ -332,15 +348,19 @@ export function deriveDesignDetails(
     buildTimeStyleOverrides(metricDetails, timeStylesOf(design)),
     buildDateStyleOverrides(metricDetails, dateStylesOf(design)),
     buildLayerColorOverrides(metricDetails, design.layerColors ?? {}),
-    buildControlIconPositionOverrides(metricDetails, design.controlIconOffsets ?? {}),
+    // A synthesized icon must establish its base path/position before the
+    // user's per-component movement is applied. Reversing these two entries
+    // makes the generated fallback position overwrite every drag.
+    selectableAssetOverrides,
+    buildControlIconPositionOverrides(
+      selectableAssetDetails,
+      design.controlIconOffsets ?? {}
+    ),
     buildStaticSeparatorOverrides(details, design.staticSeparators),
-    buildWatchfaceConfigAssetOverrides(
-      details,
-      design.configAssetOverrides ?? {}
-    )
+    buildDisabledControlComplicationOverrides(details, design)
   );
   const styledMetricDetails = applyConfigOverridesToDetails(
-    metricDetails,
+    controlMetricDetails,
     componentStyleOverrides
   );
   const laidOutDetails = applyLayoutToDetails(
@@ -350,12 +370,7 @@ export function deriveDesignDetails(
   const previewDetails = applyConfigOverridesToDetails(
     laidOutDetails,
     mergeConfigOverrides(
-      buildLayerVisibilityOverrides(laidOutDetails, design.layerVisibility ?? {}),
-      buildControlBatteryVisibilityOverrides(
-        laidOutDetails,
-        design.controlBatteryEnabled
-      ),
-      buildControlComplicationVisibilityOverrides(laidOutDetails, design)
+      buildLayerVisibilityOverrides(laidOutDetails, design.layerVisibility ?? {})
     )
   );
   return {
@@ -449,11 +464,11 @@ export async function composeWatchfaceReplacements(
   const ampmSupported = Boolean(getAmPmCapability(details) && ampmStyle);
   const ampmActive = Boolean(ampmSupported && ampmStyle?.enabled);
   const weatherStyle = design.weatherIndicator;
-  const controlTemperatureActive =
-    design.controlTemperatureEnabled !== false &&
-    getAvailableComplications(details).some(
-      (item) => item.id === "temperature"
-    );
+  const controlTemperatureActive = isControlComplicationEnabled(
+    details,
+    design,
+    "temperature"
+  );
   const controlTemperatureStyle = metricStyles.temperature ?? {
     color: design.digitColor,
     scale: 1
@@ -465,16 +480,30 @@ export async function composeWatchfaceReplacements(
     rasterFontSupportsText(controlTemperatureStyle.rasterFont, "0123456789") ||
     controlTemperatureStyle.scale !== 1
   );
+  const controlComplicationOverrides =
+    buildControlComplicationConfigurationOverrides(metricDetails, design);
+  const controlMetricDetails = applyConfigOverridesToDetails(
+    metricDetails,
+    controlComplicationOverrides
+  );
   const exportedControlTemperatureOverrides = controlTemperatureActive
     ? buildControlTemperatureOverrides(
-        metricDetails,
+        controlMetricDetails,
         controlTemperatureStyle,
         controlTemperatureRasterActive
       )
     : [];
   const selectableConfigDetails = applyConfigOverridesToDetails(
-    metricDetails,
+    controlMetricDetails,
     exportedControlTemperatureOverrides
+  );
+  const selectableAssetOverrides = buildWatchfaceConfigAssetOverrides(
+    selectableConfigDetails,
+    design.configAssetOverrides ?? {}
+  );
+  const selectableAssetDetails = applyConfigOverridesToDetails(
+    selectableConfigDetails,
+    selectableAssetOverrides
   );
   const batteryIconEffectSources = await buildBatteryIconEffectSources(
     details,
@@ -517,7 +546,7 @@ export async function composeWatchfaceReplacements(
       : [],
     controlTemperatureActive && controlTemperatureRasterActive
       ? await buildControlTemperatureSpriteReplacements(
-          metricDetails,
+          controlMetricDetails,
           controlTemperatureStyle,
           design.fontFamily,
           loadAssets,
@@ -598,6 +627,7 @@ export async function composeWatchfaceReplacements(
     mergeConfigOverrides(
       metricOverrides,
       timeFormatOverrides,
+      controlComplicationOverrides,
       metricStyleActive ? buildMetricStyleOverrides(metricDetails, metricStyles, true) : [],
       exportedControlTemperatureOverrides,
       selectableMetricStyleActive
@@ -611,7 +641,13 @@ export async function composeWatchfaceReplacements(
       dateStyleActive ? buildDateStyleOverrides(details, dateStyles, true) : [],
       timeTrackingOverrides,
       buildLayerColorOverrides(details, design.layerColors ?? {}),
-      buildControlIconPositionOverrides(details, design.controlIconOffsets ?? {}),
+      // Preserve the generated path and base position for selectable icons
+      // that were not present in the imported template.
+      selectableAssetOverrides,
+      buildControlIconPositionOverrides(
+        selectableAssetDetails,
+        design.controlIconOffsets ?? {}
+      ),
       buildStaticSeparatorOverrides(details, design.staticSeparators),
       ampmSupported ? buildAmPmOverrides(details, ampmStyle!) : [],
       weatherStyle ? buildWeatherOverrides(details, weatherStyle) : [],
@@ -624,14 +660,13 @@ export async function composeWatchfaceReplacements(
       selectableMetricComposition.configOverrides,
       buildEffectPaddingOverrides(configAssetPositionDetails, effectedAssets.padding),
       buildLayerVisibilityOverrides(details, design.layerVisibility ?? {}),
-      buildControlBatteryVisibilityOverrides(details, design.controlBatteryEnabled),
-      buildControlComplicationVisibilityOverrides(details, design),
       batteryIconEffectSources.configOverrides,
       buildWatchfaceConfigAssetOverrides(
         configAssetPositionDetails,
         design.configAssetOverrides ?? {},
         true
-      )
+      ),
+      buildDisabledControlComplicationOverrides(details, design)
     )
   );
 

--- a/src/watchfaces/watchfaceDisplayModes.ts
+++ b/src/watchfaces/watchfaceDisplayModes.ts
@@ -1,0 +1,266 @@
+import type {
+  CorosWatchfaceArtwork,
+  CorosWatchfaceDesignState,
+  CorosWatchfaceModeDesignState
+} from "../../electron/types";
+import {
+  AOD_DIM_FACTOR,
+  dimHexColor,
+  type WatchfacePreviewMode
+} from "./watchfaceStudio.ts";
+
+const DEFAULT_STATIC_SEPARATORS = {
+  colon: { enabled: false, x: 400, y: 320, size: 64, color: "#ffffff" },
+  dateSlash: { enabled: false, x: 400, y: 240, size: 48, color: "#ffffff" }
+};
+const DEFAULT_AMPM_STYLE = {
+  enabled: false,
+  x: 480,
+  y: 360,
+  scale: 1
+};
+
+function makeModeDefaultDesign(): CorosWatchfaceDesignState {
+  return {
+    version: 1,
+    backgroundColor: "#000000",
+    accentColor: "#51e0b5",
+    artwork: null,
+    artworkVisible: true,
+    zoom: 1,
+    fontFamily: "",
+    fontWeight: 400,
+    fontStyle: "normal",
+    letterSpacing: 0,
+    digitColor: "#ffffff",
+    tintLabels: false,
+    tintIcons: false,
+    previewComplication: "",
+    metricChanges: {},
+    metricStyles: {},
+    controlComplicationEnabled: {},
+    controlIconOffsets: {},
+    separateAutoTime: false,
+    timeStyles: {},
+    dateStyles: {},
+    staticSeparators: {
+      colon: { ...DEFAULT_STATIC_SEPARATORS.colon },
+      dateSlash: { ...DEFAULT_STATIC_SEPARATORS.dateSlash }
+    },
+    ampmIndicator: { ...DEFAULT_AMPM_STYLE },
+    layoutOffsets: {},
+    linkedLayerGroups: [],
+    editorGroups: [],
+    editorGuides: [],
+    lockedLayerIds: [],
+    effectStyles: [],
+    layerEffects: {},
+    layerVisibility: {},
+    layerColors: {},
+    configAssetOverrides: {},
+    designSprites: [],
+    artworkLayerOrder: [],
+    backgroundElements: []
+  };
+}
+
+const MODE_DESIGN_KEYS = [
+  "backgroundColor",
+  "accentColor",
+  "artwork",
+  "artworkVisible",
+  "zoom",
+  "fontFamily",
+  "rasterFont",
+  "fontWeight",
+  "fontStyle",
+  "letterSpacing",
+  "digitColor",
+  "tintLabels",
+  "tintIcons",
+  "previewComplication",
+  "metricChanges",
+  "metricStyles",
+  "selectableMetricStyle",
+  "controlComplicationEnabled",
+  "controlIconOffsets",
+  "separateAutoTime",
+  "timeStyles",
+  "dateStyles",
+  "staticSeparators",
+  "ampmIndicator",
+  "weatherIndicator",
+  "layoutOffsets",
+  "linkedLayerGroups",
+  "editorGroups",
+  "editorGuides",
+  "lockedLayerIds",
+  "effectStyles",
+  "layerEffects",
+  "layerVisibility",
+  "layerColors",
+  "configAssetOverrides",
+  "designSprites",
+  "artworkLayerOrder",
+  "backgroundElements"
+] as const satisfies ReadonlyArray<keyof CorosWatchfaceModeDesignState>;
+
+function scopedRecord<T>(
+  record: Record<string, T> | undefined,
+  prefix: string
+): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(record ?? {}).flatMap(([key, value]) =>
+      key.startsWith(prefix) ? [[key.slice(prefix.length), value]] : []
+    )
+  );
+}
+
+function dimStyleRecord<T extends { color?: string }>(
+  record: Record<string, T> | undefined
+): Record<string, T> {
+  return Object.fromEntries(
+    Object.entries(record ?? {}).map(([key, style]) => [
+      key,
+      style.color
+        ? { ...style, color: dimHexColor(style.color, AOD_DIM_FACTOR) }
+        : { ...style }
+    ])
+  );
+}
+
+/** Produces the legacy auto-dimmed AOD appearance as independent mode state. */
+export function materializeLegacyAodDesign(
+  design: CorosWatchfaceDesignState,
+  artwork: CorosWatchfaceArtwork | null,
+  backgroundColor = "#000000"
+): CorosWatchfaceModeDesignState {
+  const configAssetOverrides = Object.fromEntries(
+    Object.entries(design.configAssetOverrides ?? {}).flatMap(([key, value]) =>
+      key.startsWith("aod:")
+        ? [[`config:${key.slice("aod:".length)}`, value]]
+        : []
+    )
+  );
+  const layerEffects = scopedRecord(design.layerEffects, "aod:");
+  return {
+    backgroundColor,
+    accentColor: dimHexColor(design.accentColor, AOD_DIM_FACTOR),
+    artwork,
+    artworkVisible:
+      configAssetOverrides["config:background_icon"]?.enabled !== false,
+    zoom: 1,
+    fontFamily: design.fontFamily,
+    rasterFont: design.rasterFont,
+    fontWeight: design.fontWeight,
+    fontStyle: design.fontStyle,
+    letterSpacing: design.letterSpacing,
+    digitColor: dimHexColor(design.digitColor, AOD_DIM_FACTOR),
+    tintLabels: design.tintLabels,
+    tintIcons: design.tintIcons,
+    previewComplication: "",
+    metricChanges: {},
+    metricStyles: dimStyleRecord(design.metricStyles),
+    controlComplicationEnabled: {},
+    controlIconOffsets: {},
+    separateAutoTime: false,
+    timeStyles: dimStyleRecord(design.timeStyles),
+    dateStyles: dimStyleRecord(design.dateStyles),
+    staticSeparators: {
+      colon: { ...DEFAULT_STATIC_SEPARATORS.colon },
+      dateSlash: { ...DEFAULT_STATIC_SEPARATORS.dateSlash }
+    },
+    ampmIndicator: { ...DEFAULT_AMPM_STYLE, enabled: false },
+    weatherIndicator: undefined,
+    layoutOffsets: {},
+    linkedLayerGroups: [],
+    editorGroups: [],
+    editorGuides: [],
+    lockedLayerIds: [],
+    effectStyles: [...(design.effectStyles ?? [])],
+    layerEffects,
+    layerVisibility: {},
+    layerColors: Object.fromEntries(
+      Object.entries(design.layerColors ?? {}).map(([key, color]) => [
+        key,
+        dimHexColor(color, AOD_DIM_FACTOR)
+      ])
+    ),
+    configAssetOverrides,
+    designSprites: [],
+    artworkLayerOrder: [],
+    backgroundElements: []
+  };
+}
+
+export function resolveWatchfaceModeDesign(
+  design: CorosWatchfaceDesignState,
+  mode: WatchfacePreviewMode
+): CorosWatchfaceDesignState {
+  if (mode === "current" || !design.modeDesigns?.aod) return design;
+  const defaults = makeModeDefaultDesign();
+  return {
+    ...defaults,
+    ...design.modeDesigns.aod,
+    version: 1,
+    archiveWatchFaceVersion: design.archiveWatchFaceVersion,
+    stripBlankConfigKeys: design.stripBlankConfigKeys,
+    configTextEdits: design.configTextEdits,
+    modeDesigns: design.modeDesigns
+  };
+}
+
+/**
+ * Writes an active mode design back into the project while keeping archive
+ * settings and raw config edits global.
+ */
+export function writeWatchfaceModeDesign(
+  root: CorosWatchfaceDesignState,
+  mode: WatchfacePreviewMode,
+  active: CorosWatchfaceDesignState
+): CorosWatchfaceDesignState {
+  const global = {
+    archiveWatchFaceVersion: active.archiveWatchFaceVersion,
+    stripBlankConfigKeys: active.stripBlankConfigKeys,
+    configTextEdits: active.configTextEdits
+  };
+  if (mode === "current") {
+    return {
+      ...active,
+      ...global,
+      modeDesigns: root.modeDesigns
+    };
+  }
+  const previous = resolveWatchfaceModeDesign(root, "aod");
+  const backgroundKeys = [
+    "backgroundColor",
+    "artwork",
+    "artworkVisible",
+    "zoom",
+    "staticSeparators",
+    "designSprites",
+    "artworkLayerOrder",
+    "backgroundElements"
+  ] as const;
+  const backgroundEdited =
+    root.modeDesigns?.aod?.backgroundEdited === true ||
+    backgroundKeys.some(
+      (key) =>
+        JSON.stringify(previous[key]) !== JSON.stringify(active[key])
+    );
+  const aod: CorosWatchfaceModeDesignState = {};
+  for (const key of MODE_DESIGN_KEYS) {
+    (aod as Record<string, unknown>)[key] = active[key];
+  }
+  return {
+    ...root,
+    ...global,
+    modeDesigns: {
+      ...(root.modeDesigns ?? {}),
+      aod: {
+        ...aod,
+        ...(backgroundEdited ? { backgroundEdited: true } : {})
+      }
+    }
+  };
+}

--- a/src/watchfaces/watchfaceEditorModel.ts
+++ b/src/watchfaces/watchfaceEditorModel.ts
@@ -17,7 +17,6 @@ import {
   getWatchfaceControlStatusPreviewLayers,
   hasControlBattery,
   isControlComplicationEnabled,
-  listWatchfaceConfigAssets,
   pickPreviewResolution,
   WATCHFACE_COMPLICATIONS,
   WATCHFACE_LAYOUT_GROUPS,
@@ -30,6 +29,10 @@ import { deriveDesignDetails } from "./watchfaceCompose";
 import { getWeatherCapability } from "./weatherAssets";
 import { rotatedCenterBounds } from "./watchfaceEditorGeometry";
 import { watchfaceDesignSpriteName } from "./watchfaceSpriteTransform";
+import {
+  listWatchfaceEditorConfigAssets,
+  watchfaceEditorControlBatteryIsListed
+} from "./watchfaceEditorVisibility";
 
 export { editorLayerAtPoint } from "./watchfaceEditorGeometry";
 
@@ -387,10 +390,12 @@ export function deriveEditorLayers(
     }
 
     if (groupId === "controlBatteryIcon") {
-      if (
-        !hasControlBattery(details) &&
-        !isControlComplicationEnabled(details, design, "battery")
-      ) {
+      if (!watchfaceEditorControlBatteryIsListed(
+        hasControlBattery(details),
+        isControlComplicationEnabled(details, design, "battery"),
+        design.controlComplicationEnabled?.battery,
+        design.controlBatteryEnabled
+      )) {
         continue;
       }
       layers.push({
@@ -558,9 +563,9 @@ export function deriveEditorLayers(
         isControlComplicationEnabled(details, design, complication.id)
     )
     .map((complication) => complication.id);
-  for (const reference of listWatchfaceConfigAssets(
+  for (const reference of listWatchfaceEditorConfigAssets(
+    details,
     offsetDetails,
-    undefined,
     enabledControlIcons
   )) {
     // The current-face background_icon is the source behind the editable

--- a/src/watchfaces/watchfaceEditorModel.ts
+++ b/src/watchfaces/watchfaceEditorModel.ts
@@ -7,8 +7,6 @@ import {
   applyConfigOverridesToDetails,
   applyLayoutToDetails,
   batteryPreviewStateIndex,
-  buildControlBatteryVisibilityOverrides,
-  buildControlComplicationVisibilityOverrides,
   configAssetCanvasSize,
   controlStatusLayoutGroupId,
   scaledBatterySpriteCanvasSize,
@@ -18,8 +16,10 @@ import {
   getWatchfaceAnalogPreviewLayers,
   getWatchfaceControlStatusPreviewLayers,
   hasControlBattery,
+  isControlComplicationEnabled,
   listWatchfaceConfigAssets,
   pickPreviewResolution,
+  WATCHFACE_COMPLICATIONS,
   WATCHFACE_LAYOUT_GROUPS,
   type WatchfaceLayoutGroupBounds,
   type WatchfaceMetricId,
@@ -276,16 +276,7 @@ export function deriveEditorLayers(
     styledDetails,
     design.layoutOffsets ?? {}
   );
-  const offsetDetails = applyConfigOverridesToDetails(
-    laidOutDetails,
-    [
-      ...buildControlBatteryVisibilityOverrides(
-        laidOutDetails,
-        design.controlBatteryEnabled
-      ),
-      ...buildControlComplicationVisibilityOverrides(laidOutDetails, design)
-    ]
-  );
+  const offsetDetails = laidOutDetails;
   const resolution = pickPreviewResolution(offsetDetails);
   const boundsById = new Map<string, WatchfaceLayoutGroupBounds>();
   if (resolution) {
@@ -393,15 +384,17 @@ export function deriveEditorLayers(
     }
 
     if (groupId === "controlBatteryIcon") {
-      if (!hasControlBattery(details)) {
+      if (
+        !hasControlBattery(details) &&
+        !isControlComplicationEnabled(details, design, "battery")
+      ) {
         continue;
       }
       layers.push({
         id: groupId,
         kind: "controlBatteryIcon",
         label: "Control battery icon",
-        visible:
-          design.controlBatteryEnabled ?? hasControlBattery(details),
+        visible: isControlComplicationEnabled(details, design, "battery"),
         canHide: true,
         present: true,
         bounds: null,
@@ -555,7 +548,18 @@ export function deriveEditorLayers(
     });
   }
 
-  for (const reference of listWatchfaceConfigAssets(details)) {
+  const enabledControlIcons = WATCHFACE_COMPLICATIONS
+    .filter(
+      (complication) =>
+        complication.id !== "battery" &&
+        isControlComplicationEnabled(details, design, complication.id)
+    )
+    .map((complication) => complication.id);
+  for (const reference of listWatchfaceConfigAssets(
+    offsetDetails,
+    undefined,
+    enabledControlIcons
+  )) {
     // The current-face background_icon is the source behind the editable
     // Artwork → Background layer below. Exposing it again as a template asset
     // creates two controls for the same on-watch image. Keep AOD background

--- a/src/watchfaces/watchfaceEditorModel.ts
+++ b/src/watchfaces/watchfaceEditorModel.ts
@@ -280,7 +280,10 @@ export function deriveEditorLayers(
   const resolution = pickPreviewResolution(offsetDetails);
   const boundsById = new Map<string, WatchfaceLayoutGroupBounds>();
   if (resolution) {
-    for (const box of computeLayoutGroupBounds(resolution)) {
+    for (const box of computeLayoutGroupBounds(resolution, {
+      timeStyles: design.timeStyles,
+      letterSpacing: design.letterSpacing
+    })) {
       if (box.id === "batteryIcon") {
         const batteryOverride = design.configAssetOverrides?.["config:battery_icon"];
         const batteryScale = batteryOverride?.scale ?? 1;

--- a/src/watchfaces/watchfaceEditorVisibility.ts
+++ b/src/watchfaces/watchfaceEditorVisibility.ts
@@ -1,0 +1,92 @@
+import type {
+  CorosWatchfaceDesignState,
+  CorosWatchfaceTemplateDetails
+} from "../../electron/types";
+import {
+  listWatchfaceConfigAssets,
+  WATCHFACE_COMPLICATIONS,
+  type WatchfaceConfigAssetReference,
+  type WatchfacePreviewMode
+} from "./watchfaceStudio.ts";
+
+interface WatchfacePanelLayer {
+  kind: string;
+  present: boolean;
+  layoutGroupId?: string;
+  metricId?: string;
+  configAssetId?: string;
+}
+
+/**
+ * Returns every config-backed asset the Layers panel must keep addressable.
+ * Rendered details provide live geometry and replacement paths; source details
+ * retain references deleted from the config when an asset is hidden.
+ */
+export function listWatchfaceEditorConfigAssets(
+  sourceDetails: CorosWatchfaceTemplateDetails,
+  renderedDetails: CorosWatchfaceTemplateDetails,
+  virtualControlIcons: ReadonlyArray<
+    (typeof WATCHFACE_COMPLICATIONS)[number]["id"]
+  > = []
+): WatchfaceConfigAssetReference[] {
+  const byId = new Map(
+    listWatchfaceConfigAssets(sourceDetails, undefined, virtualControlIcons)
+      .map((reference) => [reference.id, reference])
+  );
+  for (const reference of listWatchfaceConfigAssets(
+    renderedDetails,
+    undefined,
+    virtualControlIcons
+  )) {
+    byId.set(reference.id, reference);
+  }
+  return [...byId.values()];
+}
+
+/** Whether a derived layer remains recoverable from the Layers panel. */
+export function watchfaceEditorLayerIsListed(
+  layer: WatchfacePanelLayer,
+  previewMode: WatchfacePreviewMode,
+  design: CorosWatchfaceDesignState
+): boolean {
+  if (
+    previewMode === "current" ||
+    layer.present ||
+    layer.kind === "background" ||
+    layer.kind === "backgroundElement" ||
+    layer.kind === "customSprite"
+  ) {
+    return true;
+  }
+  if (
+    layer.metricId &&
+    design.metricChanges?.[layer.metricId] === false
+  ) {
+    return true;
+  }
+  if (
+    layer.configAssetId &&
+    design.configAssetOverrides?.[layer.configAssetId]?.enabled === false
+  ) {
+    return true;
+  }
+  return Boolean(
+    layer.layoutGroupId &&
+    design.layerVisibility?.[layer.layoutGroupId] === false
+  );
+}
+
+/** Retains an editor-added selectable battery after it has been switched off. */
+export function watchfaceEditorControlBatteryIsListed(
+  templateHasBattery: boolean,
+  enabled: boolean,
+  configured: boolean | undefined,
+  legacyConfigured: boolean | undefined
+): boolean {
+  return (
+    templateHasBattery ||
+    enabled ||
+    configured !== undefined ||
+    legacyConfigured !== undefined
+  );
+}

--- a/src/watchfaces/watchfaceStudio.ts
+++ b/src/watchfaces/watchfaceStudio.ts
@@ -43,6 +43,11 @@ export interface WatchfaceStudioOptions extends WatchfaceTypography {
   tintIcons: boolean;
   /** Changes only the studio preview; the watch rotates the control slot. */
   previewComplication?: WatchfaceComplicationId;
+  /**
+   * Editor-only isolation used while independently dragging a selectable
+   * control icon. Normal previews render both the icon and its value.
+   */
+  previewComplicationContent?: "all" | "icon";
   /** Per-fixed-metric bitmap styles, isolated into their own sprite folders. */
   metricStyles?: WatchfaceMetricStyles;
   /** Shared bitmap style for values shown in the selectable control slot. */
@@ -6377,7 +6382,11 @@ export async function drawStudioPreview(
       }
     }
   }
-  if (complication && complicationSource) {
+  if (
+    complication &&
+    complicationSource &&
+    options.previewComplicationContent !== "icon"
+  ) {
     for (const part of relativeComplicationRects) {
       numberPlans.push({
         rect: {
@@ -6900,6 +6909,12 @@ export async function drawStudioPreview(
   }
 
   for (const layer of controlStatusLayers) {
+    if (
+      options.previewComplicationContent === "icon" &&
+      layer.controlRelative
+    ) {
+      continue;
+    }
     const image = await configuredAssetImage(
       layer.configKey,
       layer.source,
@@ -7266,7 +7281,11 @@ export async function drawStudioPreview(
     }
   }
 
-  if (controlColonFile && relativeComplicationRects.length > 1) {
+  if (
+    options.previewComplicationContent !== "icon" &&
+    controlColonFile &&
+    relativeComplicationRects.length > 1
+  ) {
     const first = relativeComplicationRects[0]!.rect;
     const second = relativeComplicationRects[1]!.rect;
     const image = await configuredAssetImage(

--- a/src/watchfaces/watchfaceStudio.ts
+++ b/src/watchfaces/watchfaceStudio.ts
@@ -288,7 +288,8 @@ function pngConfigEntries(
 /** Every direct PNG reference in config.txt and AODconfig.txt. */
 export function listWatchfaceConfigAssets(
   details: CorosWatchfaceTemplateDetails,
-  resolutionDirectory?: string
+  resolutionDirectory?: string,
+  virtualControlIcons: ReadonlyArray<WatchfaceComplicationId> = []
 ): WatchfaceConfigAssetReference[] {
   const selectedResolution = resolutionDirectory
     ? details.resolutions.find((candidate) => candidate.directory === resolutionDirectory)
@@ -324,6 +325,27 @@ export function listWatchfaceConfigAssets(
         });
       }
     }
+  }
+  for (const complicationId of virtualControlIcons) {
+    if (complicationId === "battery") continue;
+    const complication = WATCHFACE_COMPLICATIONS.find(
+      (candidate) => candidate.id === complicationId
+    );
+    if (!complication) continue;
+    const configKey = `control_${complication.controlPrefix}_icon`;
+    const id = watchfaceConfigAssetId("config", configKey);
+    if (byId.has(id)) continue;
+    const relativePath = configAssetCreatedRelativePath(id);
+    byId.set(id, {
+      id,
+      scope: "config",
+      configKey,
+      configPath: `${selectedResolution.directory}/config.txt`,
+      label: configAssetLabel(configKey, "config"),
+      relativePath,
+      archivePath: `${selectedResolution.directory}/${relativePath}`,
+      source: null
+    });
   }
   const references = [...byId.values()];
   return references.sort((left, right) =>
@@ -599,6 +621,39 @@ export function configAssetCanvasSize(
   };
 }
 
+/**
+ * A synthesized selectable has no source PNG to define its firmware canvas.
+ * Reuse the template's first positioned control icon so arbitrary imported
+ * artwork is fitted to the same predictable slot instead of being interpreted
+ * as full-size watch pixels.
+ */
+export function virtualControlIconCanvasSize(
+  resolution: CorosWatchfaceResolutionDetails
+): { width: number; height: number } {
+  for (const [configKey, rawPath] of Object.entries(resolution.config)) {
+    if (
+      !/^control_[a-z0-9_]+_icon$/.test(configKey) ||
+      !parseConfigPos(resolution.config[`${configKey}_pos`])
+    ) {
+      continue;
+    }
+    const path = `${resolution.directory}/${rawPath.replace(/\\/g, "/")}`;
+    const source = resolution.icons.find((icon) => icon.path === path);
+    if (source) {
+      return { width: source.width, height: source.height };
+    }
+  }
+  const rect = firstControlRect(resolution.config);
+  const parsed = rect ? parseConfigRect(rect) : null;
+  const size = Math.max(
+    1,
+    parsed
+      ? parsed.y1 - parsed.y0
+      : Math.round(Math.min(resolution.width, resolution.height) * 0.07)
+  );
+  return { width: size, height: size };
+}
+
 function replaceConfigAssetInPlace(configKey: string): boolean {
   return configAssetSupportsNativeSize(configKey);
 }
@@ -659,7 +714,24 @@ export function buildWatchfaceConfigAssetOverrides(
   for (const resolution of details.resolutions) {
     for (const scope of ["config", "aod"] as const) {
       const values: Record<string, string> = {};
-      for (const [configKey] of pngConfigEntries(resolution, scope)) {
+      const scopedConfig = scope === "aod"
+        ? resolution.aodConfig
+        : resolution.config;
+      const entries = pngConfigEntries(resolution, scope);
+      if (scope === "config") {
+        for (const complication of WATCHFACE_COMPLICATIONS) {
+          if (complication.id === "battery") continue;
+          const configKey = `control_${complication.controlPrefix}_icon`;
+          const id = watchfaceConfigAssetId(scope, configKey);
+          if (
+            overrides[id]?.replacement &&
+            !entries.some(([candidate]) => candidate === configKey)
+          ) {
+            entries.push([configKey, configAssetCreatedRelativePath(id)]);
+          }
+        }
+      }
+      for (const [configKey] of entries) {
         // The current background is always a composed Studio PNG written back
         // to the template's original path. Artwork visibility is handled while
         // composing that PNG, never by clearing or repointing this config key.
@@ -680,6 +752,8 @@ export function buildWatchfaceConfigAssetOverrides(
             ? currentAnalogOverride
             : undefined);
         if (!override) continue;
+        const virtual =
+          !Object.prototype.hasOwnProperty.call(scopedConfig, configKey);
         if (override.enabled === false) {
           // A disabled direct asset must not leave a blank declaration behind:
           // COROS can treat key presence itself as feature presence. Delete the
@@ -687,16 +761,23 @@ export function buildWatchfaceConfigAssetOverrides(
           // absent from the exported watch face.
           values[configKey] = COROS_CONFIG_DELETE_VALUE;
         } else if (
-          includeReplacementPaths &&
+          (includeReplacementPaths || virtual) &&
           override.replacement &&
-          !replaceConfigAssetInPlace(configKey)
+          (virtual || !replaceConfigAssetInPlace(configKey))
         ) {
           values[configKey] = configAssetCreatedRelativePath(id).replace(/\//g, "\\");
+          if (virtual && configKey.startsWith("control_")) {
+            const positionKey = `${configKey}_pos`;
+            if (!parseConfigPos(scopedConfig[positionKey])) {
+              values[positionKey] = fallbackControlIconPosition(
+                scopedConfig,
+                firstControlRect(scopedConfig) ??
+                  `{0,0,${Math.max(1, override.replacement.width)},${Math.max(1, override.replacement.height)},hcenter|vcenter}`
+              );
+            }
+          }
         }
       }
-      const scopedConfig = scope === "aod"
-        ? resolution.aodConfig
-        : resolution.config;
       if (
         hasCustomControlBattery &&
         controlBatteryOverride?.enabled !== false &&
@@ -782,6 +863,27 @@ export function buildWatchfaceConfigAssetOverrides(
   return result;
 }
 
+/**
+ * Final archive-boundary safeguard for direct asset visibility. This repeats
+ * only deletion sentinels; replaying enabled virtual assets here would restore
+ * their pre-layout fallback positions after movement/origin rebasing.
+ */
+export function buildDisabledWatchfaceConfigAssetOverrides(
+  details: CorosWatchfaceTemplateDetails,
+  overrides: Record<string, CorosWatchfaceConfigAssetOverride> = {}
+): CorosWatchfaceConfigOverride[] {
+  return buildWatchfaceConfigAssetOverrides(details, overrides)
+    .map(({ path, values }) => ({
+      path,
+      values: Object.fromEntries(
+        Object.entries(values).filter(
+          ([, value]) => value === COROS_CONFIG_DELETE_VALUE
+        )
+      )
+    }))
+    .filter(({ values }) => Object.keys(values).length > 0);
+}
+
 /** Builds native-sized created PNGs for every customized config reference. */
 export async function buildWatchfaceConfigAssetReplacements(
   details: CorosWatchfaceTemplateDetails,
@@ -792,7 +894,21 @@ export async function buildWatchfaceConfigAssetReplacements(
   for (const resolution of details.resolutions) {
     const nativeScale = masterWidth ? resolution.width / masterWidth : 1;
     for (const scope of ["config", "aod"] as const) {
-      for (const [configKey, rawPath] of pngConfigEntries(resolution, scope)) {
+      const entries = pngConfigEntries(resolution, scope);
+      if (scope === "config") {
+        for (const complication of WATCHFACE_COMPLICATIONS) {
+          if (complication.id === "battery") continue;
+          const configKey = `control_${complication.controlPrefix}_icon`;
+          const id = watchfaceConfigAssetId(scope, configKey);
+          if (
+            overrides[id]?.replacement &&
+            !entries.some(([candidate]) => candidate === configKey)
+          ) {
+            entries.push([configKey, configAssetCreatedRelativePath(id)]);
+          }
+        }
+      }
+      for (const [configKey, rawPath] of entries) {
         const id = watchfaceConfigAssetId(scope, configKey);
         const override = overrides[id];
         if (!override?.replacement || override.enabled === false) continue;
@@ -801,13 +917,20 @@ export async function buildWatchfaceConfigAssetReplacements(
         const source = resolution.icons.find(
           (file) => file.path === `${resolution.directory}/${relativePath}`
         );
+        const virtual = !source && configKey.startsWith("control_");
+        const effectiveOverride = virtual
+          ? { ...override, nativeSize: false }
+          : override;
+        const virtualCanvas = virtual
+          ? virtualControlIconCanvasSize(resolution)
+          : null;
         const canvasSize = configAssetCanvasSize(
           configKey,
-          override,
+          effectiveOverride,
           {
-            width: source?.width ??
+            width: source?.width ?? virtualCanvas?.width ??
               Math.max(1, Math.round(override.replacement.width * nativeScale)),
-            height: source?.height ??
+            height: source?.height ?? virtualCanvas?.height ??
               Math.max(1, Math.round(override.replacement.height * nativeScale))
           },
           nativeScale
@@ -2576,7 +2699,7 @@ interface WatchfaceFixedMetricDefinition {
   center: { x: number; y: number };
 }
 
-interface WatchfaceComplicationDefinition {
+export interface WatchfaceComplicationDefinition {
   id: WatchfaceComplicationId;
   label: string;
   controlPrefix: string;
@@ -2821,7 +2944,44 @@ export function getFixedMetricCapabilities(
   });
 }
 
-/** Complication choices implemented by the template's control slot. */
+function complicationRectKeys(
+  complication: WatchfaceComplicationDefinition
+): string[] {
+  if (complication.id === "battery") {
+    return ["control_battery_level_rect"];
+  }
+  return complication.valueParts
+    ? complication.valueParts.map(
+        ({ rectSuffix }) =>
+          `control_${complication.controlPrefix}_${rectSuffix}_rect`
+      )
+    : [`control_${complication.controlPrefix}_rect`];
+}
+
+function complicationFontKey(
+  complication: WatchfaceComplicationDefinition
+): string {
+  return complication.id === "battery"
+    ? "control_battery_level_font"
+    : `control_${complication.controlPrefix}_font`;
+}
+
+function resolutionHasControlComplication(
+  resolution: CorosWatchfaceResolutionDetails,
+  complication: WatchfaceComplicationDefinition
+): boolean {
+  return (
+    Object.keys(resolution.config).some((key) =>
+      /^rect_control\d+_pos$/.test(key)
+    ) &&
+    complicationRectKeys(complication).every(
+      (key) => parseConfigRect(resolution.config[key]) !== null
+    ) &&
+    Boolean(resolution.config[complicationFontKey(complication)])
+  );
+}
+
+/** Complication choices currently implemented by the effective config. */
 export function getAvailableComplications(
   details: CorosWatchfaceTemplateDetails
 ): WatchfaceComplicationDefinition[] {
@@ -2829,41 +2989,86 @@ export function getAvailableComplications(
   if (!resolution) {
     return [];
   }
-  const hasControlSlot = Object.keys(resolution.config).some((key) =>
-    /^rect_control\d+_pos$/.test(key)
-  );
-  return WATCHFACE_COMPLICATIONS.filter((complication) =>
-    complication.id === "temperature" || complication.id === "battery"
-      ? hasControlSlot
-      : Boolean(
-          (complication.valueParts
-            ? complication.valueParts.every(({ rectSuffix }) =>
-                parseConfigRect(
-                  resolution.config[
-                    `control_${complication.controlPrefix}_${rectSuffix}_rect`
-                  ]
-                )
-              )
-            : parseConfigRect(
-                resolution.config[`control_${complication.controlPrefix}_rect`]
-              )) &&
-          findSpriteFolder(
-            resolution,
-            resolution.config[`control_${complication.controlPrefix}_font`]
-          )
+  return WATCHFACE_COMPLICATIONS.filter(
+    (complication) =>
+      resolutionHasControlComplication(resolution, complication) &&
+      Boolean(
+        findSpriteFolder(
+          resolution,
+          resolution.config[complicationFontKey(complication)]
         )
+      )
   );
+}
+
+/** Whether the imported current-face config already implements one choice. */
+export function hasControlComplication(
+  details: CorosWatchfaceTemplateDetails,
+  id: WatchfaceComplicationId
+): boolean {
+  const resolution = pickPreviewResolution(details);
+  const complication = WATCHFACE_COMPLICATIONS.find(
+    (candidate) => candidate.id === id
+  );
+  return Boolean(
+    resolution &&
+      complication &&
+      resolutionHasControlComplication(resolution, complication)
+  );
+}
+
+interface ControlComplicationSelection {
+  controlComplicationEnabled?: Record<string, boolean>;
+  controlBatteryEnabled?: boolean;
+  controlSunriseEnabled?: boolean;
+  controlSunsetEnabled?: boolean;
+  controlFloorEnabled?: boolean;
+  controlTemperatureEnabled?: boolean;
+}
+
+function legacyControlComplicationSetting(
+  design: ControlComplicationSelection,
+  id: WatchfaceComplicationId
+): boolean | undefined {
+  switch (id) {
+    case "battery":
+      return design.controlBatteryEnabled;
+    case "sunrise":
+      return design.controlSunriseEnabled;
+    case "sunset":
+      return design.controlSunsetEnabled;
+    case "floors":
+      return design.controlFloorEnabled;
+    case "temperature":
+      return design.controlTemperatureEnabled;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Resolves the primary selectable toggle. New per-component state wins, old
+ * saved-project flags remain compatible, and otherwise the imported config is
+ * the default: configured choices on, missing choices off.
+ */
+export function isControlComplicationEnabled(
+  details: CorosWatchfaceTemplateDetails,
+  design: ControlComplicationSelection,
+  id: WatchfaceComplicationId
+): boolean {
+  const configured = design.controlComplicationEnabled?.[id];
+  if (configured !== undefined) {
+    return configured;
+  }
+  const legacy = legacyControlComplicationSetting(design, id);
+  return legacy ?? hasControlComplication(details, id);
 }
 
 /** Whether the current-face config actually declares Battery as a selector choice. */
 export function hasControlBattery(
   details: CorosWatchfaceTemplateDetails
 ): boolean {
-  return details.resolutions.some((resolution) =>
-    Object.keys(resolution.config).some((key) =>
-      key.startsWith("control_battery_")
-    )
-  );
+  return hasControlComplication(details, "battery");
 }
 
 /**
@@ -2949,6 +3154,288 @@ export function buildControlComplicationVisibilityOverrides(
   );
 }
 
+const COMPLICATION_ICON_NAMES: Record<WatchfaceComplicationId, string[]> = {
+  heartRate: ["hr.png", "heart_rate.png", "heartrate.png"],
+  steps: ["step.png", "steps.png"],
+  calories: ["kcal.png", "calorie.png", "calories.png"],
+  floors: ["floor.png", "floors.png"],
+  elevation: ["elevation.png", "altitude.png"],
+  exercise: ["exercise.png", "workout.png", "sport.png"],
+  sunrise: ["sunrise.png"],
+  sunset: ["sunset.png"],
+  battery: ["battery.png"],
+  temperature: ["temperature.png", "temp.png"]
+};
+
+function firstControlRect(config: Record<string, string>): string | undefined {
+  return Object.entries(config).find(
+    ([key, value]) =>
+      /^control_[a-z0-9_]+_rect$/.test(key) &&
+      parseConfigRect(value) !== null
+  )?.[1];
+}
+
+function fallbackControlRect(
+  resolution: CorosWatchfaceResolutionDetails,
+  config: Record<string, string>,
+  aod: boolean
+): string {
+  const existing = firstControlRect(config);
+  if (existing) {
+    return existing;
+  }
+  const digitFolder = resolution.spriteFolders.find(
+    (folder) => folder.kind === "digits" && folder.aod === aod
+  ) ?? resolution.spriteFolders.find((folder) => folder.kind === "digits");
+  const height = Math.max(
+    1,
+    digitFolder?.files[0]?.height ?? Math.round(resolution.height * 0.07)
+  );
+  const width = Math.max(height * 4, Math.round(resolution.width * 0.25));
+  const x0 = Math.round((resolution.width - width) / 2);
+  const y0 = Math.round(resolution.height * 0.72);
+  return `{${x0},${y0},${x0 + width},${y0 + height},hcenter|vcenter}`;
+}
+
+function splitControlRect(
+  value: string
+): { hour: string; minute: string } | null {
+  const rect = parseConfigRect(value);
+  if (!rect) {
+    return null;
+  }
+  const gap = Math.max(1, Math.round((rect.x1 - rect.x0) * 0.04));
+  const middle = Math.round((rect.x0 + rect.x1) / 2);
+  const suffix =
+    value.match(
+      /^\{\s*-?\d+\s*,\s*-?\d+\s*,\s*-?\d+\s*,\s*-?\d+\s*((?:,[^}]*)?)\}$/
+    )?.[1] || ",hcenter|vcenter";
+  return {
+    hour: `{${rect.x0},${rect.y0},${middle - gap},${rect.y1}${suffix}}`,
+    minute: `{${middle + gap},${rect.y0},${rect.x1},${rect.y1}${suffix}}`
+  };
+}
+
+function fallbackControlFont(
+  resolution: CorosWatchfaceResolutionDetails,
+  config: Record<string, string>,
+  aod: boolean
+): string | undefined {
+  const configured = Object.entries(config).find(
+    ([key, value]) =>
+      /^control_[a-z0-9_]+_font$/.test(key) &&
+      Boolean(findSpriteFolder(resolution, value))
+  )?.[1];
+  if (configured) {
+    return configured;
+  }
+  return (
+    resolution.spriteFolders.find(
+      (folder) => folder.kind === "digits" && folder.aod === aod
+    ) ?? resolution.spriteFolders.find((folder) => folder.kind === "digits")
+  )?.folder.replace(/\//g, "\\");
+}
+
+function fallbackControlIconPosition(
+  config: Record<string, string>,
+  rectValue: string
+): string {
+  const existing = Object.entries(config).find(
+    ([key, value]) =>
+      /^control_[a-z0-9_]+_icon_pos$/.test(key) &&
+      parseConfigPos(value) !== null
+  )?.[1];
+  if (existing) {
+    return existing;
+  }
+  const rect = parseConfigRect(rectValue);
+  return rect ? `{${rect.x0},${rect.y0}}` : "{0,0}";
+}
+
+function complicationIconPath(
+  resolution: CorosWatchfaceResolutionDetails,
+  complication: WatchfaceComplicationDefinition
+): string | undefined {
+  const names = COMPLICATION_ICON_NAMES[complication.id];
+  const icon = resolution.icons.find((candidate) =>
+    names.includes(candidate.path.split("/").at(-1)?.toLowerCase() ?? "")
+  );
+  return icon?.path
+    .replace(`${resolution.directory}/`, "")
+    .replace(/\//g, "\\");
+}
+
+function addMissingControlComplication(
+  resolution: CorosWatchfaceResolutionDetails,
+  config: Record<string, string>,
+  complication: WatchfaceComplicationDefinition,
+  aod: boolean
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  if (
+    Object.keys(config).some((key) => /^rect_control\d+_pos$/.test(key)) &&
+    complicationRectKeys(complication).every(
+      (key) => parseConfigRect(config[key]) !== null
+    ) &&
+    Boolean(config[complicationFontKey(complication)])
+  ) {
+    return values;
+  }
+  if (
+    !Object.keys(config).some((key) => /^rect_control\d+_pos$/.test(key))
+  ) {
+    values.rect_control1_pos = "{0,0}";
+  }
+
+  const rectKeys = complicationRectKeys(complication);
+  const baseRect = fallbackControlRect(resolution, config, aod);
+  const splitRect = complication.valueParts
+    ? splitControlRect(baseRect)
+    : null;
+  for (const [index, key] of rectKeys.entries()) {
+    if (parseConfigRect(config[key])) {
+      continue;
+    }
+    values[key] =
+      splitRect && index === 0
+        ? splitRect.hour
+        : splitRect && index === 1
+          ? splitRect.minute
+          : baseRect;
+  }
+
+  const fontKey = complicationFontKey(complication);
+  if (!config[fontKey]) {
+    const font = fallbackControlFont(resolution, config, aod);
+    if (font) {
+      values[fontKey] = font;
+    }
+  }
+  const fontColorKey = `${fontKey}_color`;
+  if (!Object.prototype.hasOwnProperty.call(config, fontColorKey)) {
+    values[fontColorKey] = "";
+  }
+
+  const iconPositionKey = `control_${complication.controlPrefix}_icon_pos`;
+  const iconKey = `control_${complication.controlPrefix}_icon`;
+  const iconPath = complicationIconPath(resolution, complication);
+  if (complication.id === "battery") {
+    const directoryKey = "control_battery_icon_dir";
+    if (!config[directoryKey]) {
+      const batteryFolder = resolution.spriteFolders.find(
+        (folder) =>
+          folder.kind === "state" &&
+          /(^|\\)(control_)?battery$/i.test(
+            folder.folder.replace(/\//g, "\\")
+          )
+      );
+      if (batteryFolder) {
+        values[directoryKey] = batteryFolder.folder.replace(/\//g, "\\");
+      }
+    }
+  } else if (!config[iconKey] && iconPath) {
+    values[iconKey] = iconPath;
+  }
+  if (
+    (config[iconKey] || iconPath || complication.id === "battery") &&
+    !parseConfigPos(config[iconPositionKey])
+  ) {
+    values[iconPositionKey] = fallbackControlIconPosition(config, baseRect);
+  }
+
+  if (
+    complication.id === "temperature" &&
+    !config.control_temperature_negative_sign_icon &&
+    config.control_negative_sign_icon
+  ) {
+    values.control_temperature_negative_sign_icon =
+      config.control_negative_sign_icon;
+  }
+  return values;
+}
+
+/**
+ * Produces the complete selectable-control lifecycle for every supported
+ * component: missing enabled choices are synthesized, while disabled choices
+ * have every related declaration deleted from current and AOD configs.
+ */
+export function buildControlComplicationConfigurationOverrides(
+  details: CorosWatchfaceTemplateDetails,
+  design: ControlComplicationSelection
+): CorosWatchfaceConfigOverride[] {
+  return details.resolutions.flatMap((resolution) =>
+    [
+      { fileName: "config.txt", config: resolution.config, aod: false },
+      { fileName: "AODconfig.txt", config: resolution.aodConfig, aod: true }
+    ].flatMap(({ fileName, config, aod }) => {
+      const canAdd =
+        !aod ||
+        Object.keys(config).some((key) => /^rect_control\d+_pos$/.test(key));
+      const values: Record<string, string> = {};
+      for (const complication of WATCHFACE_COMPLICATIONS) {
+        const enabled = isControlComplicationEnabled(
+          details,
+          design,
+          complication.id
+        );
+        if (enabled && canAdd) {
+          Object.assign(
+            values,
+            addMissingControlComplication(
+              resolution,
+              { ...config, ...values },
+              complication,
+              aod
+            )
+          );
+          continue;
+        }
+        if (enabled) {
+          continue;
+        }
+        const prefix = `control_${complication.controlPrefix}_`;
+        for (const key of Object.keys(config)) {
+          if (key.startsWith(prefix)) {
+            values[key] = COROS_CONFIG_DELETE_VALUE;
+          }
+        }
+        if (complication.id === "battery") {
+          for (const key of Object.keys(config)) {
+            if (
+              key.startsWith("control_bluetooth_") ||
+              key.startsWith("control_no_disturb_") ||
+              key === "battery_icon_lowpower" ||
+              (aod && key.startsWith("battery_"))
+            ) {
+              values[key] = COROS_CONFIG_DELETE_VALUE;
+            }
+          }
+        }
+      }
+      return Object.keys(values).length > 0
+        ? [{ path: `${resolution.directory}/${fileName}`, values }]
+        : [];
+    })
+  );
+}
+
+/** Reasserts disabled-component deletion after later asset/style overrides. */
+export function buildDisabledControlComplicationOverrides(
+  details: CorosWatchfaceTemplateDetails,
+  design: ControlComplicationSelection
+): CorosWatchfaceConfigOverride[] {
+  return buildControlComplicationConfigurationOverrides(details, design)
+    .map(({ path, values }) => ({
+      path,
+      values: Object.fromEntries(
+        Object.entries(values).filter(
+          ([, value]) => value === COROS_CONFIG_DELETE_VALUE
+        )
+      )
+    }))
+    .filter(({ values }) => Object.keys(values).length > 0);
+}
+
 /** Moves selectable-control icons independently from their value rectangles. */
 export function buildControlIconPositionOverrides(
   details: CorosWatchfaceTemplateDetails,
@@ -2983,11 +3470,12 @@ export function buildControlIconPositionOverrides(
 
 /**
  * Every `control_*` child coordinate is relative to `rect_controlN_pos`, and
- * stock templates keep all children non-negative. Icon drags can push a child
- * above/left of the origin, and negative child values are unproven on-watch
- * (COROS's pipeline may clamp or drop them). This rewrites the merged export
- * overrides so the origin absorbs any negative child offsets: absolute screen
- * positions are unchanged, but every child coordinate stays non-negative.
+ * stock templates keep both the origin and children non-negative. Layout or
+ * icon drags can make either side negative, which is unproven on-watch (COROS's
+ * pipeline may clamp or drop the whole control). This rewrites the merged
+ * export overrides so the origin and children share the offset safely:
+ * absolute screen positions are unchanged while both stay non-negative
+ * whenever the control itself remains within the screen's positive space.
  */
 export function rebaseNegativeControlChildren(
   details: CorosWatchfaceTemplateDetails,
@@ -3013,8 +3501,8 @@ export function rebaseNegativeControlChildren(
         /^control_[a-z0-9_]+_(icon_pos|rect)$/.test(key) &&
         offsetConfigValue(effective[key]!, 0, 0) !== null
     );
-    let minX = 0;
-    let minY = 0;
+    let minX = Number.POSITIVE_INFINITY;
+    let minY = Number.POSITIVE_INFINITY;
     for (const key of childKeys) {
       const pos = parseConfigPos(effective[key]);
       const rect = pos ? null : parseConfigRect(effective[key]);
@@ -3026,13 +3514,29 @@ export function rebaseNegativeControlChildren(
       minX = Math.min(minX, x);
       minY = Math.min(minY, y);
     }
-    if (minX === 0 && minY === 0) {
+    if (!Number.isFinite(minX) || !Number.isFinite(minY)) {
       continue;
     }
-    const shiftX = -minX;
-    const shiftY = -minY;
+
+    const safeOrigin = (originValue: number, minimumChild: number): number => {
+      const minimumAbsolute = originValue + minimumChild;
+      // When the absolute control is already partly off-screen, preserving its
+      // position and making both values non-negative is mathematically
+      // impossible. Preserve the position and retain the non-negative child.
+      if (minimumAbsolute < 0) {
+        return minimumAbsolute;
+      }
+      return Math.min(Math.max(originValue, 0), minimumAbsolute);
+    };
+    const originX = safeOrigin(origin.x, minX);
+    const originY = safeOrigin(origin.y, minY);
+    const shiftX = origin.x - originX;
+    const shiftY = origin.y - originY;
+    if (shiftX === 0 && shiftY === 0) {
+      continue;
+    }
     const values: Record<string, string> = {
-      [originKey]: `{${origin.x - shiftX},${origin.y - shiftY}}`
+      [originKey]: `{${originX},${originY}}`
     };
     for (const key of childKeys) {
       const shifted = offsetConfigValue(effective[key]!, shiftX, shiftY);
@@ -4653,6 +5157,7 @@ export function buildLayerVisibilityOverrides(
       if (group.id === "temperature") {
         for (const key of [
           "temperature_rect",
+          "temperature_font",
           "temperature_font_color",
           "temperature_negative_sign_icon"
         ]) {
@@ -5530,6 +6035,16 @@ export async function drawStudioPreview(
     : complication?.id === "battery"
       ? controlBatteryFile
       : null;
+  const complicationIconKey =
+    complicationPrefix && complication?.id !== "battery"
+      ? `control_${complicationPrefix}_icon`
+      : "";
+  const virtualComplicationIconOverride =
+    complicationIconKey && !complicationIcon
+      ? options.configAssetOverrides?.[
+          watchfaceConfigAssetId("config", complicationIconKey)
+        ]
+      : undefined;
   const configuredComplicationIconPos = complicationPrefix
     ? parseConfigPos(
         config[`control_${complicationPrefix}_icon_pos`]
@@ -6154,9 +6669,6 @@ export async function drawStudioPreview(
   }
 
   if (complicationIcon && complicationIconPos) {
-    const complicationIconKey = complicationPrefix
-      ? `control_${complicationPrefix}_icon`
-      : "";
     const image =
       complication?.id === "battery" && controlBatteryReplacement
         ? await loadStudioImage(
@@ -6189,6 +6701,44 @@ export async function drawStudioPreview(
         false
       );
     }
+  } else if (
+    virtualComplicationIconOverride?.replacement &&
+    virtualComplicationIconOverride.enabled !== false &&
+    complicationIconPos
+  ) {
+    const fallback = virtualControlIconCanvasSize(resolution);
+    const canvasSize = configAssetCanvasSize(
+      complicationIconKey,
+      { ...virtualComplicationIconOverride, nativeSize: false },
+      fallback,
+      options.nativeSpriteResolutionScale ?? 1
+    );
+    const image = await loadStudioImage(
+      canvasSize.native
+        ? await resizeAndTintSprite(
+            virtualComplicationIconOverride.replacement.dataUrl,
+            canvasSize.width,
+            canvasSize.height
+          )
+        : await fitVisibleSpriteToCanvas(
+            virtualComplicationIconOverride.replacement.dataUrl,
+            canvasSize.width,
+            canvasSize.height,
+            virtualComplicationIconOverride.scale ?? 1
+          )
+    );
+    drawStudioLayerImage(
+      context,
+      image,
+      complicationIconPos.x * scale,
+      complicationIconPos.y * scale,
+      image.naturalWidth * scale,
+      image.naturalHeight * scale,
+      scale,
+      options,
+      "complication",
+      false
+    );
   } else if (complication?.id === "battery" && complicationIconPos) {
     // Some watches offer Battery as a firmware control even though the source
     // template contains no battery control PNG. Draw a preview-only glyph so

--- a/src/watchfaces/watchfaceStudio.ts
+++ b/src/watchfaces/watchfaceStudio.ts
@@ -2687,6 +2687,32 @@ export type WatchfaceDateStyles = Partial<
   Record<WatchfaceDatePartId, WatchfaceDateSpriteStyle>
 >;
 
+/**
+ * Removes state introduced by choosing a rasterized date font. Returning
+ * `undefined` is significant: an absent style lets the original template PNG
+ * bypass resizing and transparent-padding normalization entirely.
+ */
+export function removeWatchfaceDateFontOverride(
+  style: WatchfaceDateSpriteStyle | undefined
+): WatchfaceDateSpriteStyle | undefined {
+  if (!style) return undefined;
+  const {
+    fontFamily: _fontFamily,
+    rasterFont: _rasterFont,
+    nativeSize: _nativeSize,
+    letterSpacing: _letterSpacing,
+    monthFormat: _monthFormat,
+    ...remaining
+  } = style;
+  const hasIndependentEdits =
+    remaining.scale !== 1 ||
+    remaining.color !== undefined ||
+    remaining.rotation !== undefined ||
+    remaining.width !== undefined ||
+    remaining.height !== undefined;
+  return hasIndependentEdits ? remaining : undefined;
+}
+
 interface WatchfaceDatePartDefinition {
   id: WatchfaceDatePartId;
   rectKey: string;
@@ -5455,6 +5481,16 @@ export interface WatchfaceLayoutGroupBounds {
   y1: number;
 }
 
+/**
+ * Visual styling that changes position-backed layout geometry without changing
+ * the source folder metadata stored on the imported template.
+ */
+export interface WatchfaceLayoutGeometryOptions {
+  timeStyles?: WatchfaceTimeStyles;
+  /** Face-wide tracking used when a time part has no component override. */
+  letterSpacing?: number;
+}
+
 export interface WatchfaceLayoutOffsetLimits {
   minDx: number;
   maxDx: number;
@@ -5468,7 +5504,8 @@ export interface WatchfaceLayoutOffsetLimits {
  * size they reference (digit font folder or icon file).
  */
 export function computeLayoutGroupBounds(
-  resolution: CorosWatchfaceResolutionDetails
+  resolution: CorosWatchfaceResolutionDetails,
+  geometry: WatchfaceLayoutGeometryOptions = {}
 ): WatchfaceLayoutGroupBounds[] {
   const bounds: WatchfaceLayoutGroupBounds[] = [];
   for (const group of WATCHFACE_LAYOUT_GROUPS) {
@@ -5598,10 +5635,41 @@ export function computeLayoutGroupBounds(
       }
       const pos = parseConfigPos(value);
       if (pos) {
-        const size = spriteSizeForPosKey(resolution, key);
-        x0 = Math.min(x0, pos.x);
+        const sourceSize = spriteSizeForPosKey(resolution, key);
+        const timeStyle =
+          group.id === "hours" ||
+          group.id === "minutes" ||
+          group.id === "seconds"
+            ? geometry.timeStyles?.[group.id]
+            : undefined;
+        const timeScale = timeStyle
+          ? normalizeSpriteScale(timeStyle.scale)
+          : 1;
+        const size = {
+          width: Math.max(1, Math.round(sourceSize.width * timeScale)),
+          height: Math.max(1, Math.round(sourceSize.height * timeScale))
+        };
+        // Preview tracking is applied at draw time rather than written into the
+        // live config. Mirror that horizontal offset here so hit testing,
+        // selection outlines, snapping, and edge limits follow the glyphs.
+        const tracking = Math.max(
+          -0.35,
+          Math.min(
+            0.25,
+            timeStyle?.letterSpacing ?? geometry.letterSpacing ?? 0
+          )
+        );
+        const slotDirection = key.includes("_high_")
+          ? -1
+          : key.includes("_low_")
+            ? 1
+            : 0;
+        const trackingOffset =
+          Math.round((size.height * tracking) / 2) * slotDirection;
+        const drawX = pos.x + trackingOffset;
+        x0 = Math.min(x0, drawX);
         y0 = Math.min(y0, pos.y);
-        x1 = Math.max(x1, pos.x + size.width);
+        x1 = Math.max(x1, drawX + size.width);
         y1 = Math.max(y1, pos.y + size.height);
       }
     }
@@ -5617,10 +5685,11 @@ export function computeLayoutGroupBounds(
  * while keeping its complete bounding box on the face.
  */
 export function computeLayoutOffsetLimits(
-  resolution: CorosWatchfaceResolutionDetails
+  resolution: CorosWatchfaceResolutionDetails,
+  geometry: WatchfaceLayoutGeometryOptions = {}
 ): Record<string, WatchfaceLayoutOffsetLimits> {
   return Object.fromEntries(
-    computeLayoutGroupBounds(resolution).map((box) => [
+    computeLayoutGroupBounds(resolution, geometry).map((box) => [
       box.id,
       box.id === "analogCenter"
         ? (() => {

--- a/src/watchfaces/watchfaceStudio.ts
+++ b/src/watchfaces/watchfaceStudio.ts
@@ -244,6 +244,191 @@ export function detailsForPreviewMode(
   };
 }
 
+/**
+ * Narrows a template to the assets referenced by one display configuration.
+ * Composition uses this view so styling Current cannot overwrite a sprite
+ * shared with AOD (and vice versa).
+ */
+export function detailsForCompositionMode(
+  details: CorosWatchfaceTemplateDetails,
+  mode: WatchfacePreviewMode
+): CorosWatchfaceTemplateDetails {
+  const projected = detailsForPreviewMode(details, mode);
+  return {
+    ...projected,
+    resolutions: projected.resolutions.map((resolution) => {
+      const references = new Set(
+        Object.values(resolution.config)
+          .map((value) => value?.trim().replace(/\\/g, "/").replace(/^\.\//, ""))
+          .filter((value): value is string => Boolean(value))
+      );
+      return {
+        ...resolution,
+        spriteFolders: resolution.spriteFolders
+          .filter((folder) =>
+            references.has(folder.folder.replace(/\\/g, "/"))
+          )
+          .map((folder) =>
+            mode === "aod" ? { ...folder, aod: false } : folder
+          ),
+        icons: resolution.icons.filter((icon) =>
+          references.has(
+            icon.path.slice(resolution.directory.length + 1).replace(/\\/g, "/")
+          )
+        ),
+        // The selected configuration is exposed through `config`; clearing the
+        // secondary map prevents generic builders from processing both modes.
+        aodConfig: {}
+      };
+    })
+  };
+}
+
+function normalizedConfigAsset(value: string | undefined): string {
+  return value?.trim().replace(/\\/g, "/").replace(/^\.\//, "") ?? "";
+}
+
+function stableFolderSuffix(value: string): string {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36).slice(0, 6);
+}
+
+export interface WatchfaceModeComposition {
+  assetReplacements: CorosWatchfaceAssetReplacement[];
+  configOverrides: CorosWatchfaceConfigOverride[];
+  minWatchFaceVersion?: number;
+}
+
+/**
+ * Retargets a composition built against the virtual AOD `config` map to real
+ * AODconfig.txt paths and clones every referenced bitmap into an AOD-owned
+ * Studio folder. This is the isolation boundary for shared template assets.
+ */
+function retargetWatchfaceCompositionToOwnedMode<
+  T extends WatchfaceModeComposition
+>(
+  modeDetails: CorosWatchfaceTemplateDetails,
+  composition: T,
+  mode: WatchfacePreviewMode
+): T {
+  const effective = applyConfigOverridesToDetails(
+    modeDetails,
+    composition.configOverrides
+  );
+  const pathOverrides: CorosWatchfaceConfigOverride[] = [];
+  const replacements: CorosWatchfaceAssetReplacement[] = [];
+  const folderNames = new Map<string, string>();
+
+  for (const replacement of composition.assetReplacements) {
+    const separator = replacement.path.indexOf("/");
+    if (separator < 0) continue;
+    const directory = replacement.path.slice(0, separator);
+    const relativePath = replacement.path.slice(separator + 1);
+    const resolution = effective.resolutions.find(
+      (candidate) => candidate.directory === directory
+    );
+    if (!resolution) continue;
+    const slash = relativePath.lastIndexOf("/");
+    const sourceFolder = slash >= 0 ? relativePath.slice(0, slash) : "";
+    const sourceFile = slash >= 0 ? relativePath.slice(slash + 1) : relativePath;
+    const matchedKeys = Object.entries(resolution.config).flatMap(
+      ([key, value]) => {
+        const normalized = normalizedConfigAsset(value);
+        return normalized === sourceFolder || normalized === relativePath
+          ? [{ key, direct: normalized === relativePath }]
+          : [];
+      }
+    );
+    if (matchedKeys.length === 0) continue;
+
+    const directOnly = matchedKeys.every(({ direct }) => direct);
+    const folderKey = `${directory}/${
+      directOnly ? relativePath : sourceFolder || relativePath
+    }`;
+    let targetFolder = folderNames.get(folderKey);
+    if (!targetFolder) {
+      const basename = (
+        (directOnly ? sourceFile.replace(/\.png$/i, "") : sourceFolder.split("/").at(-1)) ||
+        "asset"
+      )
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]/g, "_")
+        .slice(0, 42);
+      targetFolder = `studio/${mode}_${basename}_${stableFolderSuffix(folderKey)}`;
+      folderNames.set(folderKey, targetFolder);
+    }
+    const targetFile = /^\d{2}\.png$/i.test(sourceFile)
+      ? sourceFile.toLowerCase()
+      : "00.png";
+    replacements.push({
+      ...replacement,
+      path: `${directory}/${targetFolder}/${targetFile}`,
+      create: true,
+      allowDimensionOverride: true
+    });
+    pathOverrides.push({
+      path: `${directory}/${mode === "aod" ? "AODconfig" : "config"}.txt`,
+      values: Object.fromEntries(
+        matchedKeys.map(({ key, direct }) => [
+          key,
+          (direct ? `${targetFolder}/${targetFile}` : targetFolder).replace(
+            /\//g,
+            "\\"
+          )
+        ])
+      )
+    });
+  }
+
+  return {
+    ...composition,
+    assetReplacements: mergeAssetReplacements(replacements),
+    configOverrides: mergeConfigOverrides(
+      composition.configOverrides.map((override) => ({
+        ...override,
+        path: mode === "aod"
+          ? override.path.replace(/\/config\.txt$/i, "/AODconfig.txt")
+          : override.path
+      })),
+      pathOverrides
+    )
+  };
+}
+
+export function retargetWatchfaceCompositionToAod<
+  T extends WatchfaceModeComposition
+>(
+  aodDetails: CorosWatchfaceTemplateDetails,
+  composition: T
+): T {
+  return retargetWatchfaceCompositionToOwnedMode(
+    aodDetails,
+    composition,
+    "aod"
+  );
+}
+
+/**
+ * Current assets are also cloned when a separate AOD exists, ensuring a
+ * Current edit cannot alter an original sprite still referenced by AOD.
+ */
+export function retargetWatchfaceCompositionToCurrent<
+  T extends WatchfaceModeComposition
+>(
+  currentDetails: CorosWatchfaceTemplateDetails,
+  composition: T
+): T {
+  return retargetWatchfaceCompositionToOwnedMode(
+    currentDetails,
+    composition,
+    "current"
+  );
+}
+
 function configAssetLabel(configKey: string, _scope: WatchfaceConfigAssetScope): string {
   const special: Record<string, string> = {
     background_icon: "Background image",

--- a/src/watchfaces/watchfaces.css
+++ b/src/watchfaces/watchfaces.css
@@ -1830,7 +1830,7 @@
 }
 
 .watchface-shell .wf-export-preview-modal {
-  width: min(760px, 100%);
+  width: min(1080px, 100%);
 }
 
 .watchface-shell .wf-export-preview-header,
@@ -1867,7 +1867,7 @@
 
 .watchface-shell .wf-export-preview-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 18px;
 }
 
@@ -1916,6 +1916,12 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+@media (max-width: 900px) {
+  .watchface-shell .wf-export-preview-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 680px) {

--- a/src/watchfaces/watchfaces.css
+++ b/src/watchfaces/watchfaces.css
@@ -2393,19 +2393,91 @@
   top: -12px;
   align-items: center;
   justify-content: space-between;
-  min-height: 44px;
+  min-height: 46px;
   gap: 8px;
   border-bottom: 1px solid var(--wf-border);
-  background: color-mix(in srgb, var(--wf-surface) 94%, transparent);
-  padding: 5px 2px 6px;
+  background: color-mix(in srgb, var(--wf-surface-raised) 96%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--text-primary) 4%, transparent);
+  padding: 0 10px;
+}
+
+.watchface-shell .wf-layers-pane > .wf-pane-heading {
+  margin: -12px -10px 8px;
+}
+
+.watchface-shell .wf-properties-pane > .wf-pane-heading {
+  margin: -12px -12px 10px;
+}
+
+.watchface-shell .wf-pane-heading::after {
+  position: absolute;
+  bottom: -1px;
+  left: 10px;
+  width: 32px;
+  height: 2px;
+  border-radius: 2px 2px 0 0;
+  background: var(--accent);
+  content: "";
 }
 
 .watchface-shell .wf-pane-heading > div:first-child {
   min-width: 0;
 }
 
-.watchface-shell .wf-pane-heading > div:first-child > span,
-.watchface-shell .wf-pane-heading > div:first-child > strong {
+.watchface-shell .wf-pane-heading-main {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+}
+
+.watchface-shell .wf-pane-heading-icon {
+  display: inline-grid;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid var(--wf-border);
+  border-radius: 6px;
+  background: var(--wf-surface-hover);
+  color: var(--text-secondary);
+}
+
+.watchface-shell .wf-pane-count {
+  display: inline-flex;
+  min-width: 20px;
+  height: 20px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--wf-border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--wf-surface-hover) 82%, transparent);
+  color: var(--text-secondary);
+  padding: 0 6px;
+  font-size: 10px;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.watchface-shell .wf-pane-context {
+  display: block;
+  overflow: hidden;
+  max-width: min(150px, 48%);
+  min-width: 0;
+  border: 1px solid var(--wf-border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--wf-surface-hover) 76%, transparent);
+  color: var(--text-secondary);
+  padding: 4px 8px;
+  font-size: var(--wf-text-xs);
+  font-weight: 650;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.watchface-shell .wf-pane-heading > div:first-child > span:not(.wf-pane-heading-icon, .wf-pane-count),
+.watchface-shell .wf-pane-heading > div:first-child > strong:not(.wf-pane-context) {
   display: block;
   overflow: hidden;
   margin-top: 1px;
@@ -2430,9 +2502,10 @@
 :is(.watchfaces-view, .wf-watchfaces, .watchface-shell) :where(.wf-pane-title, .watchface-editor-pane-title) {
   margin: 0;
   color: var(--text-primary);
-  font-size: var(--wf-text-sm);
+  font-size: var(--wf-text-xs);
   font-weight: 800;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 :is(.watchfaces-view, .wf-watchfaces, .watchface-shell) :where(.wf-add-menu, .watchface-add-menu, .wf-export-menu) {
@@ -2443,13 +2516,13 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 32px;
+  min-height: 30px;
   gap: 6px;
   border: 1px solid var(--wf-border);
   border-radius: var(--wf-control-radius);
   background: color-mix(in srgb, var(--wf-surface-raised) 76%, transparent);
   color: var(--text-secondary);
-  padding: 0 9px;
+  padding: 0 8px;
   font-size: var(--wf-text-xs);
   font-weight: 700;
 }

--- a/src/watchfaces/watchfaces.css
+++ b/src/watchfaces/watchfaces.css
@@ -2208,8 +2208,8 @@
 
 .watchface-shell .wf-command-bar {
   grid-template-columns: max-content minmax(0, 1fr) max-content;
-  gap: 10px;
-  padding: 8px 12px;
+  gap: 8px;
+  padding: 7px 12px;
 }
 
 :is(.watchfaces-view, .wf-watchfaces, .watchface-shell) :where(.wf-command-start, .watchface-editor-title) {
@@ -2243,13 +2243,13 @@
   display: inline-flex;
   width: auto;
   min-width: 0;
-  height: 40px;
-  min-height: 40px;
-  border: 1px solid var(--wf-border-strong);
-  background: var(--wf-surface-hover);
-  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--text-primary) 8%, transparent);
-  color: var(--text-primary);
-  padding: 0 10px;
+  height: 34px;
+  min-height: 34px;
+  border: 1px solid transparent;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-secondary);
+  padding: 0 8px 0 6px;
   gap: 6px;
   font-size: var(--wf-text-sm);
   font-weight: 700;
@@ -2257,8 +2257,8 @@
 }
 
 .watchface-shell .wf-back-button:hover {
-  border-color: var(--wf-accent-border);
-  background: color-mix(in srgb, var(--wf-surface-hover) 74%, var(--accent-soft));
+  border-color: var(--wf-border);
+  background: var(--wf-surface-hover);
   color: var(--text-primary);
 }
 
@@ -2269,23 +2269,23 @@
 :is(.watchfaces-view, .wf-watchfaces, .watchface-shell) :where(.wf-project-name, .watchface-editor-name) {
   flex: 0 1 min(320px, 32vw);
   width: min(320px, 32vw);
-  min-height: 40px;
-  border-color: var(--wf-border-strong);
-  background: color-mix(in srgb, var(--wf-surface-raised) 76%, transparent);
-  padding-inline: 11px;
+  min-height: 34px;
+  border-color: transparent;
+  background: transparent;
+  padding-inline: 8px;
   font-family: var(--font-display);
   font-size: var(--wf-text-lg);
   font-weight: 700;
 }
 
 :is(.watchfaces-view, .wf-watchfaces, .watchface-shell) :where(.wf-project-name, .watchface-editor-name):hover {
-  border-color: var(--wf-border-strong);
-  background: var(--wf-surface-raised);
+  border-color: var(--wf-border);
+  background: var(--wf-surface-hover);
 }
 
 :is(.watchfaces-view, .wf-watchfaces, .watchface-shell) :where(.wf-project-name, .watchface-editor-name):focus {
   border-color: var(--accent-strong);
-  background: var(--wf-surface-raised);
+  background: var(--wf-surface-hover);
 }
 
 :is(.watchfaces-view, .wf-watchfaces, .watchface-shell) :where(.wf-save-state, .watchface-save-state) {
@@ -2322,9 +2322,41 @@
 }
 
 .watchface-shell .wf-command-actions > .wf-icon-button {
-  width: 36px;
-  min-width: 36px;
-  height: 36px;
+  width: 34px;
+  min-width: 34px;
+  height: 34px;
+}
+
+.watchface-shell .wf-history-controls {
+  display: inline-flex;
+  overflow: hidden;
+  height: 34px;
+  flex: 0 0 auto;
+  align-items: stretch;
+  border: 1px solid var(--wf-border);
+  border-radius: var(--wf-control-radius);
+  background: color-mix(in srgb, var(--wf-surface-raised) 72%, transparent);
+}
+
+.watchface-shell .wf-history-controls > .wf-icon-button {
+  width: 33px;
+  min-width: 33px;
+  height: 32px;
+  min-height: 32px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-secondary);
+}
+
+.watchface-shell .wf-history-controls > .wf-icon-button + .wf-icon-button {
+  border-left: 1px solid var(--wf-border);
+}
+
+.watchface-shell .wf-history-controls > .wf-icon-button:hover:not(:disabled) {
+  background: var(--wf-surface-hover);
+  color: var(--text-primary);
 }
 
 :is(.watchfaces-view, .wf-watchfaces, .watchface-shell) :where(.wf-studio-grid, .watchface-editor-grid) {
@@ -2361,11 +2393,11 @@
   top: -12px;
   align-items: center;
   justify-content: space-between;
-  min-height: 48px;
+  min-height: 44px;
   gap: 8px;
   border-bottom: 1px solid var(--wf-border);
   background: color-mix(in srgb, var(--wf-surface) 94%, transparent);
-  padding: 8px 2px;
+  padding: 5px 2px 6px;
 }
 
 .watchface-shell .wf-pane-heading > div:first-child {
@@ -2376,7 +2408,7 @@
 .watchface-shell .wf-pane-heading > div:first-child > strong {
   display: block;
   overflow: hidden;
-  margin-top: 2px;
+  margin-top: 1px;
   color: var(--text-secondary);
   font-size: var(--wf-text-xs);
   font-weight: 600;
@@ -2411,14 +2443,14 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 40px;
-  gap: 7px;
+  min-height: 32px;
+  gap: 6px;
   border: 1px solid var(--wf-border);
   border-radius: var(--wf-control-radius);
-  background: var(--wf-surface-raised);
+  background: color-mix(in srgb, var(--wf-surface-raised) 76%, transparent);
   color: var(--text-secondary);
-  padding: 0 10px;
-  font-size: var(--wf-text-sm);
+  padding: 0 9px;
+  font-size: var(--wf-text-xs);
   font-weight: 700;
 }
 

--- a/src/watchfaces/watchfaces.css
+++ b/src/watchfaces/watchfaces.css
@@ -2475,7 +2475,7 @@
 
 .watchface-shell .wf-layer-list {
   display: grid;
-  gap: 3px;
+  gap: 1px;
   margin: 8px 0 0;
   padding: 0;
   list-style: none;
@@ -2495,7 +2495,7 @@
 
 .watchface-shell .wf-editor-group-tree {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 28px 28px;
+  grid-template-columns: minmax(0, 1fr) 32px 32px;
   align-items: center;
 }
 
@@ -2528,12 +2528,49 @@
 }
 
 .watchface-shell .wf-layer-group {
-  margin: 12px 7px 4px;
+  margin: 10px 0 2px;
+}
+
+.watchface-shell .wf-layer-group:first-child {
+  margin-top: 2px;
+}
+
+.watchface-shell .wf-layer-section-toggle {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) auto;
+  align-items: center;
+  width: 100%;
+  min-height: 28px;
+  gap: 3px;
+  border: 0;
+  border-radius: var(--wf-control-radius);
+  background: transparent;
   color: var(--text-secondary);
+  padding: 0 7px 0 4px;
+  text-align: left;
+  font: inherit;
   font-size: var(--wf-text-xs);
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  font-weight: 750;
+}
+
+.watchface-shell .wf-layer-section-toggle:hover {
+  background: var(--wf-surface-hover);
+  color: var(--text-primary);
+}
+
+.watchface-shell .wf-layer-section-toggle > svg {
+  transition: transform 140ms ease;
+}
+
+.watchface-shell .wf-layer-section-toggle > svg.is-collapsed {
+  transform: rotate(-90deg);
+}
+
+.watchface-shell .wf-layer-section-count {
+  color: var(--text-tertiary);
+  font-size: var(--wf-text-xs);
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
 }
 
 .watchface-shell .wf-layer-icon {
@@ -2588,8 +2625,8 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr) 40px;
   align-items: center;
-  min-height: 40px;
-  gap: 5px;
+  min-height: 36px;
+  gap: 3px;
   border: 1px solid transparent;
   border-radius: var(--wf-control-radius);
   background: transparent;
@@ -2628,8 +2665,8 @@
 
 :is(.watchfaces-view, .wf-watchfaces, .watchface-shell) :where(.wf-layer-visibility, .watchface-layer-visibility) {
   display: grid;
-  width: 40px;
-  height: 40px;
+  width: 32px;
+  height: 32px;
   border: 0;
   border-radius: var(--wf-control-radius);
   background: transparent;
@@ -2645,8 +2682,8 @@
 
 .watchface-shell .watchface-layer-lock {
   display: grid;
-  width: 40px;
-  height: 40px;
+  width: 32px;
+  height: 32px;
   border: 0;
   border-radius: var(--wf-control-radius);
   background: transparent;

--- a/src/watchfaces/watchfaces.css
+++ b/src/watchfaces/watchfaces.css
@@ -51,16 +51,59 @@
 
 :root[data-theme="paper"] :is(.watchfaces-view, .wf-watchfaces, .watchface-shell) {
   --wf-canvas: color-mix(in srgb, var(--bg-base) 88%, #dce3df);
-  --wf-surface: color-mix(in srgb, var(--surface) 92%, var(--bg-base));
+  --wf-surface: #f7f8f6;
   --wf-surface-raised: #ffffff;
-  --wf-surface-hover: color-mix(in srgb, var(--accent-soft) 32%, #ffffff);
-  --wf-border: color-mix(in srgb, var(--glass-border) 90%, #6d716e 10%);
-  --wf-border-strong: color-mix(in srgb, var(--text-secondary) 32%, transparent);
+  --wf-surface-hover: #eef4f0;
+  --wf-border: rgba(43, 58, 50, 0.13);
+  --wf-border-strong: rgba(43, 58, 50, 0.22);
   --wf-accent-ink: #06150f;
   --wf-primary-bg: color-mix(in srgb, var(--accent) 68%, #9de8cf);
   --wf-primary-bg-hover: color-mix(in srgb, var(--accent-hover) 70%, #8cdfc3);
   --wf-shadow: 0 18px 42px rgba(56, 49, 39, 0.12);
   --wf-workspace-bg: transparent;
+}
+
+:root[data-theme="paper"] .watchface-shell :where(
+    .watchface-editor-layers,
+    .watchface-editor-inspector
+  ) {
+  background: var(--wf-surface);
+  box-shadow: none;
+}
+
+:root[data-theme="paper"] .watchface-shell .wf-pane-heading {
+  background: var(--wf-surface-raised);
+  box-shadow: 0 1px 3px rgba(43, 58, 50, 0.045);
+}
+
+:root[data-theme="paper"] .watchface-shell :where(
+    .wf-layer-row,
+    .watchface-layer-row
+  ):hover {
+  border-color: color-mix(in srgb, var(--wf-border) 76%, transparent);
+  background: var(--wf-surface-hover);
+}
+
+:root[data-theme="paper"] .watchface-shell :where(
+    .wf-layer-row,
+    .watchface-layer-row
+  ).is-selected,
+:root[data-theme="paper"] .watchface-shell :where(
+    .wf-layer-row,
+    .watchface-layer-row
+  )[aria-selected="true"] {
+  border-color: color-mix(in srgb, var(--accent) 32%, var(--wf-border));
+  background: color-mix(in srgb, var(--accent) 11%, #ffffff);
+}
+
+:root[data-theme="paper"] .watchface-shell :where(
+    .watchface-color-control,
+    .wf-color-control,
+    .wf-inline-config-asset,
+    .watchface-position-inputs input,
+    .wf-position-inputs input
+  ) {
+  box-shadow: 0 1px 2px rgba(43, 58, 50, 0.035);
 }
 
 /* Dark workspace glass is intentionally neutral charcoal. Emerald stays an accent. */


### PR DESCRIPTION
## What changed

- correct the PACE 4 firmware profile and finalize watch-face export handling
- add independent always-on display editing and preview support
- improve text bounds, font resets, layer visibility recovery, and editor tests
- reorganize the Layers panel into collapsible Time, Date, Metrics, Indicators, Artwork, and template-asset sections
- fix selector-icon dragging so only the icon moves in the temporary preview

## Why

PACE 4 projects and always-on layouts needed accurate export behavior and a complete editing path. The layer panel also mixed unrelated component types, while selector-icon drags reused a whole-component preview bitmap and made the value appear to move before snapping back.

## Impact

Watch-face authors get more reliable PACE 4 archives, full current/AOD editing, a clearer layer hierarchy, recoverable hidden assets, and accurate selector-icon drag feedback.

## Validation

- `npm run build:renderer`
- `npm run test:watchface-editor`
- live Electron visual check of expanded and collapsed Layers sections
- `git diff --check`
