### PR TITLE
Fix resumable combined downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Combined playlist downloads now detect completed temporary MP3s reliably, preserve actionable download errors, and resume retries from cached tracks instead of downloading the whole playlist again.
+
 ## [0.1.21] - 2026-07-21
 
 ### Added

--- a/electron/combinedDownloadCache.ts
+++ b/electron/combinedDownloadCache.ts
@@ -1,0 +1,110 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export const COMBINED_DOWNLOAD_CACHE_VERSION = 1;
+export const COMBINED_DOWNLOAD_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Includes both the service-scoped playlist id and the resolved download
+ * inputs. Retrying the same playlist reuses completed tracks, while edits to
+ * the playlist automatically move the operation to a fresh cache directory.
+ */
+export function createCombinedDownloadCacheKey(
+  id: string,
+  inputs: string[]
+): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        version: COMBINED_DOWNLOAD_CACHE_VERSION,
+        id,
+        inputs
+      })
+    )
+    .digest("hex");
+}
+
+export function combinedTrackCompletionMarker(filePath: string): string {
+  return `${filePath}.complete`;
+}
+
+/**
+ * The marker is written only after yt-dlp exits and the MP3 is detected. This
+ * prevents a non-empty but partially written file left by a crash from being
+ * mistaken for a completed track on the next launch.
+ */
+export async function markCombinedTrackReusable(
+  filePath: string
+): Promise<void> {
+  await fs.promises.writeFile(
+    combinedTrackCompletionMarker(filePath),
+    "complete\n",
+    "utf8"
+  );
+}
+
+export async function isReusableCombinedTrack(
+  filePath: string
+): Promise<boolean> {
+  try {
+    const [stat] = await Promise.all([
+      fs.promises.stat(filePath),
+      fs.promises.access(combinedTrackCompletionMarker(filePath))
+    ]);
+    return stat.isFile() && stat.size > 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function touchCombinedDownloadCache(
+  directory: string,
+  now = new Date()
+): Promise<void> {
+  await fs.promises.utimes(directory, now, now).catch(() => {});
+}
+
+/** Removes abandoned caches without touching combines active in this process. */
+export async function pruneCombinedDownloadCache(
+  rootDirectory: string,
+  activeKeys: ReadonlySet<string>,
+  now = Date.now(),
+  maxAgeMs = COMBINED_DOWNLOAD_CACHE_MAX_AGE_MS
+): Promise<void> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(rootDirectory, {
+      withFileTypes: true
+    });
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return;
+    }
+    throw error;
+  }
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isDirectory() || activeKeys.has(entry.name)) {
+        return;
+      }
+
+      const directory = path.join(rootDirectory, entry.name);
+      try {
+        const stat = await fs.promises.stat(directory);
+        if (now - stat.mtimeMs <= maxAgeMs) {
+          return;
+        }
+        await fs.promises.rm(directory, { recursive: true, force: true });
+      } catch {
+        // Cache cleanup is best-effort and must never block a download.
+      }
+    })
+  );
+}

--- a/electron/downloadProgress.ts
+++ b/electron/downloadProgress.ts
@@ -202,6 +202,54 @@ export function partitionDownloadedMp3Files(
   return { newFiles, existingFiles };
 }
 
