### PR TITLE
Fix coach run distance and add load/open workout targets

### DIFF
--- a/docs/coros-plan-write-api.md
+++ b/docs/coros-plan-write-api.md
@@ -24,9 +24,27 @@ with `userId`) against the regional `teamapi*.coros.com` host.
 2. `POST /training/program/add` with identity fields cleared (`id: "0"`, etc.)
 3. Response `data` is the new program ID string.
 
-Running workouts use `sportType: 1`. Distance targets use `targetType: 5` with
-values in **centimeters** (meters × 100). Time targets use `targetType: 2` with
-seconds.
+Running workouts use `sportType: 1`. The full `targetType` enum (from the
+traininghub web-app bundle, `main-*.js` → `targetTypeName`):
+
+| value | name | targetValue encoding | UI label |
+|---|---|---|---|
+| 0 | notSet | 0 | — |
+| 1 | manualEnd | 0 (no value) | **Open** |
+| 2 | time | seconds | **Time** |
+| 3 | count | raw | — |
+| 4 | heart | raw | — |
+| 5 | distance | **centimeters** (meters × 100) | **Distance** |
+| 6 | load | raw integer 0–999 | **Training Load** |
+| 7 | heartRateRecovery | raw | — |
+| 8 | cumulativeClimb | centimeters | — |
+| 9 | routes | raw | — |
+
+The web app derives `targetValue` as `100 × meters` for distance, `cm` for
+cumulativeClimb, and the **raw input value** for everything else (time, load, …).
+Related enums: `intensityType` (2=heart, 3=pace, 4=speed, 6=power, 8=adjustedPace,
+9=ftp, 11=rpe), `intensityUnit` (1=min/km, 2=min/mi, 3=s/100m, 4=km/h, 5=mph),
+`restType` (0=manualEnd, 1=time, 2=heart, 3=noRest, 4=distance).
 
 ## Schedule on calendar
 

--- a/electron/chatService.ts
+++ b/electron/chatService.ts
@@ -1286,8 +1286,13 @@ function withLiveToolInstructions(
       "",
       "## Training plan tools",
       `Plan authoring tools: ${planTools.map((tool) => tool.name).join(", ")}. ` +
-        "Use draft_training_plan to build multi-day schedules with structured runs " +
-        "(distance_km for easy runs, steps for intervals). Include schedule_date " +
+        "Use draft_training_plan to build multi-day schedules. Use distance_km for a " +
+        "simple easy run; use steps for anything structured. Pick each step's target " +
+        "deliberately: distance for easy/long/tempo blocks, time for duration-based reps " +
+        "and recovery jogs, load only when prescribing by training-load budget, and open " +
+        "(no value, run-until-lap) for by-feel warmups/cooldowns or fartlek surges. Add a " +
+        "pace target (range like '4:05-4:15/km') to work intervals so they carry training " +
+        "load; leave easy/open segments paceless. Include schedule_date " +
         "(YYYYMMDD) for calendar placement. The athlete must confirm before upload. " +
         "Use list_scheduled_workouts + delete_workout to stage deletions. " +
         "The athlete confirms via the Delete from COROS button in chat."

--- a/electron/chatWorkoutTools.ts
+++ b/electron/chatWorkoutTools.ts
@@ -178,8 +178,11 @@ export function getChatWorkoutTools(): CorosMcpTool[] {
                   type: "array",
                   description:
                     "Structured run steps. Plain step: kind (warmup|training|rest|cooldown), " +
-                    "target_type (distance|time), target_distance_meters or target_duration_seconds, " +
-                    "optional pace string. Repeat group: { repeat, steps: [...] }."
+                    "target_type (distance|time|load|open) with its value — " +
+                    "distance→target_distance_meters, time→target_duration_seconds, " +
+                    "load→target_load (raw training-load integer 0–999), open→no value " +
+                    "(run until lap press). Optional pace string (single '5:30/km' or range " +
+                    "'4:05-4:15/km', /km or /mi). Repeat group: { repeat, steps: [...] }."
                 }
               },
               required: ["key", "name"]

--- a/electron/corosWorkoutBuilder.ts
+++ b/electron/corosWorkoutBuilder.ts
@@ -10,7 +10,9 @@ export type RunStepKind =
   | "cooldown"
   | "interval";
 
