### PR TITLE
Add adaptive multi-sport Coach plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Multi-sport Coach plans** — Coach now uses the athlete's recent activity mix and complete schedule to create adaptive plans across all nine supported COROS workout sports instead of defaulting to running
+
+### Fixed
+
+- Coach plan uploads now preserve each workout's sport and sport options instead of treating non-running workouts as Run
+- Strength and HYROX plan drafts now resolve harmless exercise-name variants automatically and feed genuine COROS catalog ambiguities back to Coach for same-response correction before preview or upload
+
 ## [0.1.24] - 2026-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Ask training questions with answers grounded in your COROS data.
 
 - **Providers** — ChatGPT (cloud), Claude Code, or local LLMs (Ollama / LM Studio)
 - **Model selection & extended thinking** where the provider supports them
-- **Workout tools** — draft plans, preview in chat, upload/list/delete COROS workouts with confirmation cards
+- **Multi-sport workout tools** — draft adaptive plans across Run, Trail Run, Bike, Pool Swim, Strength, Indoor Climb, Bouldering, XC Ski, and HYROX; preview them in chat and upload/list/delete COROS workouts with confirmation cards
 - **Chat history** — per-provider conversations persist across restarts
 
 ---

--- a/electron/chatCoachContext.ts
+++ b/electron/chatCoachContext.ts
@@ -1,0 +1,184 @@
+import { corosSportName } from "./corosSportTypes";
+import {
+  WORKOUT_SPORT_CAPABILITIES,
+  WORKOUT_SPORTS,
+  formatIntensityType,
+  formatWorkoutSport,
+  workoutSportFromType
+} from "./workoutCapabilities";
+import type {
+  TrainingHubActivity,
+  TrainingHubDashboard,
+  UnitSystem,
+  WorkoutSport
+} from "./types";
+import { formatDistanceValue } from "./unitSystem.js";
+
+export function buildCoachInstructions(): string {
+  return (
+    "You are a friendly, knowledgeable multi-sport endurance and strength-training coach built " +
+    "into CorosLink. You have access to the athlete's recent COROS training data " +
+    "below. Give concise, practical, encouraging advice grounded in that data. If " +
+    "the data does not cover the question, say so rather than inventing numbers.\n\n" +
+    "When building training plans: review the athlete's recent activity mix, recovery, and complete upcoming " +
+    "schedule first. Honor every sport the athlete explicitly requests. For a vague request, preserve sports " +
+    "demonstrated in their history and use their stated goal to choose the mix; ask one concise clarifying " +
+    "question when the goal, intended sports, facilities, or equipment would materially change the plan. " +
+    "Never add an unfamiliar sport merely for variety. Balance hard, easy, and rest days across all sports, " +
+    "and do not assume an easy ride, swim, or strength workout is automatically a rest day. Use " +
+    "draft_training_plan to validate and preview before upload. Always set the workout sport explicitly, " +
+    "and always put prescribed heart rate, pace, effort pace, power, cadence, swim stroke, " +
+    "weight, RPE, or climbing grade in the step's typed intensity object rather than only " +
+    "in its name or prose. Unsupported activity types may inform advice but must not be silently converted " +
+    "to another workout sport. In particular, Open Water Swim is not Pool Swim; ask before substituting it. " +
+    "Represent triathlon or COROS Multi Sport plans as separate supported workouts. Never call " +
+    "upload_training_plan until the athlete confirms via the Upload to COROS button. If " +
+    "draft_training_plan returns exercise_resolution_required, update the affected steps to exact COROS " +
+    "candidate names and call draft_training_plan again in the same response. Ask the athlete only when " +
+    "the candidates materially change the intended movement or no supported candidate is available.\n\n" +
+    "To delete workouts: use list_scheduled_workouts to find calendar entries, then " +
+    "delete_workout to stage a confirmation card. The athlete must click Delete from COROS — " +
+    "never claim a workout was removed until they confirm via the button."
+  );
+}
+
+export function buildCoachSportCapabilityGuide(): string {
+  return WORKOUT_SPORTS.map((sport) => {
+    const capability = WORKOUT_SPORT_CAPABILITIES[sport];
+    const targets = [...new Set([...capability.targets, ...capability.restTargets])];
+    const options = [
+      capability.supportsPoolLength ? "poolLength option" : undefined,
+      capability.supportsGradingSystem ? "gradingSystem option" : undefined,
+      capability.requiresExercise ? "training steps require an exercise" : undefined
+    ].filter(Boolean);
+    return (
+      `- ${capability.label} (sport=${sport}): targets ${targets.join(", ")}; ` +
+      `intensities ${capability.intensities.map(formatIntensityType).join(", ")}` +
+      (options.length > 0 ? `; ${options.join("; ")}` : "")
+    );
+  }).join("\n");
+}
+
+interface ActivitySportGroup {
+  key: string;
+  label: string;
+  planSport?: WorkoutSport;
+  swim: boolean;
+}
+
+function activitySportGroup(activity: TrainingHubActivity): ActivitySportGroup {
+  const sportType = activity.sportType;
+  const sportName = activity.sportName ?? corosSportName(sportType) ?? `Sport type ${sportType}`;
+  const normalized = sportName.toLocaleLowerCase();
+  let planSport: WorkoutSport | undefined;
+
+  if (sportType === 102 || /trail run/.test(normalized)) planSport = "trailRun";
+  else if ([100, 101, 103].includes(sportType) || /\brun\b/.test(normalized)) planSport = "run";
+  else if ((sportType >= 200 && sportType <= 299) || /bike|cycl|ride/.test(normalized)) planSport = "bike";
+  else if (sportType === 300 || /pool swim/.test(normalized)) planSport = "swim";
+  else if (sportType === 402 || /strength/.test(normalized)) planSport = "strength";
+  else if (sportType === 502 || /xc ski|cross.?country ski/.test(normalized)) planSport = "xcSki";
+  else if (sportType === 800 || /indoor climb/.test(normalized)) planSport = "indoorClimb";
+  else if (sportType === 801 || /boulder/.test(normalized)) planSport = "bouldering";
+  else if (/hyrox/.test(normalized)) planSport = "hyrox";
+
+  return {
+    key: planSport ? `plan:${planSport}` : `activity:${sportType}:${normalized}`,
+    label: planSport ? formatWorkoutSport(planSport) : sportName,
+    planSport,
+    swim: sportType === 300 || sportType === 301 || /swim/.test(normalized)
+  };
+}
+
+function formatTotalDuration(seconds: number): string {
+  const roundedMinutes = Math.round(seconds / 60);
+  const hours = Math.floor(roundedMinutes / 60);
+  const minutes = roundedMinutes % 60;
+  if (hours <= 0) return `${minutes} min`;
+  return minutes > 0 ? `${hours} h ${minutes} min` : `${hours} h`;
+}
+
+export function formatRecentActivityMix(
+  activities: TrainingHubActivity[],
+  unitSystem: UnitSystem
+): string {
+  const groups = new Map<
+    string,
+    ActivitySportGroup & { count: number; duration: number; distance: number; trainingLoad: number }
+  >();
+
+  for (const activity of activities) {
+    const sport = activitySportGroup(activity);
+    const current = groups.get(sport.key) ?? {
+      ...sport,
+      count: 0,
+      duration: 0,
+      distance: 0,
+      trainingLoad: 0
+    };
+    current.count += 1;
+    current.duration += activity.duration ?? 0;
+    current.distance += activity.distance ?? 0;
+    current.trainingLoad += activity.trainingLoad ?? 0;
+    groups.set(sport.key, current);
+  }
+
+  return [...groups.values()]
+    .sort((left, right) => right.count - left.count || right.duration - left.duration)
+    .map((group) => {
+      const parts = [
+        `${group.count} activit${group.count === 1 ? "y" : "ies"}`,
+        group.duration > 0 ? formatTotalDuration(group.duration) : undefined,
+        group.distance > 0
+          ? formatDistanceValue(group.distance, unitSystem, { swim: group.swim })
+          : undefined,
+        group.trainingLoad > 0 ? `load ${Math.round(group.trainingLoad)}` : undefined
+      ].filter(Boolean);
+      const planningNote = group.planSport
+        ? `plan sport=${group.planSport}`
+        : "not directly plan-authorable";
+      return `- ${group.label} (${planningNote}): ${parts.join(" · ")}`;
+    })
+    .join("\n");
+}
+
+export function formatUpcomingWorkoutSport(sportType: number | undefined): string | undefined {
+  if (sportType === undefined) return undefined;
+  const sport = workoutSportFromType(sportType);
+  return sport ? formatWorkoutSport(sport) : `Sport type ${sportType}`;
+}
+
+export function formatCoachDashboard(dashboard: TrainingHubDashboard): string {
+  const lines: string[] = [];
+  if (dashboard.rhr != null) lines.push(`- Resting HR: ${dashboard.rhr} bpm`);
+  if (dashboard.recoveryPct != null) lines.push(`- Recovery: ${dashboard.recoveryPct}%`);
+  if (dashboard.fullRecoveryHours != null) {
+    lines.push(`- Full recovery in ~${dashboard.fullRecoveryHours} h`);
+  }
+  const predictor = dashboard.racePredictor;
+  if (predictor?.staminaLevel != null) {
+    lines.push(`- Running stamina level: ${predictor.staminaLevel}`);
+  }
+  const predictions = (predictor?.runScoreList ?? [])
+    .filter((score) => score.distanceLabel && score.predictSeconds)
+    .slice(0, 4)
+    .map(
+      (score) =>
+        `${score.distanceLabel} ~${formatClockDuration(score.predictSeconds ?? 0)}`
+    );
+  if (predictions.length > 0) {
+    lines.push(`- Running race predictions: ${predictions.join(", ")}`);
+  }
+  return lines.join("\n");
+}
+
+function formatClockDuration(value: number): string {
+  const totalSeconds = Math.round(value);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  }
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}