+/**
+ * Selects the MP3 produced by one combined-download track. The temporary
+ * directory is private to the combine operation, so a directory diff is a
+ * reliable fallback when yt-dlp's `after_move` line is missing, split across
+ * output chunks, or formatted differently on another platform.
+ */
+export function selectCombinedTrackOutput(
+  before: Set<string>,
+  printedPaths: string[],
+  after: string[],
+  expectedPath: string
+): string | null {
+  const { newFiles } = partitionDownloadedMp3Files(
+    before,
+    printedPaths,
+    after
+  );
+
+  return (
+    newFiles.find((filePath) => filePath === expectedPath) ??
+    newFiles[0] ??
+    null
+  );
+}
+
+export function summarizeCombinedTrackFailures(failures: string[]): string {
+  const normalized = failures
+    .map((failure) => failure.replace(/\s+/g, " ").trim())
+    .filter(Boolean);
+
+  if (normalized.length === 0) {
+    return "None of the playlist tracks could be downloaded, so there was nothing to combine.";
+  }
+
+  const firstFailure = normalized[0];
+  const preview =
+    firstFailure.length > 500
+      ? `${firstFailure.slice(0, 497)}…`
+      : firstFailure;
+  const remaining = normalized.length - 1;
+
+  return `None of the playlist tracks could be downloaded. First failure: ${preview}${
+    remaining > 0
+      ? ` (${remaining} more track${remaining === 1 ? "" : "s"} also failed.)`
+      : ""
+  }`;
+}
+
 function resolveMp3InOutputDirectory(
   candidate: string,
   outputDirectory: string

--- a/electron/downloadService.ts
+++ b/electron/downloadService.ts
@@ -1,9 +1,16 @@
 import { app } from "electron";
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import {
+  combinedTrackCompletionMarker,
+  createCombinedDownloadCacheKey,
+  isReusableCombinedTrack,
+  markCombinedTrackReusable,
+  pruneCombinedDownloadCache,
+  touchCombinedDownloadCache
+} from "./combinedDownloadCache";
 import { addDownloads } from "./database";
 import {
   parseYtDlpProgressLine,
@@ -12,7 +19,9 @@ import {
   partitionDownloadedMp3Files,
   buildPlaylistCompletionWarning,
   parsePlaylistTrackMarker,
-  isYtDlpErrorLine
+  isYtDlpErrorLine,
+  selectCombinedTrackOutput,
+  summarizeCombinedTrackFailures
 } from "./downloadProgress";
 import type {
   BinaryCheck,
@@ -56,6 +65,7 @@ interface DownloadRuntimeOptions {
 }
 
 const runningProcesses = new Map<string, ChildProcess>();
+const activeCombinedDownloadCaches = new Set<string>();
 
 export function cancelDownloadProcess(jobId: string): boolean {
   const child = runningProcesses.get(jobId);
@@ -184,6 +194,7 @@ interface ResolvedCombinedItem {
  * warnings rather than aborting the whole combine.
  */
 export async function downloadCombinedTrack(
+  id: string,
   name: string,
   items: DownloadQueueItem[],
   onProgress?: (update: CombinedDownloadProgress) => void,
@@ -207,15 +218,37 @@ export async function downloadCombinedTrack(
 
   const ytDlp = resolveBinary("yt-dlp");
   const ffmpeg = resolveBinary("ffmpeg");
-  const workDir = await fs.promises.mkdtemp(
-    path.join(os.tmpdir(), "coroslink-combined-")
+  const cacheRoot = path.join(
+    app.getPath("userData"),
+    "combined-download-cache"
   );
+  const cacheKey = createCombinedDownloadCacheKey(
+    id,
+    resolved.map((item) => item.input)
+  );
+
+  await pruneCombinedDownloadCache(
+    cacheRoot,
+    activeCombinedDownloadCaches
+  );
+  if (activeCombinedDownloadCaches.has(cacheKey)) {
+    throw new Error("This combined playlist download is already in progress.");
+  }
+
+  activeCombinedDownloadCaches.add(cacheKey);
+  const workDir = path.join(cacheRoot, cacheKey);
 
   const downloadedFiles: string[] = [];
   const warnings: string[] = [];
+  const failures: string[] = [];
   const total = resolved.length;
+  let reusedCount = 0;
+  let shouldRemoveCache = false;
 
   try {
+    await fs.promises.mkdir(workDir, { recursive: true });
+    await touchCombinedDownloadCache(workDir);
+
     for (let index = 0; index < resolved.length; index += 1) {
       if (runtime?.isCancelled?.()) {
         throw new DownloadCancelledError();
@@ -226,6 +259,28 @@ export async function downloadCombinedTrack(
         workDir,
         `${String(index).padStart(4, "0")}.%(ext)s`
       );
+      const cachedFilePath = outputTemplate.replace(/\.%\(ext\)s$/, ".mp3");
+
+      if (await isReusableCombinedTrack(cachedFilePath)) {
+        downloadedFiles.push(cachedFilePath);
+        reusedCount += 1;
+        onProgress?.({
+          phase: "downloading",
+          index: index + 1,
+          total,
+          title: item.title,
+          trackProgress: 1,
+          reused: true
+        });
+        continue;
+      }
+
+      // An unmarked or zero-byte MP3 may have been interrupted mid-write.
+      // Remove it so yt-dlp cannot mistake the track for a completed download.
+      await fs.promises.rm(cachedFilePath, { force: true }).catch(() => {});
+      await fs.promises
+        .rm(combinedTrackCompletionMarker(cachedFilePath), { force: true })
+        .catch(() => {});
 
       onProgress?.({
         phase: "downloading",
@@ -252,27 +307,23 @@ export async function downloadCombinedTrack(
           runtime
         );
 
-        if (filePath) {
-          downloadedFiles.push(filePath);
-        } else {
-          warnings.push(`Skipped "${item.title}" — no audio was produced.`);
-        }
+        downloadedFiles.push(filePath);
+        await markCombinedTrackReusable(filePath);
+        await touchCombinedDownloadCache(workDir);
       } catch (error) {
         if (error instanceof DownloadCancelledError) {
           throw error;
         }
-        warnings.push(
-          `Skipped "${item.title}" — ${
-            error instanceof Error ? error.message : String(error)
-          }`
-        );
+        const failure = `"${item.title}": ${
+          error instanceof Error ? error.message : String(error)
+        }`;
+        failures.push(failure);
+        warnings.push(`Skipped ${failure}`);
       }
     }
 
     if (downloadedFiles.length === 0) {
-      throw new Error(
-        "None of the playlist tracks could be downloaded, so there was nothing to combine."
-      );
+      throw new Error(summarizeCombinedTrackFailures(failures));
     }
 
     onProgress?.({
@@ -308,16 +359,27 @@ export async function downloadCombinedTrack(
       trackProgress: 1
     });
 
+    // Keep successful source tracks when some playlist items were skipped, so
+    // another attempt needs to fetch only the missing items. A fully complete
+    // combine has nothing left to resume and can discard its cache immediately.
+    shouldRemoveCache = warnings.length === 0;
+
     return {
       track,
       downloadedCount: downloadedFiles.length,
+      reusedCount,
       totalCount: total,
       ...(warnings.length ? { warnings } : {})
     };
   } finally {
-    await fs.promises
-      .rm(workDir, { recursive: true, force: true })
-      .catch(() => {});
+    activeCombinedDownloadCaches.delete(cacheKey);
+    if (shouldRemoveCache) {
+      await fs.promises
+        .rm(workDir, { recursive: true, force: true })
+        .catch(() => {});
+    } else {
+      await touchCombinedDownloadCache(workDir);
+    }
   }
 }
 
@@ -359,9 +421,10 @@ function resolveCombinedItem(
 
 /**
  * Downloads a single track as an MP3 into the directory implied by
- * `outputTemplate` and returns the resulting file path, or null if nothing was
- * produced. Unlike {@link runAudioDownload} this does not touch the database —
- * the caller merges the temp files and registers the final artifact.
+ * `outputTemplate` and returns the resulting file path. Unlike
+ * {@link runAudioDownload} this does not touch the database — the caller merges
+ * the temp files and registers the final artifact. A missing MP3 is an error so
+ * the combine can preserve the actual yt-dlp/ffmpeg diagnostic for the user.
  */
 async function downloadSingleTrackFile(
   input: string,
@@ -370,7 +433,7 @@ async function downloadSingleTrackFile(
   ffmpeg: ResolvedBinary,
   onFraction: (fraction: number) => void,
   runtime?: DownloadRuntimeOptions
-): Promise<string | null> {
+): Promise<string> {
   const args = [
     "--no-playlist",
     "--no-mtime",
@@ -397,6 +460,8 @@ async function downloadSingleTrackFile(
   args.push(input);
 
   const targetDir = path.dirname(outputTemplate);
+  const beforeMp3Files = new Set(listMp3Files(targetDir));
+  const beforeArtifacts = new Set(listMediaArtifacts(targetDir));
   const printedPaths: string[] = [];
 
   const onLine = (line: string) => {
@@ -411,18 +476,52 @@ async function downloadSingleTrackFile(
     }
   };
 
-  await runProcess(ytDlp.command, args, onLine, runtime);
+  const { lines, exitCode } = await runProcess(
+    ytDlp.command,
+    args,
+    onLine,
+    runtime
+  );
 
   if (runtime?.isCancelled?.()) {
     throw new DownloadCancelledError();
   }
 
   const expected = outputTemplate.replace(/\.%\(ext\)s$/, ".mp3");
-  const produced =
-    printedPaths.find((filePath) => filePath.toLowerCase().endsWith(".mp3")) ??
-    (fs.existsSync(expected) ? expected : null);
+  const afterMp3Files = listMp3Files(targetDir);
+  const produced = selectCombinedTrackOutput(
+    beforeMp3Files,
+    printedPaths,
+    afterMp3Files,
+    expected
+  );
 
-  return produced && fs.existsSync(produced) ? produced : null;
+  if (produced && fs.existsSync(produced)) {
+    if (fs.existsSync(expected)) {
+      return expected;
+    }
+
+    // Keep resumable cache filenames deterministic even if yt-dlp reports a
+    // platform-specific output name that differs from the template.
+    await fs.promises.rename(produced, expected);
+    return expected;
+  }
+
+  const newArtifacts = listMediaArtifacts(targetDir).filter(
+    (filePath) => !beforeArtifacts.has(filePath)
+  );
+
+  if (exitCode !== 0 && exitCode !== null) {
+    throw buildProcessError(path.basename(ytDlp.command), exitCode, lines);
+  }
+
+  throw buildNoMp3Error({
+    output: lines,
+    ytDlp,
+    ffmpeg,
+    newArtifacts,
+    exitCode
+  });
 }
 
 /**
@@ -963,6 +1062,7 @@ function runProcess(
 ): Promise<ProcessResult> {
   return new Promise((resolve, reject) => {
     const lines: string[] = [];
+    const pending = { stdout: "", stderr: "" };
     const child = spawn(command, args, {
       windowsHide: true,
       env: {
@@ -975,23 +1075,37 @@ function runProcess(
       runningProcesses.set(runtime.jobId, child);
     }
 
-    const capture = (chunk: Buffer): void => {
-      for (const line of chunk.toString().split(/\r?\n/)) {
-        const trimmed = line.trim();
-        if (!trimmed) {
-          continue;
-        }
+    const captureLine = (line: string): void => {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        return;
+      }
 
-        onLine?.(trimmed);
-        lines.push(trimmed);
-        if (lines.length > MAX_CAPTURED_LINES) {
-          lines.shift();
-        }
+      onLine?.(trimmed);
+      lines.push(trimmed);
+      if (lines.length > MAX_CAPTURED_LINES) {
+        lines.shift();
       }
     };
 
-    child.stdout.on("data", capture);
-    child.stderr.on("data", capture);
+    const capture = (
+      stream: keyof typeof pending,
+      chunk: Buffer
+    ): void => {
+      const parts = `${pending[stream]}${chunk.toString()}`.split(/\r\n|\n|\r/);
+      pending[stream] = parts.pop() ?? "";
+      parts.forEach(captureLine);
+    };
+
+    const flush = (stream: keyof typeof pending): void => {
+      captureLine(pending[stream]);
+      pending[stream] = "";
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => capture("stdout", chunk));
+    child.stderr.on("data", (chunk: Buffer) => capture("stderr", chunk));
+    child.stdout.on("end", () => flush("stdout"));
+    child.stderr.on("end", () => flush("stderr"));
     child.on("error", (error) => {
       if (runtime?.jobId) {
         runningProcesses.delete(runtime.jobId);
@@ -999,6 +1113,8 @@ function runProcess(
       reject(error);
     });
     child.on("close", (code) => {
+      flush("stdout");
+      flush("stderr");
       if (runtime?.jobId) {
         runningProcesses.delete(runtime.jobId);
       }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1182,7 +1182,7 @@ function registerIpcHandlers(): void {
       name: string,
       items: DownloadQueueItem[]
     ): Promise<CombinedDownloadResult> =>
-      downloadCombinedTrack(name, items, (update) => {
+      downloadCombinedTrack(id, name, items, (update) => {
         event.sender.send("music:combinedProgress", { id, ...update });
       })
   );

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -1188,6 +1188,8 @@ export interface CombinedDownloadProgress {
   title: string;
   /** 0..1 progress of the current track download. */
   trackProgress: number;
+  /** The track was already present from an earlier interrupted attempt. */
+  reused?: boolean;
 }
 
 /**
@@ -1203,6 +1205,8 @@ export interface CombinedDownloadResult {
   track: LocalTrack;
   /** Number of source tracks that were successfully downloaded and merged. */
   downloadedCount: number;
+  /** Number of tracks restored from a previous attempt's cache. */
+  reusedCount: number;
   /** Number of source tracks requested. */
   totalCount: number;
   warnings?: string[];

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "test:watch-models": "npm run build:electron && node scripts/test-watch-models.mjs",
     "test:maps": "npm run build:electron && node scripts/test-maps.mjs",
     "test:apple-podcasts": "npm run build:electron && node scripts/test-apple-podcasts.mjs",
+    "test:combined-download-cache": "npm run build:electron && node scripts/test-combined-download-cache.mjs",
+    "test:download-progress": "npm run build:electron && node scripts/test-download-progress.mjs",
     "test:route-location": "node --experimental-strip-types scripts/test-route-location.mjs",
     "test:route-overlap": "node --experimental-strip-types scripts/test-route-overlap.mjs",
     "test:sketch": "npm run build:electron && node scripts/test-sketch-geometry.mjs",

--- a/scripts/test-combined-download-cache.mjs
+++ b/scripts/test-combined-download-cache.mjs
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  combinedTrackCompletionMarker,
+  createCombinedDownloadCacheKey,
+  isReusableCombinedTrack,
+  markCombinedTrackReusable,
+  pruneCombinedDownloadCache,
+  touchCombinedDownloadCache
+} from "../dist-electron/combinedDownloadCache.js";
+
+const inputs = [
+  "ytsearch1:Artist Track official audio",
+  "https://www.youtube.com/watch?v=abcdefghijk"
+];
+const key = createCombinedDownloadCacheKey("spotify:playlist-1", inputs);
+
+assert.match(key, /^[a-f0-9]{64}$/);
+assert.equal(
+  createCombinedDownloadCacheKey("spotify:playlist-1", inputs),
+  key,
+  "the same playlist revision should get the same resume cache"
+);
+assert.notEqual(
+  createCombinedDownloadCacheKey("spotify:playlist-2", inputs),
+  key,
+  "service-scoped playlist ids must not share caches"
+);
+assert.notEqual(
+  createCombinedDownloadCacheKey("spotify:playlist-1", [...inputs, "new"]),
+  key,
+  "editing a playlist should create a fresh cache"
+);
+
+const root = fs.mkdtempSync(
+  path.join(os.tmpdir(), "coroslink-combined-cache-test-")
+);
+
+try {
+  const reusableTrack = path.join(root, "0000.mp3");
+  const emptyTrack = path.join(root, "0001.mp3");
+  fs.writeFileSync(reusableTrack, "mp3-data");
+  fs.writeFileSync(emptyTrack, "");
+
+  assert.equal(
+    await isReusableCombinedTrack(reusableTrack),
+    false,
+    "an MP3 left mid-write must not be reused without its completion marker"
+  );
+  await markCombinedTrackReusable(reusableTrack);
+  await markCombinedTrackReusable(emptyTrack);
+  assert.equal(await isReusableCombinedTrack(reusableTrack), true);
+  assert.equal(await isReusableCombinedTrack(emptyTrack), false);
+  assert.equal(
+    fs.existsSync(combinedTrackCompletionMarker(reusableTrack)),
+    true
+  );
+  assert.equal(
+    await isReusableCombinedTrack(path.join(root, "missing.mp3")),
+    false
+  );
+
+  const now = Date.now();
+  const oldKey = "old-cache";
+  const recentKey = "recent-cache";
+  const activeKey = "active-cache";
+  const oldDirectory = path.join(root, oldKey);
+  const recentDirectory = path.join(root, recentKey);
+  const activeDirectory = path.join(root, activeKey);
+
+  fs.mkdirSync(oldDirectory);
+  fs.mkdirSync(recentDirectory);
+  fs.mkdirSync(activeDirectory);
+  const oldDate = new Date(now - 10_000);
+  fs.utimesSync(oldDirectory, oldDate, oldDate);
+  fs.utimesSync(activeDirectory, oldDate, oldDate);
+
+  await pruneCombinedDownloadCache(
+    root,
+    new Set([activeKey]),
+    now,
+    5_000
+  );
+
+  assert.equal(fs.existsSync(oldDirectory), false, "expired caches are removed");
+  assert.equal(fs.existsSync(recentDirectory), true, "recent caches are retained");
+  assert.equal(fs.existsSync(activeDirectory), true, "active caches are retained");
+
+  await touchCombinedDownloadCache(activeDirectory, new Date(now));
+  assert.ok(fs.statSync(activeDirectory).mtimeMs >= now - 1);
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+console.log("combined download cache tests passed");

--- a/scripts/test-download-progress.mjs
+++ b/scripts/test-download-progress.mjs
@@ -10,7 +10,9 @@ import {
   parseAlreadyDownloadedPath,
   parsePlaylistTrackMarker,
   parseYtDlpProgressLine,
-  partitionDownloadedMp3Files
+  partitionDownloadedMp3Files,
+  selectCombinedTrackOutput,
+  summarizeCombinedTrackFailures
 } from "../dist-electron/downloadProgress.js";
 
 const samples = [
@@ -157,6 +159,27 @@ assert.deepEqual(partitionDownloadedMp3Files(before, [], after), {
   newFiles: [relativeMp3, "/tmp/new.mp3", "/tmp/also-new.mp3"],
   existingFiles: []
 });
+
+const combinedExpected = path.join(downloadDir, "0000.mp3");
+fs.writeFileSync(combinedExpected, "fake");
+assert.equal(
+  selectCombinedTrackOutput(
+    new Set([absoluteMp3, relativeMp3]),
+    [],
+    [absoluteMp3, relativeMp3, combinedExpected],
+    combinedExpected
+  ),
+  combinedExpected,
+  "combined downloads should find an MP3 from the private temp-directory diff when after_move output is missing"
+);
+
+assert.match(
+  summarizeCombinedTrackFailures([
+    '"Track one": yt-dlp exited with code 1. ERROR: Video unavailable',
+    '"Track two": no audio was produced.'
+  ]),
+  /First failure: "Track one".*1 more track also failed/
+);
 
 fs.rmSync(downloadDir, { recursive: true, force: true });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -851,7 +851,10 @@ export default function App() {
           if (!current[id]?.busy) {
             return current;
           }
-          return { ...current, [id]: { busy: true, progress } };
+          return {
+            ...current,
+            [id]: { busy: true, progress, error: undefined },
+          };
         });
       },
     );
@@ -1317,32 +1320,57 @@ export default function App() {
 
     setCombinedDownloads((current) => ({
       ...current,
-      [id]: { busy: true, progress: null },
+      [id]: { busy: true, progress: null, error: undefined },
     }));
     setError(null);
     setMessage(null);
 
+    let result;
     try {
-      const result = await api.downloadCombinedPlaylist(id, name, items);
-      const skipped = result.totalCount - result.downloadedCount;
-      setMessage(
-        `Combined ${result.downloadedCount} track${
-          result.downloadedCount === 1 ? "" : "s"
-        } into “${result.track.title}”.${
-          skipped > 0
-            ? ` ${skipped} track${skipped === 1 ? "" : "s"} could not be downloaded.`
-            : ""
-        }`,
-      );
+      result = await api.downloadCombinedPlaylist(id, name, items);
+    } catch (caught) {
+      const error = toErrorMessage(caught);
+      setError(error);
+      setCombinedDownloads((current) => ({
+        ...current,
+        [id]: { busy: false, progress: null, error },
+      }));
+      return;
+    }
+
+    const skipped = result.totalCount - result.downloadedCount;
+    const reused = result.reusedCount;
+    setMessage(
+      `Combined ${result.downloadedCount} track${
+        result.downloadedCount === 1 ? "" : "s"
+      } into “${result.track.title}”.${
+        reused > 0
+          ? ` Reused ${reused} cached track${reused === 1 ? "" : "s"}.`
+          : ""
+      }${
+        skipped > 0
+          ? ` ${skipped} track${skipped === 1 ? "" : "s"} could not be downloaded; retry to fetch only the missing ${skipped === 1 ? "track" : "tracks"}.`
+          : ""
+      }`,
+    );
+    setCombinedDownloads((current) => {
+      const next = { ...current };
+      if (skipped > 0) {
+        next[id] = {
+          busy: false,
+          progress: null,
+          retryMissingCount: skipped,
+        };
+      } else {
+        delete next[id];
+      }
+      return next;
+    });
+
+    try {
       await refreshAll();
     } catch (caught) {
       setError(toErrorMessage(caught));
-    } finally {
-      setCombinedDownloads((current) => {
-        const next = { ...current };
-        delete next[id];
-        return next;
-      });
     }
   }
 
@@ -3734,6 +3762,8 @@ interface SpotifySyncViewProps {
 interface CombinedDownloadState {
   busy: boolean;
   progress: CombinedDownloadProgress | null;
+  error?: string;
+  retryMissingCount?: number;
 }
 
 /** Per-playlist combined-download state, keyed by a service-scoped playlist id. */
@@ -3744,6 +3774,8 @@ interface CombinedDownloadButtonProps {
   items: DownloadQueueItem[];
   busy: boolean;
   progress: CombinedDownloadProgress | null;
+  error?: string;
+  retryMissingCount?: number;
   onDownload: (name: string, items: DownloadQueueItem[]) => void;
 }
 
@@ -3758,6 +3790,8 @@ function CombinedDownloadButton({
   items,
   busy,
   progress,
+  error,
+  retryMissingCount,
   onDownload,
 }: CombinedDownloadButtonProps) {
   const [editing, setEditing] = useState(false);
@@ -3779,9 +3813,11 @@ function CombinedDownloadButton({
         ? "Merging tracks…"
         : progress?.phase === "completed"
           ? "Finishing…"
-          : progress
-            ? `Downloading ${progress.index}/${progress.total}`
-            : "Preparing…";
+          : progress?.reused
+            ? `Reusing ${progress.index}/${progress.total}`
+            : progress
+              ? `Downloading ${progress.index}/${progress.total}`
+              : "Preparing…";
     return (
       <div
         className="combined-download combined-download--busy"
@@ -3801,16 +3837,36 @@ function CombinedDownloadButton({
 
   if (!editing) {
     return (
-      <button
-        className="secondary-button combined-download-trigger"
-        type="button"
-        disabled={items.length === 0}
-        onClick={() => setEditing(true)}
-        title="Download every track and merge into one MP3"
+      <div
+        className={`combined-download${
+          error ? " combined-download--failed" : ""
+        }`}
       >
-        <Combine size={16} aria-hidden="true" />
-        Combined download
-      </button>
+        <button
+          className="secondary-button combined-download-trigger"
+          type="button"
+          disabled={items.length === 0}
+          onClick={() => setEditing(true)}
+          title="Download every track and merge into one MP3"
+        >
+          <Combine size={16} aria-hidden="true" />
+          {error
+            ? "Retry combined download"
+            : retryMissingCount
+              ? `Retry ${retryMissingCount} missing track${retryMissingCount === 1 ? "" : "s"}`
+              : "Combined download"}
+        </button>
+        {error ? (
+          <span
+            className="combined-download-error"
+            role="alert"
+            title={error}
+          >
+            <AlertCircle size={14} aria-hidden="true" />
+            <span>{error}</span>
+          </span>
+        ) : null}
+      </div>
     );
   }
 
@@ -4462,6 +4518,8 @@ function YouTubeMusicPlaylistDetail({
               items={combinedItems}
               busy={combinedState?.busy ?? false}
               progress={combinedState?.progress ?? null}
+              error={combinedState?.error}
+              retryMissingCount={combinedState?.retryMissingCount}
               onDownload={(name, items) =>
                 onCombinedDownload(combinedId, name, items)
               }
@@ -5185,6 +5243,8 @@ function SpotifyPlaylistDetail({
               items={combinedItems}
               busy={combinedState?.busy ?? false}
               progress={combinedState?.progress ?? null}
+              error={combinedState?.error}
+              retryMissingCount={combinedState?.retryMissingCount}
               onDownload={(name, items) =>
                 onCombinedDownload(combinedId, name, items)
               }
@@ -6924,6 +6984,8 @@ function AppleMusicPlaylistDetail({
               items={combinedItems}
               busy={combinedState?.busy ?? false}
               progress={combinedState?.progress ?? null}
+              error={combinedState?.error}
+              retryMissingCount={combinedState?.retryMissingCount}
               onDownload={(name, items) =>
                 onCombinedDownload(combinedId, name, items)
               }

--- a/src/styles.css
+++ b/src/styles.css
@@ -9605,6 +9605,35 @@ td span {
   white-space: nowrap;
 }
 
+.combined-download--failed {
+  max-width: 320px;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
+.combined-download-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 5px;
+  max-width: 320px;
+  color: #fca5a5;
+  font-size: 0.72rem;
+  line-height: 1.35;
+  text-align: left;
+}
+
+.combined-download-error > svg {
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+
+.combined-download-error > span {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
 .combined-download-form {
   padding: 4px;
   border: 1px solid rgba(255, 255, 255, 0.16);


### PR DESCRIPTION
## Summary

- reliably detect temporary MP3 outputs produced during combined playlist downloads
- preserve actionable yt-dlp/ffmpeg failures in persistent playlist UI
- cache completed source tracks so retries, interruptions, and app restarts only fetch missing tracks
- retain partial-attempt caches for seven days and remove complete caches immediately
- mark cached tracks complete only after yt-dlp exits, avoiding reuse of crash-truncated files

## Root cause

The combine flow trusted a parsed `after_move` output path and reduced every per-track failure to a skipped warning. If output parsing missed a generated MP3, or conversion failed, the final list appeared empty and the UI showed only the generic “nothing to combine” error. Temporary tracks were always deleted in `finally`, forcing a full re-download on retry.

## User impact

Combined downloads can now recover their generated MP3s reliably. When a track or final merge fails, the actual cause remains visible. Retrying reuses completed tracks, downloads only missing items, and exposes this through “Reusing” progress plus a “Retry N missing tracks” control.

## Validation

- `npm run test:combined-download-cache`
- `npm run test:download-progress`
- `npm run build:renderer`
- `git diff --check`
