### PR TITLE
Clean up installed update installers from updater cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Strength tab** — a dedicated view for resistance training, with an animated anatomical body map that shades each muscle by how hard you have worked it, per-muscle set/volume/time breakdowns, weekly volume trends, push/pull/legs/core balance, estimated one-rep-max progression, and recent session history
 - Dev view can preview the Strength tab against a generated sample history, so the page can be worked on without a populated COROS account
 
+### Fixed
+
+- Auto-update no longer leaves the downloaded installer in the updater cache after installing it, which duplicated roughly 100MB per release on Windows ([#33](https://github.com/JunAkerBuilds/CorosLink/issues/33))
+
 ## [0.1.23] - 2026-07-22
 
 ### Changed

--- a/electron/updaterService.ts
+++ b/electron/updaterService.ts
@@ -1,4 +1,7 @@
 import { execFileSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
 import { app, BrowserWindow, shell } from "electron";
 import { autoUpdater } from "electron-updater";
 import { getSetting, setSetting } from "./database";
@@ -9,6 +12,7 @@ const AUTO_DOWNLOAD_KEY = "updater.autoDownload";
 
 let mainWindow: BrowserWindow | undefined;
 let listenersRegistered = false;
+let staleUpdateCleanupStarted = false;
 let snapshot: AppUpdateSnapshot = {
   supported: false,
   currentVersion: app.getVersion(),
@@ -114,6 +118,98 @@ function resolveInstallDetails(
   };
 }
 
+function getUpdaterBaseCacheDir(): string {
+  if (process.platform === "win32") {
+    return process.env.LOCALAPPDATA ?? path.join(homedir(), "AppData", "Local");
+  }
+
+  if (process.platform === "darwin") {
+    return path.join(homedir(), "Library", "Caches");
+  }
+
+  return process.env.XDG_CACHE_HOME ?? path.join(homedir(), ".cache");
+}
+
+async function getUpdaterCacheDirName(): Promise<string> {
+  try {
+    const config = await fs.readFile(
+      path.join(process.resourcesPath, "app-update.yml"),
+      "utf8"
+    );
+    const match = config.match(/^updaterCacheDirName:\s*(\S+)\s*$/m);
+    if (match) {
+      return match[1];
+    }
+  } catch {
+    // fall through to electron-updater's default
+  }
+
+  return app.getName();
+}
+
+function parseVersion(value: string): [number, number, number] | undefined {
+  const match = value.match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    return undefined;
+  }
+
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function isVersionNewerThanCurrent(version: [number, number, number]): boolean {
+  const current = parseVersion(app.getVersion());
+  if (!current) {
+    return false;
+  }
+
+  for (let i = 0; i < 3; i++) {
+    if (version[i] !== current[i]) {
+      return version[i] > current[i];
+    }
+  }
+
+  return false;
+}
+
+/**
+ * electron-updater leaves the downloaded installer in the cache dir's
+ * "pending" folder after the update is installed, and only clears it when
+ * the next release starts downloading. On Windows that duplicates the
+ * ~100MB installer already kept at the cache root as "installer.exe" for
+ * differential downloads (which must be preserved). See issue #33.
+ */
+async function cleanupInstalledUpdateCache(): Promise<void> {
+  try {
+    const pendingDir = path.join(
+      getUpdaterBaseCacheDir(),
+      await getUpdaterCacheDirName(),
+      "pending"
+    );
+
+    try {
+      const raw = await fs.readFile(
+        path.join(pendingDir, "update-info.json"),
+        "utf8"
+      );
+      const fileName = (JSON.parse(raw) as { fileName?: unknown }).fileName;
+      if (typeof fileName === "string") {
+        const pendingVersion = parseVersion(fileName);
+        if (pendingVersion && isVersionNewerThanCurrent(pendingVersion)) {
+          // Downloaded but not installed yet — keep it.
+          return;
+        }
+      }
+    } catch {
+      // No readable update-info.json: anything left here is an orphaned
+      // partial download, safe to remove.
+    }
+
+    await fs.rm(pendingDir, { recursive: true, force: true });
+  } catch {
+    // Cleanup is best-effort; never block updater startup.
+  }
+}
+
 function publishSnapshot(): void {
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.webContents.send("app:updateStatus", snapshot);
@@ -217,6 +313,11 @@ export function initializeAppUpdater(window: BrowserWindow): void {
   registerAutoUpdaterListeners();
   autoUpdater.autoDownload = autoDownload;
   publishSnapshot();
+
+  if (!staleUpdateCleanupStarted) {
+    staleUpdateCleanupStarted = true;
+    void cleanupInstalledUpdateCache();
+  }
 
   if (autoCheck) {
     setTimeout(() => {


### PR DESCRIPTION
After an auto-update on Windows, the downloaded installer stayed in the updater cache's "pending" folder alongside the installer.exe kept at the cache root for differential downloads, duplicating ~100MB per release. electron-updater only clears "pending" when the next release starts downloading, so the stale copy lingered indefinitely.

On startup, remove the pending folder once its recorded update version is no longer newer than the running app (or when only orphaned partial downloads remain), keeping installer.exe and current.blockmap intact so differential updates keep working.

Fixes #33

## Description
<!-- Briefly describe what this PR does and why -->


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Improvement / enhancement
- [ ] Refactor (no functional changes)
- [ ] Documentation update
- [ ] Breaking change

## How to Test
<!-- Steps to verify your changes work correctly -->
1. 
2. 

## Checklist
- [x] I have tested my changes
- [ ] My changes do not break existing functionality
- [ ] I have added comments where necessary