-export type RunTargetType = "time" | "distance";
+// Mirrors COROS's targetType enum (from the traininghub web-app bundle):
+// 1=manualEnd ("Open"), 2=time, 5=distance, 6=load ("Training Load").
+export type RunTargetType = "time" | "distance" | "load" | "open";
 
 export interface RunWorkoutStep {
   kind: RunStepKind;
@@ -18,6 +20,8 @@ export interface RunWorkoutStep {
   target_type?: RunTargetType;
   target_distance_meters?: number;
   target_duration_seconds?: number;
+  /** Training-load target (COROS targetType 6): a raw integer 0–999. */
+  target_load?: number;
   /** e.g. "5:30/km", "4:05-4:15/km", "8:00/mi" */
   pace?: string;
   intensity_type?: number;
@@ -124,7 +128,15 @@ const RUN_KIND_ALIASES: Record<string, RunStepKind> = {
 
 const RUN_TARGET_ALIASES: Record<string, RunTargetType> = {
   time: "time",
-  distance: "distance"
+  distance: "distance",
+  load: "load",
+  "training load": "load",
+  training_load: "load",
+  trainingload: "load",
+  open: "open",
+  "manual end": "open",
+  manual_end: "open",
+  manualend: "open"
 };
 
 export function metersToCorosDistance(meters: number): number {
@@ -225,8 +237,13 @@ function resolveRunTarget(step: RunWorkoutStep): {
 } {
   let targetType = step.target_type;
   if (!targetType) {
-    targetType =
-      step.target_distance_meters !== undefined ? "distance" : "time";
+    if (step.target_distance_meters !== undefined) {
+      targetType = "distance";
+    } else if (step.target_load !== undefined) {
+      targetType = "load";
+    } else {
+      targetType = "time";
+    }
   }
 
   if (targetType === "distance") {
@@ -238,6 +255,30 @@ function resolveRunTarget(step: RunWorkoutStep): {
       targetType: 5,
       targetValue: metersToCorosDistance(Number(meters)),
       targetDisplayUnit: step.target_display_unit ?? 3
+    };
+  }
+
+  // "Open" / manual-end segment: run until the athlete presses lap. COROS stores
+  // targetType 1 with no value (verified against the traininghub web-app bundle).
+  if (targetType === "open") {
+    return {
+      targetType: 1,
+      targetValue: 0,
+      targetDisplayUnit: step.target_display_unit ?? 0
+    };
+  }
+
+  // Training-load target: COROS stores the raw integer as targetValue (no unit
+  // scaling — verified in the web-app bundle: targetValue = input, 0–999).
+  if (targetType === "load") {
+    const load = step.target_load ?? step.target_value;
+    if (load === undefined) {
+      throw new Error("Load steps require target_load.");
+    }
+    return {
+      targetType: 6,
+      targetValue: Math.round(Number(load)),
+      targetDisplayUnit: step.target_display_unit ?? 0
     };
   }
 
@@ -322,27 +363,111 @@ function buildRunExercise(
   };
 }
 
+// COROS's default "run training" exercise template. These constants are lifted
+// verbatim from the payload the official web app sends for a simple distance run
+// (captured in t.coros.com.har → /training/schedule/update). A distance run must
+// carry ONE real exercise like this — with exercises: [] COROS zeroes the stored
+// program.distance and only keeps the target in program.targetValue, so the
+// calendar reads back Volume "--".
+const RUN_TRAINING_EXERCISE_ORIGIN_ID = "426109589008859136";
+const RUN_TRAINING_EXERCISE_SOURCE_ID = "425868113867882497";
+const RUN_TRAINING_EXERCISE_SOURCE_URL =
+  "https://d31oxp44ddzkyk.cloudfront.net/source/source_default/0/e3611f19b15648338b0f229b2b1b1015.jpg";
+
 export function buildEasyRun(options: {
   name: string;
   distanceKm: number;
   sportType?: number;
 }): Record<string, unknown> {
   const distance = metersToCorosDistance(options.distanceKm * 1000);
-  return {
-    name: options.name,
-    sportType: options.sportType ?? 1,
-    estimatedTime: 0,
-    estimatedDistance: distance,
-    distanceDisplayUnit: 3,
-    estimatedType: 6,
+  const sportType = options.sportType ?? 1;
+
+  const exercise: Record<string, unknown> = {
+    access: 0,
+    createTimestamp: 1587381919,
+    defaultOrder: 2,
+    equipment: [1],
+    exerciseType: 2,
+    groupId: "",
+    hrType: 0,
+    id: 1,
+    intensityCustom: 0,
+    intensityDisplayUnit: 0,
+    intensityMultiplier: 0,
+    intensityPercent: 0,
+    intensityPercentExtend: 0,
+    intensityType: 0,
+    intensityValue: 0,
+    intensityValueExtend: 0,
+    isDefaultAdd: 1,
+    isGroup: false,
+    isIntensityPercent: true,
+    name: "T3001",
+    originId: RUN_TRAINING_EXERCISE_ORIGIN_ID,
+    overview: "sid_run_training",
+    part: [0],
+    restType: 3,
+    restValue: 0,
+    sets: 1,
+    sortNo: 2,
+    sourceId: "0",
+    sourceUrl: "",
+    sportType,
+    subType: 0,
+    targetDisplayUnit: 1,
     targetType: 5,
     targetValue: distance,
+    userId: 0,
+    videoUrl: ""
+  };
+
+  const barChartEntry: Record<string, unknown> = {
+    exerciseId: "1",
+    exerciseType: 2,
+    height: 5,
+    name: "T3001",
+    targetType: 5,
+    targetValue: distance,
+    value: distance,
+    width: 100,
+    widthFill: 0
+  };
+
+  return {
+    id: "0",
+    name: options.name,
+    sportType,
+    subType: 0,
+    totalSets: 1,
+    sets: 1,
+    // Program-level target fields are intentionally empty strings — the target
+    // lives on the exercise. This matches the web app byte-for-byte.
+    exerciseNum: "",
+    targetType: "",
+    targetValue: "",
+    version: 0,
     simple: true,
+    exercises: [exercise],
     access: 1,
-    exerciseNum: 0,
-    totalSets: 0,
-    exercises: [],
-    distance
+    essence: 0,
+    estimatedTime: 0,
+    originEssence: 0,
+    overview: "",
+    type: 0,
+    unit: 0,
+    pbVersion: 2,
+    sourceId: RUN_TRAINING_EXERCISE_SOURCE_ID,
+    sourceUrl: RUN_TRAINING_EXERCISE_SOURCE_URL,
+    referExercise: { intensityType: 0, hrType: 0, valueType: 0 },
+    poolLengthId: 1,
+    poolLength: 2500,
+    poolLengthUnit: 2,
+    distance: distance.toFixed(2),
+    duration: 0,
+    trainingLoad: 0,
+    pitch: 0,
+    exerciseBarChart: [barChartEntry],
+    distanceDisplayUnit: 1
   };
 }
 

--- a/electron/trainingHubService.ts
+++ b/electron/trainingHubService.ts
@@ -1237,13 +1237,16 @@ export async function createAndScheduleWorkout(
 ): Promise<{ programId?: string }> {
   const entry = toPlanWorkoutEntry(entryInput);
   const payload = buildWorkoutPayloadFromEntry(entry);
-  let program = structuredClone(payload) as Record<string, unknown>;
+  // Schedule the freshly-built payload, not the library read-back. The library
+  // list endpoint returns a summary that omits distance/simple/exerciseNum for a
+  // simple distance run, so scheduling it drops the distance target (Volume "--").
+  const program = structuredClone(payload) as Record<string, unknown>;
   let programId: string | undefined;
 
   if (saveToLibrary) {
-    const created = await createWorkoutProgram(program);
+    const created = await createWorkoutProgram(payload);
     programId = created.programId;
-    program = created.program;
+    program.id = programId;
   }
 
   await scheduleWorkoutOnDate(program, happenDay, entryInput.sort_no ?? 1);
@@ -1510,13 +1513,16 @@ export async function uploadTrainingPlan(
   for (const entry of draft.workouts) {
     const payload = buildWorkoutPayloadFromEntry(entry);
     const saveToLibrary = entry.save_to_library !== false;
-    let program = structuredClone(payload) as Record<string, unknown>;
+    // Schedule the freshly-built payload, not the library read-back. The library
+    // list endpoint returns a summary that omits distance/simple/exerciseNum for a
+    // simple distance run, so scheduling it drops the distance target (Volume "--").
+    const program = structuredClone(payload) as Record<string, unknown>;
     let programId: string | undefined;
 
     if (saveToLibrary) {
-      const created = await createWorkoutProgram(program);
+      const created = await createWorkoutProgram(payload);
       programId = created.programId;
-      program = created.program;
+      program.id = programId;
       workoutsCreated += 1;
     }
 
@@ -1864,6 +1870,17 @@ function resolveWorkoutDistanceMeters(
 
   if (estimatedDistance > 0) {
     return estimatedDistance;
+  }
+
+  // Simple distance runs come back with distance/estimatedDistance zeroed out —
+  // COROS keeps the target only in the program-level targetType/targetValue
+  // (targetType 5 = distance, targetValue in centimeters). Read it so the
+  // calendar shows the planned km instead of Volume "--".
+  const programTargetType = toOptionalNumber(program.targetType);
+  const programTargetValue = toOptionalNumber(program.targetValue);
+
+  if (programTargetType === 5 && programTargetValue && programTargetValue > 0) {
+    return corosWorkoutDistanceToMeters(programTargetValue);
   }
 
   const exercises = Array.isArray(program.exercises) ? program.exercises : [];

--- a/scripts/test-coros-workout-builder.mjs
+++ b/scripts/test-coros-workout-builder.mjs
@@ -26,8 +26,22 @@ assert.equal(pace.intensity_display_unit, 2);
 
 const easy = buildEasyRun({ name: "7km Easy", distanceKm: 7 });
 assert.equal(easy.name, "7km Easy");
-assert.equal(easy.distance, 700000);
 assert.equal(easy.simple, true);
+// A distance run must carry ONE real exercise carrying the distance target —
+// mirroring the official web app. With exercises: [] COROS zeroes the stored
+// program.distance and the calendar reads back Volume "--".
+assert.equal(easy.distance, "700000.00");
+assert.equal(Array.isArray(easy.exercises), true);
+assert.equal(easy.exercises.length, 1);
+const easyExercise = easy.exercises[0];
+assert.equal(easyExercise.exerciseType, 2);
+assert.equal(easyExercise.targetType, 5);
+assert.equal(easyExercise.targetValue, 700000);
+// Program-level target fields are empty strings; the target lives on the exercise.
+assert.equal(easy.targetType, "");
+assert.equal(easy.targetValue, "");
+assert.equal(Array.isArray(easy.exerciseBarChart), true);
+assert.equal(easy.exerciseBarChart[0].targetValue, 700000);
 
 const intervals = buildIntervalWorkout({
   name: "Rolling 400s",
@@ -67,6 +81,25 @@ const payload = buildRunWorkoutPayload("Tempo 5k", [
   }
 ]);
 assert.equal(payload.estimatedDistance, 500000);
+
+// Load target (COROS targetType 6): raw integer, no unit scaling.
+const loadPayload = buildRunWorkoutPayload("Load Block", [
+  { kind: "training", target_type: "load", target_load: 45 }
+]);
+const loadExercise = loadPayload.exercises[0];
+assert.equal(loadExercise.targetType, 6);
+assert.equal(loadExercise.targetValue, 45);
+// A load step contributes no distance/time to the estimate.
+assert.equal(loadPayload.estimatedDistance, 0);
+assert.equal(loadPayload.estimatedTime, 0);
+
+// Open / manual-end target (COROS targetType 1): run until lap, no value.
+const openPayload = buildRunWorkoutPayload("Open Warmup", [
+  { kind: "warmup", target_type: "open" }
+]);
+const openExercise = openPayload.exercises[0];
+assert.equal(openExercise.targetType, 1);
+assert.equal(openExercise.targetValue, 0);
 
 const valid = validatePlanDraft({
   name: "Test Week",


### PR DESCRIPTION
Coach-created runs showed Volume "--" on the calendar. Two causes:

- Read path: COROS stores a simple distance run with program.distance zeroed and the target only in program-level targetType/targetValue. resolveWorkoutDistanceMeters never read targetValue, so it computed 0. Now falls back to program targetType 5 / targetValue.
- Write path: buildEasyRun emitted a bare `simple` run with exercises: [], which COROS stores with distance zeroed. Now mirrors the official web app's single-exercise payload (exerciseType 2 + exerciseBarChart), so distance populates natively everywhere. Also schedule the freshly-built payload instead of the library-list summary, which drops distance fields.

Add the two remaining COROS run target types (enum + value encoding extracted from the traininghub web-app bundle): load (targetType 6, raw integer) and open/manual-end (targetType 1, no value). Wire them through the builder, the draft_training_plan tool schema, and the coach prompt with guidance on when to use each. Document the full targetType enum.

Verified against the live COROS API (create/read-back/delete) and via build + workout-builder tests + renderer typecheck.

## Description
<!-- Briefly describe what this PR does and why -->


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Improvement / enhancement
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [ ] Breaking change

## How to Test
<!-- Steps to verify your changes work correctly -->
1. 
2. 

## Checklist
- [x] I have tested my changes
- [ ] My changes do not break existing functionality
- [ ] I have added comments where necessary
