### PR TITLE
Improve Watch Studio metrics and controls

### DIFF
--- a/scripts/test-watchface-studio.mjs
+++ b/scripts/test-watchface-studio.mjs
@@ -2611,6 +2611,66 @@ assert.deepEqual(
     { id: "temperature", label: "Temperature", active: false }
   ]
 );
+const sparseMetricDetails = {
+  ...details,
+  resolutions: details.resolutions.map((resolution) => ({
+    ...resolution,
+    config: Object.fromEntries(
+      Object.entries(resolution.config).filter(([key]) =>
+        ![
+          "heartreate_level_rect",
+          "heartreate_level_font",
+          "step_rect",
+          "step_font",
+          "kcal_rect",
+          "kcal_font",
+          "exercise_hour_rect",
+          "exercise_minute_rect",
+          "exercise_font",
+          "elevation_rect",
+          "elevation_font",
+          "temperature_rect",
+          "temperature_font"
+        ].includes(key)
+      )
+    )
+  }))
+};
+assert.deepEqual(
+  getFixedMetricCapabilities(sparseMetricDetails),
+  [
+    { id: "battery", label: "Battery data", active: false },
+    { id: "heartRate", label: "Heart rate", active: false },
+    { id: "steps", label: "Steps", active: false },
+    { id: "calories", label: "Calories", active: false },
+    { id: "exercise", label: "Exercise", active: false },
+    { id: "elevation", label: "Elevation", active: false },
+    { id: "temperature", label: "Temperature", active: false }
+  ],
+  "every fixed metric should remain available when a template omits its config keys"
+);
+const addedSparseMetrics = applyConfigOverridesToDetails(
+  sparseMetricDetails,
+  buildMetricOverrides(sparseMetricDetails, {
+    heartRate: true,
+    steps: true,
+    calories: true,
+    elevation: true,
+    temperature: true
+  })
+);
+for (const resolution of addedSparseMetrics.resolutions) {
+  assert.match(resolution.config.heartreate_level_rect ?? "", /^\{/);
+  assert.equal(resolution.config.heartreate_level_font, "13x19");
+  assert.match(resolution.config.step_rect ?? "", /^\{/);
+  assert.equal(resolution.config.step_font, "13x19");
+  assert.match(resolution.config.kcal_rect ?? "", /^\{/);
+  assert.equal(resolution.config.kcal_font, "13x19");
+  assert.match(resolution.config.elevation_rect ?? "", /^\{/);
+  assert.equal(resolution.config.elevation_font, "13x19");
+  assert.match(resolution.config.temperature_rect ?? "", /^\{/);
+  assert.equal(resolution.config.temperature_font, "13x19");
+}
 assert.deepEqual(
   buildMetricOverrides(details, { exercise: false }),
   [],

--- a/src/watchfaces/WatchfaceEditor.tsx
+++ b/src/watchfaces/WatchfaceEditor.tsx
@@ -6645,7 +6645,13 @@ export function WatchfaceEditor({
                   disabled={spriteImportPending || previewingExport || creating || exporting || !backgroundDataUrl}
                   onClick={() => { setExportMenuOpen(false); void openExportPreview(); }}
                 >
-                  <Eye size={15} aria-hidden="true" /> Preview export
+                  <span className="wf-export-option-icon" aria-hidden="true">
+                    <Eye size={16} />
+                  </span>
+                  <span className="wf-export-option-copy">
+                    <strong>Preview export</strong>
+                    <small>Review the final render</small>
+                  </span>
                 </button>
                 <button
                   type="button"
@@ -6653,9 +6659,16 @@ export function WatchfaceEditor({
                   disabled={spriteImportPending || creating || exporting || !backgroundDataUrl}
                   onClick={() => { setExportMenuOpen(false); void exportEditableProject(); }}
                 >
-                  <Download size={15} aria-hidden="true" /> Editable project ZIP
+                  <span className="wf-export-option-icon" aria-hidden="true">
+                    <Download size={16} />
+                  </span>
+                  <span className="wf-export-option-copy">
+                    <strong>Editable project ZIP</strong>
+                    <small>Save an editable backup</small>
+                  </span>
                 </button>
                 <button
+                  className="is-convert"
                   type="button"
                   role="menuitem"
                   disabled={spriteImportPending || creating || exporting || !backgroundDataUrl}
@@ -6669,7 +6682,13 @@ export function WatchfaceEditor({
                     );
                   }}
                 >
-                  <Repeat2 size={15} aria-hidden="true" /> Convert to another watch
+                  <span className="wf-export-option-icon" aria-hidden="true">
+                    <Repeat2 size={16} />
+                  </span>
+                  <span className="wf-export-option-copy">
+                    <strong>Convert to another watch</strong>
+                    <small>Adapt the design for a new model</small>
+                  </span>
                 </button>
                 {showDevelopmentTools ? (
                   <button
@@ -6678,7 +6697,13 @@ export function WatchfaceEditor({
                     disabled={spriteImportPending || creating || exporting || !backgroundDataUrl}
                     onClick={() => { setExportMenuOpen(false); void createArchive("export"); }}
                   >
-                    <Package size={15} aria-hidden="true" /> Final watch ZIP (dev)
+                    <span className="wf-export-option-icon" aria-hidden="true">
+                      <Package size={16} />
+                    </span>
+                    <span className="wf-export-option-copy">
+                      <strong>Final watch ZIP</strong>
+                      <small>Development export</small>
+                    </span>
                   </button>
                 ) : null}
               </div>

--- a/src/watchfaces/watchfaceStudio.ts
+++ b/src/watchfaces/watchfaceStudio.ts
@@ -3934,7 +3934,7 @@ function fixedMetricValueParts(
   }];
 }
 
-/** Fixed metrics available to the editor and whether they are already active. */
+/** All fixed metrics the editor can add, and whether each is already active. */
 export function getFixedMetricCapabilities(
   details: CorosWatchfaceTemplateDetails
 ): WatchfaceMetricCapability[] {
@@ -3942,27 +3942,15 @@ export function getFixedMetricCapabilities(
   if (!resolution) {
     return [];
   }
-  return WATCHFACE_FIXED_METRICS.flatMap((metric) => {
-    // Battery and Exercise can be added to templates that did not originally
-    // declare them; buildMetricOverrides supplies their missing config entries.
-    const canAdd = metric.id === "battery" || metric.id === "exercise";
+  return WATCHFACE_FIXED_METRICS.map((metric) => {
     const parts = fixedMetricValueParts(metric);
-    const hasRect = parts.every((part) =>
-      Object.prototype.hasOwnProperty.call(resolution.config, part.rectKey)
-    );
-    const hasFont =
-      !metric.fontKey ||
-      metric.id === "temperature" ||
-      Object.prototype.hasOwnProperty.call(resolution.config, metric.fontKey);
-    return canAdd || (hasRect && hasFont)
-      ? [{
-          id: metric.id,
-          label: metric.label,
-          active: parts.every(
-            (part) => parseConfigRect(resolution.config[part.rectKey]) !== null
-          )
-        }]
-      : [];
+    return {
+      id: metric.id,
+      label: metric.label,
+      active: parts.every(
+        (part) => parseConfigRect(resolution.config[part.rectKey]) !== null
+      )
+    };
   });
 }
 
@@ -5632,27 +5620,12 @@ export function buildMetricOverrides(
         }
         continue;
       }
-      if (
-        enabled === undefined ||
-        (metric.id !== "battery" && metric.id !== "exercise" &&
-          !parts.every((part) =>
-            Object.prototype.hasOwnProperty.call(
-              resolution.config,
-              part.rectKey
-            )
-          )) ||
-        (metric.fontKey &&
-          metric.id !== "battery" &&
-          metric.id !== "exercise" &&
-          metric.id !== "temperature" &&
-          !Object.prototype.hasOwnProperty.call(resolution.config, metric.fontKey))
-      ) {
+      if (enabled === undefined) {
         continue;
       }
       if (!enabled) {
         for (const part of parts) {
           if (
-            metric.id !== "exercise" ||
             Object.prototype.hasOwnProperty.call(
               resolution.config,
               part.rectKey

--- a/src/watchfaces/watchfaces.css
+++ b/src/watchfaces/watchfaces.css
@@ -2665,11 +2665,96 @@
 }
 
 :is(.watchfaces-view, .wf-watchfaces, .watchface-shell) :where(.wf-export-popover) {
-  width: 224px;
+  z-index: 30;
+  width: 276px;
+  gap: 3px;
+  border-color: color-mix(in srgb, var(--wf-border-strong) 88%, var(--text-primary));
+  background: color-mix(in srgb, var(--bg-base) 96%, var(--glass-bg-elevated));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--text-primary) 8%, transparent),
+    0 20px 54px rgba(0, 0, 0, 0.38);
+  padding: 7px;
+  -webkit-backdrop-filter: blur(22px) saturate(118%);
+  backdrop-filter: blur(22px) saturate(118%);
 }
 
 :is(.watchfaces-view, .wf-watchfaces, .watchface-shell) :where(.wf-export-popover) button {
+  display: grid;
+  position: relative;
+  min-height: 58px;
+  grid-template-columns: 36px minmax(0, 1fr);
+  gap: 11px;
+  padding: 7px 9px;
+  white-space: normal;
+}
+
+.watchface-shell .wf-export-popover button:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent-soft) 36%, var(--wf-surface-hover));
+}
+
+.watchface-shell .wf-export-option-icon {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--wf-border);
+  border-radius: var(--wf-control-radius);
+  background: color-mix(in srgb, var(--wf-surface-hover) 74%, transparent);
+  color: var(--text-secondary);
+  place-items: center;
+}
+
+.watchface-shell .wf-export-popover button:hover:not(:disabled) .wf-export-option-icon {
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--wf-border));
+  background: color-mix(in srgb, var(--accent-soft) 58%, transparent);
+  color: var(--accent-strong);
+}
+
+.watchface-shell .wf-export-option-copy {
+  display: grid;
+  min-width: 0;
+  align-self: center;
+  gap: 3px;
+}
+
+.watchface-shell .wf-export-option-copy :where(strong, small) {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.watchface-shell .wf-export-option-copy strong {
+  color: var(--text-primary);
+  font-size: var(--wf-text-sm);
+  font-weight: 750;
+}
+
+.watchface-shell .wf-export-option-copy small {
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.watchface-shell .wf-export-popover button.is-convert {
+  margin-top: 5px;
+}
+
+.watchface-shell .wf-export-popover button.is-convert::before {
+  content: "";
+  position: absolute;
+  top: -3px;
+  right: 7px;
+  left: 7px;
+  height: 1px;
+  background: var(--wf-border);
+}
+
+.watchface-shell .wf-export-button > svg:last-child {
+  transition: transform 160ms ease;
+}
+
+.watchface-shell .wf-export-button[aria-expanded="true"] > svg:last-child {
+  transform: rotate(180deg);
 }
 
 :is(.watchfaces-view, .wf-watchfaces, .watchface-shell) :where(.watchface-layer-group) {
@@ -7354,54 +7439,74 @@ body.wf-value-scrubbing * {
 
 .watchface-shell--hub .watchface-dashboard-tabs > button {
   position: relative;
-  min-height: 48px;
-  gap: 7px;
+  min-height: 46px;
+  gap: 8px;
   border-radius: 0;
-  padding: 0 10px;
+  padding: 0 15px;
   font-size: var(--wf-text-md);
   font-weight: 600;
+  color: var(--text-secondary);
+  background: transparent;
+  transition: color 0.16s ease;
 }
 
-.watchface-shell--hub .watchface-dashboard-tabs > button:hover {
+.watchface-shell--hub .watchface-dashboard-tabs > button:hover,
+.watchface-shell--hub .watchface-dashboard-tabs > button:focus-visible {
   background: transparent;
   color: var(--text-primary);
 }
 
+.watchface-shell--hub .watchface-dashboard-tabs > button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -4px;
+  border-radius: 8px;
+}
+
 .watchface-shell--hub .watchface-dashboard-tabs > button.is-active,
-.watchface-shell--hub .watchface-dashboard-tabs > button[aria-selected="true"] {
+.watchface-shell--hub .watchface-dashboard-tabs > button[aria-selected="true"],
+.watchface-shell--hub .watchface-dashboard-tabs > button.is-active:hover,
+.watchface-shell--hub .watchface-dashboard-tabs > button[aria-selected="true"]:hover {
   background: transparent;
   box-shadow: none;
   color: var(--accent-strong);
-  font-weight: 800;
+  font-weight: 700;
 }
 
-.watchface-shell--hub .watchface-tab-indicator {
+.watchface-shell--hub .watchface-dashboard-tabs > button > .watchface-tab-indicator {
+  display: block;
   position: absolute;
   z-index: 1;
-  right: 8px;
+  right: 12px;
   bottom: -1px;
-  left: 8px;
+  left: 12px;
   width: auto;
   min-width: 0;
-  height: 3px;
-  border-radius: var(--wf-control-radius) var(--wf-control-radius) 0 0;
-  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
-  box-shadow: 0 -3px 12px color-mix(in srgb, var(--accent-glow) 48%, transparent);
+  height: 2.5px;
+  padding: 0;
+  border-radius: 3px 3px 0 0;
+  background: var(--accent-strong);
+  box-shadow: none;
+  filter: none;
   pointer-events: none;
 }
 
 .watchface-shell--hub .watchface-dashboard-tabs > button > .watchface-tab-count {
   display: inline-grid;
-  min-width: 21px;
-  height: 20px;
-  border-radius: var(--wf-control-radius);
-  background: color-mix(in srgb, var(--text-secondary) 10%, transparent);
+  min-width: 20px;
+  height: 19px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-secondary) 12%, transparent);
+  color: var(--text-secondary);
   font-size: var(--wf-text-xs);
+  font-weight: 700;
+  line-height: 1;
   place-items: center;
+  transition: background 0.16s ease, color 0.16s ease;
 }
 
 .watchface-shell--hub .watchface-dashboard-tabs > button.is-active > .watchface-tab-count {
-  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
   color: var(--accent-strong);
 }
 


### PR DESCRIPTION
## What changed

- Show every fixed metric for every Watch Studio template.
- Add missing metric configuration using fallback digit fonts and default placement.
- Refresh the export menu and dashboard tab styling.
- Add regression coverage for templates that omit fixed-metric keys.

## Why

Some templates only exposed Battery and Exercise because the layer list filtered out fixed metrics whose config keys were absent. The export controls and tabs also needed the pending visual polish included on this branch.

## Impact

Creators now get the same complete fixed-metric layer list across templates and can enable metrics that were not declared by the source template. Export actions are clearer and dashboard tabs have more consistent states.

## Validation

- `npm run test:watchface-studio`
- `npm run test:watchface-editor`
- `npm run build:renderer`
- `git diff --check`