--- a/electron/chatService.ts
+++ b/electron/chatService.ts
@@ -92,6 +92,13 @@ import {
   formatElevationValue,
   normalizeUnitSystem
 } from "./unitSystem.js";
+import {
+  buildCoachInstructions,
+  buildCoachSportCapabilityGuide,
+  formatCoachDashboard,
+  formatRecentActivityMix,
+  formatUpcomingWorkoutSport
+} from "./chatCoachContext";
 
 // =========================================================================
 // OpenAI "Sign in with ChatGPT" provider details.
@@ -127,21 +134,7 @@ const MAX_TOOL_ROUNDS = 10;
 const RESPONSES_ORIGINATOR = "codex_cli_rs";
 const RESPONSES_USER_AGENT = "codex_cli_rs";
 
-const COACH_INSTRUCTIONS =
-  "You are a friendly, knowledgeable running and endurance-training coach built " +
-  "into CorosLink. You have access to the athlete's recent COROS training data " +
-  "below. Give concise, practical, encouraging advice grounded in that data. If " +
-  "the data does not cover the question, say so rather than inventing numbers.\n\n" +
-  "When building training plans: review recent activities, recovery, and upcoming " +
-  "workouts first. Prefer sensible periodization (easy/hard/rest balance). Use " +
-  "draft_training_plan to validate and preview before upload. Select the workout sport, " +
-  "and always put prescribed heart rate, pace, effort pace, power, cadence, swim stroke, " +
-  "weight, RPE, or climbing grade in the step's typed intensity object rather than only " +
-  "in its name or prose. Never call " +
-  "upload_training_plan until the athlete confirms via the Upload to COROS button.\n\n" +
-  "To delete workouts: use list_scheduled_workouts to find calendar entries, then " +
-  "delete_workout to stage a confirmation card. The athlete must click Delete from COROS — " +
-  "never claim a workout was removed until they confirm via the button.";
+const COACH_INSTRUCTIONS = buildCoachInstructions();
 
 // Settings keys (encrypted blob + a plaintext timestamp).
 const SETTINGS = {
@@ -1317,6 +1310,7 @@ function withLiveToolInstructions(
       "## Training plan tools",
       `Plan authoring tools: ${planTools.map((tool) => tool.name).join(", ")}. ` +
         "Use draft_training_plan to build multi-day schedules across the supported sports. " +
+        "Always provide sport on every new workout, including sport=run. " +
         "Use distance_km only for a simple Run or Trail Run; use steps for anything structured. " +
         "Pick each step's target " +
         "deliberately: distance for easy/long/tempo blocks, time for duration-based reps " +
@@ -1327,7 +1321,10 @@ function withLiveToolInstructions(
         "Include schedule_date " +
         "(YYYYMMDD) for calendar placement. The athlete must confirm before upload. " +
         "Use list_scheduled_workouts + delete_workout to stage deletions. " +
-        "The athlete confirms via the Delete from COROS button in chat."
+        "The athlete confirms via the Delete from COROS button in chat.",
+      "",
+      "Supported workout capabilities (generated from the validator):",
+      buildCoachSportCapabilityGuide()
     );
   }
   return sections.join("\n");
@@ -1411,7 +1408,7 @@ async function buildTrainingContext(
   const includeUpcoming = permissions?.upcomingWorkouts !== false;
   const [activities, dashboard, upcoming] = await Promise.allSettled([
     includeActivities
-      ? listTrainingHubActivities(1, 10)
+      ? listTrainingHubActivities(1, 25)
       : Promise.resolve([] as TrainingHubActivity[]),
     includeMetrics
       ? getTrainingDashboard()
@@ -1425,13 +1422,16 @@ async function buildTrainingContext(
   let hasData = false;
 
   if (activities.status === "fulfilled" && activities.value.length > 0) {
+    sections.push(`## Recent activity mix (latest ${activities.value.length})`);
+    sections.push(formatRecentActivityMix(activities.value, unitSystem));
+    sections.push("");
     sections.push("## Recent activities");
     sections.push(formatActivities(activities.value.slice(0, 8), unitSystem));
     sections.push("");
     hasData = true;
   }
   if (dashboard.status === "fulfilled" && dashboard.value) {
-    const fitness = formatDashboard(dashboard.value);
+    const fitness = formatCoachDashboard(dashboard.value);
     if (fitness) {
       sections.push("## Fitness & recovery");
       sections.push(fitness);
@@ -1441,7 +1441,7 @@ async function buildTrainingContext(
   }
   if (upcoming.status === "fulfilled" && upcoming.value.length > 0) {
     sections.push("## Upcoming workouts");
-    sections.push(formatUpcoming(upcoming.value.slice(0, 8), unitSystem));
+    sections.push(formatUpcoming(upcoming.value, unitSystem));
     sections.push("");
     hasData = true;
   }
@@ -1488,28 +1488,6 @@ function formatActivities(
     .join("\n");
 }
 
-function formatDashboard(dashboard: TrainingHubDashboard): string {
-  const lines: string[] = [];
-  if (dashboard.rhr != null) lines.push(`- Resting HR: ${dashboard.rhr} bpm`);
-  if (dashboard.recoveryPct != null)
-    lines.push(`- Recovery: ${dashboard.recoveryPct}%`);
-  if (dashboard.fullRecoveryHours != null)
-    lines.push(`- Full recovery in ~${dashboard.fullRecoveryHours} h`);
-  const predictor = dashboard.racePredictor;
-  if (predictor?.staminaLevel != null)
-    lines.push(`- Stamina level: ${predictor.staminaLevel}`);
-  const predictions = (predictor?.runScoreList ?? [])
-    .filter((score) => score.distanceLabel && score.predictSeconds)
-    .slice(0, 4)
-    .map(
-      (score) =>
-        `${score.distanceLabel} ~${formatDurationSeconds(score.predictSeconds ?? 0)}`
-    );
-  if (predictions.length > 0)
-    lines.push(`- Race predictions: ${predictions.join(", ")}`);
-  return lines.join("\n");
-}
-
 function formatUpcomingVolume(
   volume: string | undefined,
   unitSystem: UnitSystem
@@ -1541,6 +1519,7 @@ function formatUpcoming(
         : undefined;
       const parts = [
         workout.happenDay,
+        formatUpcomingWorkoutSport(workout.sportType),
         workout.name,
         formatUpcomingVolume(workout.volume, unitSystem),
         workout.trainingLoad ? `load ${workout.trainingLoad}` : "",

--- a/electron/chatWorkoutTools.ts
+++ b/electron/chatWorkoutTools.ts
@@ -11,6 +11,7 @@ import {
   formatScheduledExercisesForChat,
   getTrainingHubStatus,
   listScheduledWorkoutEntries,
+  resolveTrainingPlanExercises,
   uploadTrainingPlan
 } from "./trainingHubService";
 import {
@@ -148,7 +149,8 @@ export function getChatWorkoutTools(): CorosMcpTool[] {
       description:
         "Validate and store a sport-aware training plan draft for athlete review. " +
         "Put prescribed HR, pace, power, cadence, stroke, weight, RPE, or grade in each step's typed intensity field. " +
-        "Always call this before upload. Returns a draftId and human-readable preview.",
+        "Strength and HYROX exercise names are checked against the COROS catalog; if candidates are returned, " +
+        "revise the affected steps and call this tool again. Always call this before upload. Returns a draftId and human-readable preview.",
       inputSchema: buildDraftTrainingPlanInputSchema()
     },
     {
@@ -284,6 +286,26 @@ function toPlanDraft(args: Record<string, unknown>): CorosTrainingPlanDraft {
   return { name, workouts };
 }
 
+export function buildTrainingPlanUploadInput(
+  plan: CorosTrainingPlanDraft
+): CorosTrainingPlanDraftInput {
+  return {
+    name: plan.name,
+    workouts: plan.workouts.map((entry) => ({
+      key: entry.key,
+      name: entry.name,
+      description: entry.description,
+      sport: entry.sport ?? "run",
+      sport_options: entry.sport_options,
+      steps: entry.steps,
+      distance_km: entry.distance_km,
+      schedule_date: entry.schedule_date,
+      sort_no: entry.sort_no,
+      save_to_library: entry.save_to_library
+    }))
+  };
+}
+
 async function detectScheduleConflicts(
   draft: CorosTrainingPlanDraft
 ): Promise<string[]> {
@@ -337,11 +359,32 @@ async function handleDraftTrainingPlan(
     return JSON.stringify({ ok: false, errors: validation.errors });
   }
 
+  const exerciseResolution = await resolveTrainingPlanExercises(draft);
+  if (exerciseResolution.issues.length > 0) {
+    return JSON.stringify({
+      ok: false,
+      error_code: "exercise_resolution_required",
+      issues: exerciseResolution.issues.map((issue) => ({
+        workout_key: issue.workoutKey,
+        workout_name: issue.workoutName,
+        sport: issue.sport,
+        exercise_name: issue.exerciseName,
+        reason: issue.reason,
+        candidates: issue.candidates,
+        message: issue.message
+      })),
+      action: exerciseResolution.issues.every((issue) => issue.candidates.length > 0)
+        ? "Update each affected step to the exact best-matching candidate and call draft_training_plan again now. Ask the athlete only when the candidates materially change the intended movement."
+        : "At least one exercise is unavailable. Ask the athlete for a supported alternative, then call draft_training_plan again."
+    });
+  }
+  const resolvedDraft = exerciseResolution.draft;
+
   const conflicts = allowUpcomingWorkouts
-    ? await detectScheduleConflicts(draft)
+    ? await detectScheduleConflicts(resolvedDraft)
     : [];
   const draftId = crypto.randomUUID();
-  const preview = buildPlanPreview(draftId, draft, {
+  const preview = buildPlanPreview(draftId, resolvedDraft, {
     scheduleConflicts: conflicts,
     unitSystem
   });
@@ -349,7 +392,7 @@ async function handleDraftTrainingPlan(
 
   draftStore.set(draftId, {
     draftId,
-    plan: draft,
+    plan: resolvedDraft,
     preview,
     createdAt: Date.now()
   });
@@ -410,18 +453,7 @@ async function handleUploadTrainingPlan(
     });
   }
 
-  const input: CorosTrainingPlanDraftInput = {
-    name: stored.plan.name,
-    workouts: stored.plan.workouts.map((entry) => ({
-      key: entry.key,
-      name: entry.name,
-      steps: entry.steps,
-      distance_km: entry.distance_km,
-      schedule_date: entry.schedule_date,
-      sort_no: entry.sort_no,
-      save_to_library: entry.save_to_library
-    }))
-  };
+  const input = buildTrainingPlanUploadInput(stored.plan);
 
   const result = await uploadTrainingPlan(input, unitSystem);
   stored.uploadedAt = Date.now();
@@ -737,18 +769,7 @@ export async function uploadPlanDraftById(
     throw new Error("This training plan was already uploaded.");
   }
 
-  const input: CorosTrainingPlanDraftInput = {
-    name: stored.plan.name,
-    workouts: stored.plan.workouts.map((entry) => ({
-      key: entry.key,
-      name: entry.name,
-      steps: entry.steps,
-      distance_km: entry.distance_km,
-      schedule_date: entry.schedule_date,
-      sort_no: entry.sort_no,
-      save_to_library: entry.save_to_library
-    }))
-  };
+  const input = buildTrainingPlanUploadInput(stored.plan);
 
   const result = await uploadTrainingPlan(input, unitSystem);
   stored.uploadedAt = Date.now();

--- a/electron/corosWorkoutBuilder.ts
+++ b/electron/corosWorkoutBuilder.ts
@@ -1339,6 +1339,14 @@ export function buildPlanPreview(
   const libraryOnly = draft.workouts.filter(
     (entry) => !entry.schedule_date && entry.save_to_library !== false
   );
+  const sportCounts = new Map<WorkoutSport, number>();
+  for (const entry of draft.workouts) {
+    const sport = entry.sport ?? "run";
+    sportCounts.set(sport, (sportCounts.get(sport) ?? 0) + 1);
+  }
+  const sportSummary = [...sportCounts.entries()]
+    .map(([sport, count]) => `${count} ${formatWorkoutSport(sport)}`)
+    .join(" / ");
 
   const summaryParts = [
     `${draft.workouts.length} workout${draft.workouts.length === 1 ? "" : "s"}`,
@@ -1347,7 +1355,8 @@ export function buildPlanPreview(
       : "none scheduled",
     libraryOnly.length > 0
       ? `${libraryOnly.length} library-only`
-      : undefined
+      : undefined,
+    sportSummary
   ].filter(Boolean);
 
   const warnings: string[] = [];

--- a/electron/trainingHubService.ts
+++ b/electron/trainingHubService.ts
@@ -2100,7 +2100,14 @@ export async function createAndScheduleWorkout(
     saveToLibrary = unitSystemOrSave;
   }
   const entry = toPlanWorkoutEntry(entryInput);
-  const resolvedEntry = await resolveWorkoutEntryExercises(entry);
+  const exerciseResolution = await resolveTrainingPlanExercises({
+    name: entry.name,
+    workouts: [entry]
+  });
+  if (exerciseResolution.issues.length > 0) {
+    throw new Error(exerciseResolution.issues.map((issue) => issue.message).join(" "));
+  }
+  const resolvedEntry = exerciseResolution.draft.workouts[0]!;
   const context = parseWorkoutEditorContext(
     await loadWorkoutEditorAccount(),
     unitSystem
@@ -2419,42 +2426,75 @@ export async function listWorkoutExercises(
   })).values()].sort((left, right) => left.name.localeCompare(right.name));
 }
 
-async function resolveWorkoutEntryExercises(
-  entry: PlanWorkoutEntry
-): Promise<PlanWorkoutEntry> {
-  const sport = entry.sport ?? "run";
-  if (!WORKOUT_SPORT_CAPABILITIES[sport].requiresExercise || !entry.steps?.length) {
-    return entry;
-  }
-  const cloned = structuredClone(entry);
-  const plainSteps = cloned.steps!.flatMap((step) =>
-    "repeat" in step ? step.steps : [step]
-  );
-  const unresolved = plainSteps.filter(
-    (step) => step.kind === "training" && !step.exercise_id && step.exercise_name
-  );
-  if (!unresolved.length) return cloned;
+export interface TrainingPlanExerciseResolutionIssue {
+  workoutKey: string;
+  workoutName: string;
+  sport: WorkoutSport;
+  exerciseName: string;
+  candidates: string[];
+  reason: "ambiguous" | "unavailable";
+  message: string;
+}
 
-  const catalog = await loadWorkoutExerciseCatalog(sport);
-
-  for (const step of unresolved) {
-    const resolution = resolveWorkoutExerciseName(catalog, step.exercise_name!);
-    if (!resolution.match) {
-      throw new Error(
-        resolution.candidates.length === 0
-          ? `Exercise "${step.exercise_name}" is unavailable in the COROS ${WORKOUT_SPORT_CAPABILITIES[sport].label} catalog.`
-          : `Exercise "${step.exercise_name}" is ambiguous. Choose one of: ${resolution.candidates.join(", ")}.`
-      );
+export async function resolveTrainingPlanExercises(
+  draft: CorosTrainingPlanDraft
+): Promise<{
+  draft: CorosTrainingPlanDraft;
+  issues: TrainingPlanExerciseResolutionIssue[];
+}> {
+  const resolved = structuredClone(draft);
+  const issues: TrainingPlanExerciseResolutionIssue[] = [];
+  const catalogs = new Map<WorkoutSport, Promise<Record<string, unknown>[]>>();
+  const catalogFor = (sport: WorkoutSport): Promise<Record<string, unknown>[]> => {
+    let catalog = catalogs.get(sport);
+    if (!catalog) {
+      catalog = loadWorkoutExerciseCatalog(sport);
+      catalogs.set(sport, catalog);
     }
-    const match = resolution.match;
-    const id = workoutExerciseId(match);
-    if (!id) throw new Error(`Exercise "${step.exercise_name}" has no COROS exercise ID.`);
-    step.exercise_id = id;
-    step.exercise_name = workoutExerciseName(match) || step.exercise_name;
-    const exerciseKind = toOptionalNumber(match.exerciseKind);
-    if (exerciseKind !== undefined) step.exercise_kind = exerciseKind;
+    return catalog;
+  };
+
+  for (const entry of resolved.workouts) {
+    const sport = entry.sport ?? "run";
+    const capability = WORKOUT_SPORT_CAPABILITIES[sport];
+    if (!capability?.requiresExercise || !entry.steps?.length) continue;
+    const plainSteps = entry.steps.flatMap((step) =>
+      "repeat" in step ? step.steps : [step]
+    );
+    const unresolved = plainSteps.filter(
+      (step) => step.kind === "training" && !step.exercise_id && step.exercise_name
+    );
+    if (!unresolved.length) continue;
+    const catalog = await catalogFor(sport);
+
+    for (const step of unresolved) {
+      const exerciseName = step.exercise_name!;
+      const resolution = resolveWorkoutExerciseName(catalog, exerciseName);
+      const match = resolution.match;
+      const id = match ? workoutExerciseId(match) : undefined;
+      if (!match || !id) {
+        const reason = resolution.candidates.length > 0 ? "ambiguous" : "unavailable";
+        issues.push({
+          workoutKey: entry.key,
+          workoutName: entry.name,
+          sport,
+          exerciseName,
+          candidates: resolution.candidates,
+          reason,
+          message: reason === "ambiguous"
+            ? `Exercise "${exerciseName}" in "${entry.name}" is ambiguous. Choose one of: ${resolution.candidates.join(", ")}.`
+            : `Exercise "${exerciseName}" in "${entry.name}" is unavailable in the COROS ${capability.label} catalog.`
+        });
+        continue;
+      }
+      step.exercise_id = id;
+      step.exercise_name = workoutExerciseName(match) || exerciseName;
+      const exerciseKind = toOptionalNumber(match.exerciseKind);
+      if (exerciseKind !== undefined) step.exercise_kind = exerciseKind;
+    }
   }
-  return cloned;
+
+  return { draft: resolved, issues };
 }
 
 function workoutSportTypeForService(sport: keyof typeof WORKOUT_SPORT_CAPABILITIES): number {
@@ -2476,7 +2516,13 @@ export async function uploadTrainingPlan(
     throw new Error(validation.errors.join(" "));
   }
 
-  const existingByDate = await loadExistingScheduleDates(draft);
+  const exerciseResolution = await resolveTrainingPlanExercises(draft);
+  if (exerciseResolution.issues.length > 0) {
+    throw new Error(exerciseResolution.issues.map((issue) => issue.message).join(" "));
+  }
+  const resolvedDraft = exerciseResolution.draft;
+
+  const existingByDate = await loadExistingScheduleDates(resolvedDraft);
   const entries: UploadPlanResultEntry[] = [];
   let workoutsCreated = 0;
   let workoutsScheduled = 0;
@@ -2490,9 +2536,8 @@ export async function uploadTrainingPlan(
     unitSystem
   );
 
-  for (const entry of draft.workouts) {
-    const resolvedEntry = await resolveWorkoutEntryExercises(entry);
-    const payload = buildWorkoutPayloadFromEntry(resolvedEntry, context);
+  for (const entry of resolvedDraft.workouts) {
+    const payload = buildWorkoutPayloadFromEntry(entry, context);
     const workoutSignature = JSON.stringify(payload);
     const saveToLibrary = entry.save_to_library !== false;
     // Schedule a calculated full payload, not the library query summary. The

--- a/electron/workoutCapabilities.ts
+++ b/electron/workoutCapabilities.ts
@@ -244,6 +244,26 @@ export function workoutExerciseId(row: Record<string, unknown>): string | undefi
     : String(value);
 }
 
+function normalizeExerciseName(value: string): string {
+  const singularize = (token: string): string => {
+    if (token.length > 4 && token.endsWith("ies")) return `${token.slice(0, -3)}y`;
+    if (token.length > 4 && /(ches|shes|xes|zes)$/.test(token)) return token.slice(0, -2);
+    if (token.length > 3 && token.endsWith("s") && !/(ss|us|is)$/.test(token)) {
+      return token.slice(0, -1);
+    }
+    return token;
+  };
+  return value
+    .trim()
+    .toLocaleLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(singularize)
+    .join(" ");
+}
+
 const COROS_EXERCISE_IMAGE_PREFIX = "/source/exercise_img/";
 const COROS_EXERCISE_VIDEO_PREFIX = "/source/exercise_gif/";
 
@@ -321,13 +341,22 @@ export function resolveWorkoutExerciseName(
   catalog: readonly Record<string, unknown>[],
   requestedName: string
 ): WorkoutExerciseResolution {
-  const normalize = (value: string): string => value.trim().toLocaleLowerCase();
-  const query = normalize(requestedName);
+  const literal = (value: string): string => value.trim().toLocaleLowerCase();
+  const queryLiteral = literal(requestedName);
+  const query = normalizeExerciseName(requestedName);
   if (!query) return { candidates: [] };
-  const exact = catalog.filter((row) => normalize(workoutExerciseName(row)) === query);
-  const matches = exact.length
-    ? exact
-    : catalog.filter((row) => normalize(workoutExerciseName(row)).includes(query));
+  const literalExact = catalog.filter(
+    (row) => literal(workoutExerciseName(row)) === queryLiteral
+  );
+  const canonicalExact = catalog.filter((row) => {
+    const candidate = normalizeExerciseName(workoutExerciseName(row));
+    return candidate === query || candidate.replace(/\s/g, "") === query.replace(/\s/g, "");
+  });
+  const matches = literalExact.length
+    ? literalExact
+    : canonicalExact.length
+      ? canonicalExact
+      : catalog.filter((row) => normalizeExerciseName(workoutExerciseName(row)).includes(query));
   const unique = [...new Map(
     matches.map((row) => [workoutExerciseId(row) ?? workoutExerciseName(row), row])
   ).values()];

--- a/scripts/test-chat-service.mjs
+++ b/scripts/test-chat-service.mjs
@@ -19,6 +19,65 @@ const {
 const { parseFunctionCallArguments } = await import(
   `${distUrl("chatToolArguments.js")}?cacheBust=${Date.now()}`
 );
+const {
+  buildCoachInstructions,
+  buildCoachSportCapabilityGuide,
+  formatCoachDashboard,
+  formatRecentActivityMix,
+  formatUpcomingWorkoutSport
+} = await import(`${distUrl("chatCoachContext.js")}?cacheBust=${Date.now()}`);
+
+const coachInstructions = buildCoachInstructions();
+assert.match(coachInstructions, /multi-sport endurance and strength-training coach/);
+assert.match(coachInstructions, /Honor every sport the athlete explicitly requests/);
+assert.match(coachInstructions, /Never add an unfamiliar sport merely for variety/);
+assert.match(coachInstructions, /Open Water Swim is not Pool Swim/);
+assert.match(coachInstructions, /exercise_resolution_required/);
+assert.match(coachInstructions, /call draft_training_plan again in the same response/);
+
+const capabilityGuide = buildCoachSportCapabilityGuide();
+for (const sport of [
+  "run",
+  "trailRun",
+  "bike",
+  "swim",
+  "strength",
+  "indoorClimb",
+  "bouldering",
+  "xcSki",
+  "hyrox"
+]) {
+  assert.match(capabilityGuide, new RegExp(`sport=${sport}(?:\\)|;)`));
+}
+
+const activityMix = formatRecentActivityMix(
+  [
+    { activityId: "run-1", sportType: 100, duration: 3_600, distance: 10_000, trainingLoad: 90 },
+    { activityId: "bike-1", sportType: 200, duration: 5_400, distance: 40_000, trainingLoad: 80 },
+    { activityId: "bike-2", sportType: 201, duration: 3_600, distance: 25_000, trainingLoad: 60 },
+    { activityId: "swim-1", sportType: 300, duration: 1_800, distance: 1_500, trainingLoad: 35 },
+    { activityId: "open-water-1", sportType: 301, duration: 2_400, distance: 2_000, trainingLoad: 45 }
+  ],
+  "metric"
+);
+assert.match(activityMix, /Bike \(plan sport=bike\): 2 activities/);
+assert.match(activityMix, /Run \(plan sport=run\): 1 activity/);
+assert.match(activityMix, /Pool Swim \(plan sport=swim\): 1 activity/);
+assert.match(activityMix, /Open Water Swim \(not directly plan-authorable\)/);
+assert.equal(formatUpcomingWorkoutSport(2), "Bike");
+assert.equal(formatUpcomingWorkoutSport(9), "HYROX");
+assert.equal(formatUpcomingWorkoutSport(undefined), undefined);
+
+const dashboardSummary = formatCoachDashboard({
+  rhr: 48,
+  recoveryPct: 82,
+  racePredictor: {
+    staminaLevel: 71,
+    runScoreList: [{ distanceLabel: "5K", predictSeconds: 1_200 }]
+  }
+});
+assert.match(dashboardSummary, /Running stamina level: 71/);
+assert.match(dashboardSummary, /Running race predictions: 5K ~20:00/);
 
 assert.equal(
   normalizeLocalChatBaseUrl("localhost:11434"),

--- a/scripts/test-chat-workout-tools.mjs
+++ b/scripts/test-chat-workout-tools.mjs
@@ -15,6 +15,9 @@ const {
 const { buildDraftTrainingPlanInputSchema } = await import(
   `${distUrl("workoutCapabilities.js")}?cacheBust=${Date.now()}`
 );
+const { buildTrainingPlanUploadInput } = await import(
+  `${distUrl("chatWorkoutTools.js")}?cacheBust=${Date.now()}`
+);
 
 const draft = {
   name: "Test Week",
@@ -98,5 +101,92 @@ assert.equal(heartRatePayload.exercises[0].isIntensityPercent, false);
 assert.equal(heartRatePayload.exercises[0].intensityCustom, 0);
 assert.equal(heartRatePayload.exercises[0].intensityValue, 135);
 assert.equal(heartRatePayload.exercises[0].intensityValueExtend, 145);
+
+const mixedDraft = {
+  name: "Mixed Training Week",
+  workouts: [
+    {
+      key: "easy-run",
+      name: "Easy Run",
+      sport: "run",
+      schedule_date: "20991202",
+      steps: [
+        {
+          kind: "training",
+          target_type: "time",
+          target_duration_seconds: 2_400,
+          intensity: { type: "heartRatePercent", basis: "maxHr", preset: "aerobicEndurance" }
+        }
+      ]
+    },
+    {
+      key: "bike-threshold",
+      name: "Bike Threshold",
+      sport: "bike",
+      schedule_date: "20991203",
+      steps: [
+        {
+          kind: "training",
+          target_type: "time",
+          target_duration_seconds: 2_700,
+          intensity: { type: "ftpPercent", preset: "threshold" }
+        }
+      ]
+    },
+    {
+      key: "pool-technique",
+      name: "Pool Technique",
+      sport: "swim",
+      sport_options: { poolLength: { value: 25, unit: "m" } },
+      schedule_date: "20991204",
+      steps: [
+        {
+          kind: "training",
+          target_type: "distance",
+          target_distance_meters: 1_500,
+          intensity: { type: "swimStroke", stroke: "freestyle" }
+        }
+      ]
+    },
+    {
+      key: "strength-session",
+      name: "Full Body Strength",
+      sport: "strength",
+      schedule_date: "20991205",
+      steps: [
+        {
+          kind: "training",
+          target_type: "reps",
+          target_reps: 10,
+          exercise_name: "Squat",
+          intensity: { type: "weight", mode: "bodyweight" }
+        }
+      ]
+    }
+  ]
+};
+assert.equal(validatePlanDraft(mixedDraft, { todayDay: "20260101" }).ok, true);
+const mixedPreview = buildPlanPreview("draft-mixed", mixedDraft);
+assert.equal(mixedPreview.entries.length, 4);
+assert.match(mixedPreview.summary, /1 Run \/ 1 Bike \/ 1 Pool Swim \/ 1 Strength/);
+assert.deepEqual(
+  mixedPreview.entries.map((entry) => entry.sport),
+  ["run", "bike", "swim", "strength"]
+);
+assert.deepEqual(
+  mixedDraft.workouts.map((entry) =>
+    buildWorkoutPayload(entry.name, entry.steps, entry.sport, entry.sport_options).sportType
+  ),
+  [1, 2, 3, 4]
+);
+const mixedUploadInput = buildTrainingPlanUploadInput(mixedDraft);
+assert.deepEqual(
+  mixedUploadInput.workouts.map((entry) => entry.sport),
+  ["run", "bike", "swim", "strength"]
+);
+assert.deepEqual(mixedUploadInput.workouts[2].sport_options, {
+  poolLength: { value: 25, unit: "m" }
+});
+assert.equal(mixedUploadInput.workouts[3].steps[0].target_type, "reps");
 
 console.log("test-chat-workout-tools: ok");

--- a/scripts/test-workout-intensity-codec.mjs
+++ b/scripts/test-workout-intensity-codec.mjs
@@ -269,6 +269,19 @@ assert.deepEqual(
   codec.resolveWorkoutExerciseName(exerciseCatalog, "squat").candidates,
   ["Back Squat", "Front Squat"]
 );
+const pulldownCatalog = [
+  { originId: "1052", displayName: "Seated Lat Pulldowns" },
+  { originId: "1342", displayName: "Lat Pulldowns" },
+  { originId: "1350", displayName: "Single Arm Lat Pulldown" }
+];
+assert.equal(
+  codec.resolveWorkoutExerciseName(pulldownCatalog, "Lat Pulldown").match.originId,
+  "1342"
+);
+assert.equal(
+  codec.resolveWorkoutExerciseName(pulldownCatalog, "Lat Pull Downs").match.originId,
+  "1342"
+);
 assert.equal(
   codec.workoutExerciseName({ name: "T1024", overview: "sid_exercise_preacher_curls" }),
   "Preacher Curls"

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -50,6 +50,7 @@ import type {
   WorkoutDeletePreview,
   DeleteWorkoutResult
 } from "../../electron/types";
+import { formatWorkoutSport } from "../../electron/workoutCapabilities";
 import { ActivityVisualCard } from "./ActivityVisualCard";
 import { FitnessTrendCard } from "./FitnessTrendCard";
 import { HrZoneCard } from "./HrZoneCard";
@@ -299,7 +300,7 @@ function PlanPreviewCard({
               <tr key={entry.key}>
                 <td>{entry.scheduleDate ?? "Library"}</td>
                 <td>{entry.name}</td>
-                <td>{entry.sport ?? "run"}</td>
+                <td>{formatWorkoutSport(entry.sport ?? "run")}</td>
                 <td>
                   {(entry.source
                     ? formatPlanSourceVolume(entry.source, unitSystem)
@@ -1793,11 +1794,13 @@ export function ChatView({
               <h3>How can I help with your training?</h3>
               <div className="chat-suggestions">
                 {[
-                  "How was my last run?",
-                  "Break down my latest run by lap",
-                  "Schedule an easy 8K for Saturday",
+                  "How was my latest activity?",
+                  "Break down my latest workout by lap",
+                  "Build a balanced week from my recent training",
+                  "Schedule bike intervals for Saturday",
+                  "Add strength around my endurance sessions",
                   "Am I recovered enough for a hard session?",
-                  "Download my latest FIT file"
+                  "Download my latest activity FIT file"
                 ].map((suggestion) => (
                   <button
                     key={suggestion}


### PR DESCRIPTION
## What changed

- make Coach plan adaptively across all nine supported COROS workout sports
- ground plans in the athlete activity mix, recovery, and complete upcoming schedule
- show friendly sport labels and sport distributions in plan previews
- preserve sport and sport options through both upload paths
- preflight Strength and HYROX exercise names against the COROS catalog, normalize harmless variants, and let the AI revise genuine ambiguities in the same tool loop

## Why

Coach still behaved as a running-first assistant even though the workout backend was sport-aware. Multi-sport uploads also rebuilt draft entries without sport metadata, causing non-running steps to be validated as Run. Exercise catalog resolution happened too late and treated singular and plural variants as ambiguous.

## Impact

Athletes can request mixed plans without unexpected running defaults. Strength, swim, cycling, climbing, XC ski, trail, and HYROX sessions retain their correct COROS encoding, while ambiguous exercise choices are corrected before an upload preview is confirmed.

## Validation

- npm run test:chat-service
- npm run test:chat-workout-tools
- npm run test:workout-intensity-codec
- npm run build