### PR TITLE
Build AI training library and interactive Coach workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25] - 2026-07-30
+
+### Added
+
+- **Training Library** — a dedicated tab for reusable training: search, filter, sort, preview, create, edit, duplicate, tag, collect, export, schedule, and delete COROS Workout Library workouts; build grouped multi-week plans by dragging workouts across days and a holding area, with rest days, phases, recovery weeks, start-date shifting, and undo/redo; keep local templates and collections; and compare two or three plans by duration, distance, training load, strength sets, sport/intensity mix, weekly progression, peak week, taper, shared workouts, and scheduling conflicts. Native COROS plan discovery and detail reads are live and cached; native grouped-plan writes stay visibly gated until the undocumented contract can be verified (see [architecture notes](docs/training-library-architecture.md))
+- **AI training plans** — describe a goal, length, weekly availability, sports, and constraints, and Coach drafts a complete plan straight into the library, ready to review, edit workout by workout, and schedule
+- **Plan adherence** — scheduled workouts are paired with completed activities by confidence score, with manual correction, skipped/missed/partial states, rescheduling, and planned-versus-completed metrics
+- **Hevy strength sync** — connect a Hevy API key from the Strength tab to merge Hevy workouts into your strength history; sessions logged in both apps are de-duplicated, warmup sets are optional, and disconnecting erases the cached Hevy data from this device
+- **Exercise Explorer** — open any lift for its full history: every set, per-session PRs, best sets by rep range, estimated one-rep-max progression, and volume over time ([#91](https://github.com/JunAkerBuilds/CorosLink/pull/91))
+- **Coach follow-up questions** — instead of guessing, Coach can ask one clarifying question with two to five tappable answers; a typed reply still works, and the question card survives a restart
+
 ### Changed
 
-- **Multi-sport Coach plans** — Coach now uses the athlete's recent activity mix and complete schedule to create adaptive plans across all nine supported COROS workout sports instead of defaulting to running
+- **Multi-sport Coach plans** — Coach now uses the athlete's recent activity mix and complete schedule to create adaptive plans across all nine supported COROS workout sports instead of defaulting to running ([#90](https://github.com/JunAkerBuilds/CorosLink/pull/90))
+- **Destination-aware plan confirmation** — before anything is uploaded, Coach's confirmation card shows the destination (Workout Library, Calendar, local template, COROS Plan Library, or plan plus calendar) along with the weeks, workouts, sports, start date, conflicts, and every remote write it will make; Coach's own tools can draft a plan but can never upload one
+- **Strength view redesign** — reworked layout and charts, a refined muscle mannequin on roughly 30% smaller anatomy assets, and a weekly chart that plots sets alongside weight lifted ([#91](https://github.com/JunAkerBuilds/CorosLink/pull/91))
+- **Workout builder and activity logging redesign** — restructured movement, prescription, load, and rest editing, exercise demonstration clips showing which muscles each movement trains, and a clearer manual activity form
+- Strength volume reads in full words ("1.2 tonnes" rather than "1.2t")
+- Activity queries above the COROS 100-per-page limit are now split across multiple requests and stitched back together
+- A Donate button in the header, for anyone who wants to support the project
 
 ### Fixed
 
 - Coach plan uploads now preserve each workout's sport and sport options instead of treating non-running workouts as Run
 - Strength and HYROX plan drafts now resolve harmless exercise-name variants automatically and feed genuine COROS catalog ambiguities back to Coach for same-response correction before preview or upload
+- The workout editor opened from a training plan is no longer cropped by the dialog around it
 
 ## [0.1.24] - 2026-07-28
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,19 @@ Log in with your COROS account to view training data, fitness scores, and race p
 
 ---
 
+### Strength — resistance training analytics
+
+A dedicated view for lifting, built around a rotatable 3D muscle mannequin that
+shades each muscle by how hard you have worked it.
+
+- **Muscle map** — per-muscle set, volume, and time breakdowns on muscular and skeletal layers
+- **Weekly trends** — weight lifted and sets side by side, with push/pull/legs/core balance
+- **Exercise Explorer** — open any lift for every set, per-session PRs, best sets by rep range, estimated one-rep-max progression, and volume over time
+- **Hevy sync** — connect a Hevy API key to merge Hevy workouts with your COROS strength history; sessions logged in both apps are de-duplicated, warmup sets are optional, and disconnecting erases the cached Hevy data
+- **Metric or imperial** weights and volume, following the Settings unit switch
+
+---
+
 ### Training Library — workouts, plans, templates, and adherence
 
 A dedicated workspace for building and reusing training, from one structured
@@ -317,6 +330,7 @@ Ask training questions with answers grounded in your COROS data.
 - **Multi-sport workout tools** — draft adaptive plans across Run, Trail Run, Bike, Pool Swim, Strength, Indoor Climb, Bouldering, XC Ski, and HYROX
 - **Destination-aware confirmation** — choose Workout Library, Calendar, local template, COROS Plan Library, or Plan + Calendar; review weeks, workouts, sports, start date, conflicts, grouped-plan status, and every remote write before confirming
 - **AI write guard** — Coach tool calls can draft plans but cannot upload them; the athlete must use the confirmation card
+- **Follow-up questions** — Coach asks one clarifying question at a time with tappable answers instead of guessing; typing an answer still works
 - **Chat history** — per-provider conversations persist across restarts
 
 ---

--- a/README.md
+++ b/README.md
@@ -269,6 +269,35 @@ Log in with your COROS account to view training data, fitness scores, and race p
 
 ---
 
+### Training Library — workouts, plans, templates, and adherence
+
+A dedicated workspace for building and reusing training, from one structured
+workout through a complete multi-week cycle.
+
+- **Workout Library** — search, filter, sort, preview full steps, create with the
+  sport-aware builder, edit with revision checks, duplicate, tag, collect,
+  export, schedule, and safely delete COROS workouts
+- **Training Plans** — discover and cache native COROS plans, build local grouped
+  plans, drag workouts across days and a holding area, add rest days and phases,
+  duplicate/reorder/recovery weeks, shift start dates, and undo/redo changes
+- **Templates** — reusable local plans and collections, including templates
+  created from completed activities
+- **Plan comparison** — compare two or three plans by duration, distance,
+  training load, strength sets, sport/intensity mix, weekly progression, peak
+  week, taper, shared workouts, and scheduling conflicts
+- **Completed & adherence** — automatic confidence-scored calendar/activity
+  matching, manual correction, skipped/missed/partial states, rescheduling, and
+  planned-versus-completed metrics
+- **Offline-aware sync** — cached data remains visible when one or more COROS
+  reads fail, with explicit local/synced/pending/conflicted/failed/stale states
+
+Native COROS plan discovery and detail reads are active. Native grouped-plan
+writes remain visibly gated until the undocumented create/update/activation
+contract can be verified without guessing; local templates and the existing
+individual Workout Library/Calendar writes remain available.
+
+---
+
 ### Calendar — scheduled workouts and activities
 
 Month and week views for planned workouts and completed activities on one grid.
@@ -285,7 +314,9 @@ Ask training questions with answers grounded in your COROS data.
 
 - **Providers** — ChatGPT (cloud), Claude Code, or local LLMs (Ollama / LM Studio)
 - **Model selection & extended thinking** where the provider supports them
-- **Multi-sport workout tools** — draft adaptive plans across Run, Trail Run, Bike, Pool Swim, Strength, Indoor Climb, Bouldering, XC Ski, and HYROX; preview them in chat and upload/list/delete COROS workouts with confirmation cards
+- **Multi-sport workout tools** — draft adaptive plans across Run, Trail Run, Bike, Pool Swim, Strength, Indoor Climb, Bouldering, XC Ski, and HYROX
+- **Destination-aware confirmation** — choose Workout Library, Calendar, local template, COROS Plan Library, or Plan + Calendar; review weeks, workouts, sports, start date, conflicts, grouped-plan status, and every remote write before confirming
+- **AI write guard** — Coach tool calls can draft plans but cannot upload them; the athlete must use the confirmation card
 - **Chat history** — per-provider conversations persist across restarts
 
 ---

--- a/docs/coros-plan-write-api.md
+++ b/docs/coros-plan-write-api.md
@@ -1,7 +1,9 @@
 # COROS Training Plan Write API (internal)
 
-Reverse-engineered from the COROS Training Hub web app and verified against the
-live API. These endpoints are **undocumented** and may change.
+Reverse-engineered from the COROS Training Hub web app. The workout-program and
+calendar contracts below have been verified against the live API. Native
+Training Plan Library support has only been verified for reads as of
+2026-07-29. These endpoints are **undocumented** and may change.
 
 All requests use the existing Training Hub session (`accesstoken` + `yfheader`
 with `userId`) against the regional `teamapi*.coros.com` host.
@@ -25,6 +27,44 @@ through the athlete's authenticated Training Hub session.
 | `/training/exercise/query` | GET | Resolve Strength and HYROX exercise IDs/names |
 | `/training/schedule/query` | GET | Read calendar (`startDate`, `endDate`, `supportRestExercise=1`) |
 | `/training/schedule/update` | POST | Add, edit, or delete calendar entries (`status: 1`, `2`, or `3`) |
+| `/training/plan/query` | POST | List native COROS Training Plan Library records; read verified |
+| `/training/plan/detail` | GET | Read native plan detail (`id`, `supportRestExercise=1`); read verified |
+
+## Native COROS Training Plan Library
+
+CorosLink keeps native plans behind `corosTrainingPlanAdapter.ts`, separate
+from individual `/training/program/*` workout operations. The adapter maps the
+known plan, entity, program, and week-stage fields into typed models while
+retaining the complete raw payload for forward-compatible, lossless caching.
+
+The 2026-07-29 first-party Training Hub bundle references these additional
+operations:
+
+| Path | Method | Observed first-party purpose | CorosLink status |
+|---|---|---|---|
+| `/training/plan/add` | POST | Create grouped plan | Feature-gated; write payload not live verified |
+| `/training/plan/update` | POST | Update grouped plan | Feature-gated; concurrency/write behavior not live verified |
+| `/training/plan/copy` | POST | Duplicate grouped plan | Feature-gated; write payload not live verified |
+| `/training/plan/delete` | POST | Delete grouped plan | Feature-gated; delete/active-plan behavior not live verified |
+| `/training/schedule/executeSubPlan` | POST | Activate/schedule a plan | Feature-gated; activation payload not live verified |
+| `/training/schedule/quitSubPlan` | POST | Remove active plan | Feature-gated; cleanup semantics not live verified |
+
+The bundle assembles plan-create data from fields including `name`, `overview`,
+`entities`, `programs`, `weekStages`, `maxIdInPlan`, `totalDay`, `unit`,
+`sourceId`, `sourceUrl`, `minWeeks`, `maxWeeks`, `region`, `pbVersion`, and
+`versionObjects`. That observation is not sufficient evidence to send a write:
+required defaults, identity allocation, version checks, and cleanup behavior
+remain uncertain. CorosLink therefore does not guess these payloads.
+
+Native plan query and detail were checked with a saved Training Hub session and
+no credentials or sensitive headers were logged. Some active-plan detail
+responses omit `programs`; the adapter merges detail-only fields with the full
+grouped arrays returned by `/training/plan/query`.
+
+Until a cleanup-safe, explicitly opted-in verifier proves the complete
+create/read/update/activate/remove/delete lifecycle, the UI exposes the exact
+limitation and preserves the verified alternatives: local grouped templates,
+individual Workout Library writes, and direct calendar scheduling.
 
 ## Create library workout
 
@@ -212,11 +252,12 @@ For each unique workout definition:
 One-off calendar workouts can skip the library step and embed the program
 directly in the schedule update payload.
 
-CorosLink's coach “plan” is a local, confirmation-gated draft whose workouts are
-written to the athlete's Workout Library and Training Calendar. It does not
-create a reusable entry in COROS's separate Training Plan Library via
-`/training/plan/add`. Calendar placement is sufficient for COROS App/watch
-calendar sync, but the distinction matters when describing the result.
+CorosLink's Coach “plan” is a local, confirmation-gated draft. The athlete must
+choose Workout Library, Calendar, local CorosLink template, COROS Plan Library,
+or Plan + Calendar on the card. The native grouped choices remain disabled
+while their writes are unverified. The active alternatives write individual
+workouts, write dated calendar occurrences, or save only to local SQLite. An AI
+tool call cannot execute the upload path.
 
 ## Fixtures
 

--- a/docs/training-library-architecture.md
+++ b/docs/training-library-architecture.md
@@ -1,0 +1,90 @@
+# Training Library architecture
+
+The Training Library is CorosLink's unified workspace for reusable workouts,
+grouped training plans, local templates, and plan-to-activity adherence. It
+extends the existing workout codecs and Training Hub service instead of
+creating a second workout protocol.
+
+## Model and ownership
+
+- `TrainingLibraryWorkout` decorates a COROS library summary with local
+  favorites, tags, collection membership, references, cache metadata, and sync
+  state. Full workout reads and edits still use the existing lossless workout
+  editor document and revision check.
+- `TrainingPlanDocument` is the grouped local model. Entries can reference an
+  existing `programId`, embed a typed `PlanWorkoutEntryInput`, represent rest or
+  notes, or stay in a holding area. Plan phases, metadata, dates, known remote
+  identity/version fields, and planned metrics remain on the grouped object.
+- Native plans use `NativeCorosPlanDetail` at the API boundary. Known fields are
+  typed; the raw response is cached unchanged so unknown first-party fields are
+  not discarded.
+- `TrainingActivityMatch` links a scheduled occurrence to a completed activity
+  with confidence, planned/completed metrics, status, and a durable manual
+  override.
+
+SQLite tables are additive: `training_plans`, `training_workout_metadata`,
+`training_collections`, `training_plan_workout_links`, and
+`training_activity_matches`. Startup uses `CREATE TABLE IF NOT EXISTS`; the
+existing database and legacy database migration are preserved.
+
+## Sync strategy
+
+The renderer requests one `TrainingLibrarySnapshot` through typed preload/IPC
+methods. The main process loads workouts, native plans, and the relevant
+calendar range in parallel. Successful remote reads update the cache. A failed
+source contributes a human-readable partial failure while cached workouts and
+plans remain visible. Items distinguish `local`, `synced`, `pending`,
+`conflicted`, `failed`, and `stale` states.
+
+Remote plan logic stays in `corosTrainingPlanAdapter.ts` and
+`trainingLibraryService.ts`; React does not call COROS endpoints. Snapshot
+refresh is explicit and shared across tabs to avoid per-card API waterfalls.
+
+Native plan edits currently fork to a local copy. This prevents a local change
+from claiming to overwrite COROS when native update semantics have not been
+verified. Local plan/template edits, duplication, date shifting, week
+operations, comparison, and metadata changes remain fully available.
+
+## Verified COROS surface
+
+As of 2026-07-29:
+
+- Verified existing flows: workout program query/detail/calculate/add/update/
+  delete and calendar query/update.
+- Verified read-only native plan discovery: `POST /training/plan/query`.
+- Verified read-only native plan detail: `GET /training/plan/detail` with `id`
+  and `supportRestExercise=1`.
+- Observed in the first-party bundle but not live-write-verified:
+  `/training/plan/add`, `update`, `copy`, `delete`,
+  `/training/schedule/executeSubPlan`, and
+  `/training/schedule/quitSubPlan`.
+
+All native writes are feature-gated. The reason is returned as typed capability
+data and shown in both the Training Plan Library and Coach confirmation card.
+No guessed payload is sent.
+
+## Safety and fallbacks
+
+- Remote workout deletion, plan deletion, collection deletion, and bulk
+  deletion require an explicit confirmation flag; the renderer displays the
+  affected records and known references first.
+- Coach tool calls can create a draft but cannot execute a plan upload. Only the
+  athlete's confirmation card invokes the write IPC method after a destination
+  is selected and the writes/conflicts are displayed.
+- Coach fallbacks are COROS Workout Library, direct COROS Calendar scheduling,
+  and a zero-remote-write local template.
+- Authentication tokens and request headers are never included in plan logs or
+  stored raw payloads.
+- Native write verification must remain opt-in and isolated. A future verifier
+  must create uniquely named temporary data and remove activation, calendar,
+  plan, and workout artifacts in `finally` before any write capability is
+  enabled.
+
+## Tests
+
+`npm run test:training-library` covers additive legacy migration and data
+preservation, typed/native parsing with unknown-field retention, persistence
+links, schedule shifting, week operations, plan comparison, conflict counting,
+automatic/manual activity pairing, confirmation guards, and the existing
+workout/intensity codecs. The SQLite portion runs with Electron's embedded Node
+ABI, matching the packaged application.

--- a/electron/chatCoachContext.ts
+++ b/electron/chatCoachContext.ts
@@ -35,7 +35,10 @@ export function buildCoachInstructions(): string {
     "upload_training_plan until the athlete confirms via the Upload to COROS button. If " +
     "draft_training_plan returns exercise_resolution_required, update the affected steps to exact COROS " +
     "candidate names and call draft_training_plan again in the same response. Ask the athlete only when " +
-    "the candidates materially change the intended movement or no supported candidate is available.\n\n" +
+    "the candidates materially change the intended movement or no supported candidate is available. " +
+    "Whenever you need the athlete to choose or clarify something, call request_coach_input with " +
+    "2–5 concise choices instead of asking only in prose. Put the recommended answer first, call it " +
+    "at most once per turn, and wait for the athlete's response before continuing.\n\n" +
     "To delete workouts: use list_scheduled_workouts to find calendar entries, then " +
     "delete_workout to stage a confirmation card. The athlete must click Delete from COROS — " +
     "never claim a workout was removed until they confirm via the button."

--- a/electron/chatHistoryStore.ts
+++ b/electron/chatHistoryStore.ts
@@ -13,6 +13,8 @@ import type {
   ActivityVisualPreview,
   ChatProvider,
   ChatSessionSummary,
+  CoachInputChoice,
+  CoachInputPrompt,
   FitnessTrendPreview,
   HrZoneEntry,
   HrZonePreview,
@@ -118,6 +120,57 @@ function parseSource(value: unknown): PersistedChatSource | undefined {
     source.mcpError = value.mcpError;
   }
   return source;
+}
+
+function parseCoachInputPrompt(value: unknown): CoachInputPrompt | null {
+  if (
+    !isRecord(value) ||
+    typeof value.promptId !== "string" ||
+    typeof value.question !== "string" ||
+    typeof value.allowCustom !== "boolean" ||
+    !Array.isArray(value.choices)
+  ) {
+    return null;
+  }
+
+  const choices = value.choices
+    .map((choice): CoachInputChoice | null => {
+      if (
+        !isRecord(choice) ||
+        typeof choice.id !== "string" ||
+        typeof choice.label !== "string" ||
+        typeof choice.response !== "string"
+      ) {
+        return null;
+      }
+      return {
+        id: choice.id,
+        label: choice.label,
+        response: choice.response,
+        ...(typeof choice.description === "string"
+          ? { description: choice.description }
+          : {})
+      };
+    })
+    .filter((choice): choice is CoachInputChoice => choice !== null);
+
+  if (choices.length !== value.choices.length || choices.length < 2) {
+    return null;
+  }
+
+  return {
+    promptId: value.promptId,
+    question: value.question,
+    choices,
+    allowCustom: value.allowCustom,
+    ...(typeof value.answer === "string" ? { answer: value.answer } : {}),
+    ...(typeof value.selectedChoiceId === "string"
+      ? { selectedChoiceId: value.selectedChoiceId }
+      : {}),
+    ...(typeof value.answeredAt === "number"
+      ? { answeredAt: value.answeredAt }
+      : {})
+  };
 }
 
 function parsePlanDraftEntry(value: unknown): PlanDraftPreviewEntry | null {
@@ -560,19 +613,6 @@ function parseMessageEntry(value: unknown): PersistedChatMessageEntry | null {
     return null;
   }
 
-  if (value.kind !== "message") {
-    const role =
-      value.role === "assistant" ? "assistant" : value.role === "user" ? "user" : null;
-    if (!role || typeof value.content !== "string") {
-      return null;
-    }
-
-    const source = parseSource(value.source);
-    return source
-      ? { kind: "message", role, content: value.content, source }
-      : { kind: "message", role, content: value.content };
-  }
-
   const role =
     value.role === "assistant" ? "assistant" : value.role === "user" ? "user" : null;
   if (!role || typeof value.content !== "string") {
@@ -580,9 +620,17 @@ function parseMessageEntry(value: unknown): PersistedChatMessageEntry | null {
   }
 
   const source = parseSource(value.source);
-  return source
-    ? { kind: "message", role, content: value.content, source }
-    : { kind: "message", role, content: value.content };
+  const reasoningSummary =
+    typeof value.reasoningSummary === "string" && value.reasoningSummary.trim()
+      ? value.reasoningSummary
+      : undefined;
+  return {
+    kind: "message",
+    role,
+    content: value.content,
+    ...(source ? { source } : {}),
+    ...(reasoningSummary ? { reasoningSummary } : {})
+  };
 }
 
 function parseEntry(value: unknown): PersistedChatEntry | null {
@@ -593,6 +641,11 @@ function parseEntry(value: unknown): PersistedChatEntry | null {
   if (value.kind === "planDraft") {
     const draft = parsePlanDraft(value.draft);
     return draft ? { kind: "planDraft", draft } : null;
+  }
+
+  if (value.kind === "coachPrompt") {
+    const prompt = parseCoachInputPrompt(value.prompt);
+    return prompt ? { kind: "coachPrompt", prompt } : null;
   }
 
   if (value.kind === "workoutDelete") {
@@ -678,6 +731,11 @@ function derivePreviewFromEntries(entries: PersistedChatEntry[]): string {
     }
     if (entry.kind === "planDraft") {
       return entry.draft.summary || entry.draft.name;
+    }
+    if (entry.kind === "coachPrompt") {
+      return entry.prompt.answeredAt
+        ? entry.prompt.question
+        : `Waiting for your answer: ${entry.prompt.question}`;
     }
     if (entry.kind === "workoutDelete") {
       return entry.preview.summary;

--- a/electron/chatInteractionTools.ts
+++ b/electron/chatInteractionTools.ts
@@ -1,0 +1,136 @@
+import crypto from "node:crypto";
+import type { CoachInputChoice, CoachInputPrompt, CorosMcpTool } from "./types";
+
+export const CHAT_INTERACTION_TOOL_NAMES = ["request_coach_input"] as const;
+
+export type ChatInteractionToolName =
+  (typeof CHAT_INTERACTION_TOOL_NAMES)[number];
+
+export function isChatInteractionTool(
+  name: string
+): name is ChatInteractionToolName {
+  return (CHAT_INTERACTION_TOOL_NAMES as readonly string[]).includes(name);
+}
+
+export function getChatInteractionTools(): CorosMcpTool[] {
+  return [
+    {
+      name: "request_coach_input",
+      description:
+        "Pause and ask the athlete one necessary clarifying question using clickable choices. " +
+        "Use this instead of asking a question only in prose. Put the recommended choice first. " +
+        "Call it at most once per response, then stop and wait for the athlete's next message.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          question: {
+            type: "string",
+            description: "One concise question for the athlete."
+          },
+          choices: {
+            type: "array",
+            minItems: 2,
+            maxItems: 5,
+            description: "Two to five distinct answers, recommended choice first.",
+            items: {
+              type: "object",
+              properties: {
+                label: {
+                  type: "string",
+                  description: "Short button label, ideally under 45 characters."
+                },
+                description: {
+                  type: "string",
+                  description: "Optional one-sentence consequence or tradeoff."
+                },
+                response: {
+                  type: "string",
+                  description:
+                    "Optional complete answer to send back. Defaults to the label."
+                }
+              },
+              required: ["label"]
+            }
+          },
+          allow_custom: {
+            type: "boolean",
+            description:
+              "Whether the athlete may type a different answer. Defaults to true."
+          }
+        },
+        required: ["question", "choices"]
+      }
+    }
+  ];
+}
+
+function cleanText(value: unknown, maxLength: number): string {
+  return typeof value === "string"
+    ? value.trim().replace(/\s+/g, " ").slice(0, maxLength)
+    : "";
+}
+
+export function buildCoachInputPrompt(
+  args: Record<string, unknown>,
+  promptId = crypto.randomUUID()
+): CoachInputPrompt {
+  const question = cleanText(args.question, 500);
+  if (!question) {
+    throw new Error("request_coach_input requires a question.");
+  }
+
+  const rawChoices = Array.isArray(args.choices) ? args.choices : [];
+  const choices: CoachInputChoice[] = [];
+  const seenLabels = new Set<string>();
+  for (const [index, rawChoice] of rawChoices.entries()) {
+    if (!rawChoice || typeof rawChoice !== "object" || Array.isArray(rawChoice)) {
+      continue;
+    }
+    const source = rawChoice as Record<string, unknown>;
+    const label = cleanText(source.label, 80);
+    const normalizedLabel = label.toLocaleLowerCase();
+    if (!label || seenLabels.has(normalizedLabel)) {
+      continue;
+    }
+    seenLabels.add(normalizedLabel);
+    const description = cleanText(source.description, 240);
+    const response = cleanText(source.response, 500) || label;
+    choices.push({
+      id: `choice-${index + 1}`,
+      label,
+      ...(description ? { description } : {}),
+      response
+    });
+    if (choices.length === 5) break;
+  }
+
+  if (choices.length < 2) {
+    throw new Error("request_coach_input requires at least two distinct choices.");
+  }
+
+  return {
+    promptId,
+    question,
+    choices,
+    allowCustom: args.allow_custom !== false
+  };
+}
+
+export function handleChatInteractionTool(
+  name: ChatInteractionToolName,
+  args: Record<string, unknown>,
+  onCoachPrompt?: (prompt: CoachInputPrompt) => void
+): string {
+  if (name !== "request_coach_input") {
+    throw new Error(`Unsupported Coach interaction tool: ${name}`);
+  }
+  const prompt = buildCoachInputPrompt(args);
+  onCoachPrompt?.(prompt);
+  return JSON.stringify({
+    ok: true,
+    prompt_id: prompt.promptId,
+    status: "waiting_for_athlete",
+    action:
+      "The choices are visible to the athlete. End this response now and wait for their next message."
+  });
+}

--- a/electron/chatResponsesProtocol.ts
+++ b/electron/chatResponsesProtocol.ts
@@ -1,0 +1,44 @@
+/** Build the ChatGPT Responses request with safe reasoning summaries enabled. */
+export function buildResponsesRequest(
+  model: string,
+  instructions: string,
+  input: Record<string, unknown>[],
+  tools: Record<string, unknown>[],
+  includeReasoningSummary = true
+): Record<string, unknown> {
+  const request: Record<string, unknown> = {
+    model,
+    instructions,
+    input,
+    stream: true,
+    store: false
+  };
+  if (includeReasoningSummary) {
+    request.reasoning = { summary: "auto" };
+  }
+  if (tools.length > 0) {
+    request.tools = tools;
+    request.tool_choice = "auto";
+  }
+  return request;
+}
+
+/** Pull incremental assistant output text from a Responses SSE event. */
+export function extractResponseTextDelta(event: unknown): string {
+  if (!event || typeof event !== "object") return "";
+  const evt = event as { type?: string; delta?: unknown };
+  return evt.type === "response.output_text.delta" &&
+    typeof evt.delta === "string"
+    ? evt.delta
+    : "";
+}
+
+/** Pull a display-safe reasoning summary delta (never raw chain-of-thought). */
+export function extractReasoningSummaryDelta(event: unknown): string {
+  if (!event || typeof event !== "object") return "";
+  const evt = event as { type?: string; delta?: unknown };
+  return evt.type === "response.reasoning_summary_text.delta" &&
+    typeof evt.delta === "string"
+    ? evt.delta
+    : "";
+}

--- a/electron/chatService.ts
+++ b/electron/chatService.ts
@@ -37,7 +37,18 @@ import {
   isChatAnalyticsTool,
   type ChatAnalyticsToolName
 } from "./chatAnalyticsTools";
+import {
+  getChatInteractionTools,
+  handleChatInteractionTool,
+  isChatInteractionTool,
+  type ChatInteractionToolName
+} from "./chatInteractionTools";
 import { parseFunctionCallArguments } from "./chatToolArguments";
+import {
+  buildResponsesRequest,
+  extractReasoningSummaryDelta,
+  extractResponseTextDelta
+} from "./chatResponsesProtocol";
 import {
   detectLocalChatServersRequest,
   streamLocalChatCompletion,
@@ -694,7 +705,9 @@ export async function streamChat(
       if (runtimeConfig.toolsEnabled) {
         await ensureAllMcpConnected();
       }
-      const chatTools = runtimeConfig.toolsEnabled ? getAllChatTools() : getChatWorkoutTools();
+      const chatTools = runtimeConfig.toolsEnabled
+        ? getAllChatTools()
+        : [...getChatWorkoutTools(), ...getChatInteractionTools()];
       const effectiveInstructions = withLiveToolInstructions(
         instructions,
         chatTools
@@ -840,7 +853,16 @@ export async function streamChat(
               Array.isArray(echoed) ? echoed.length : "unknown"
             );
           }
-          const delta = extractDelta(event);
+          const reasoningDelta = extractReasoningSummaryDelta(event);
+          if (reasoningDelta) {
+            send("chat:streamInfo", {
+              requestId,
+              kind: "thinking",
+              delta: reasoningDelta
+            });
+            continue;
+          }
+          const delta = extractResponseTextDelta(event);
           if (delta) {
             fullText += delta;
             send("chat:streamToken", { requestId, delta });
@@ -967,7 +989,8 @@ function getAllChatTools(): CorosMcpTool[] {
     ...getAllMcpTools(),
     ...getChatActivityTools(),
     ...getChatAnalyticsTools(),
-    ...getChatWorkoutTools()
+    ...getChatWorkoutTools(),
+    ...getChatInteractionTools()
   ];
 }
 
@@ -1026,7 +1049,13 @@ export function getClaudeCodeTools(
     return tool.name === "draft_training_plan";
   });
 
-  return [...remoteTools, ...activityTools, ...analyticsTools, ...workoutTools];
+  return [
+    ...remoteTools,
+    ...activityTools,
+    ...analyticsTools,
+    ...workoutTools,
+    ...getChatInteractionTools()
+  ];
 }
 
 async function executeChatTool(
@@ -1037,6 +1066,19 @@ async function executeChatTool(
   unitSystem: UnitSystem,
   claudePermissions?: ClaudeCodePermissions
 ): Promise<string> {
+  if (isChatInteractionTool(name)) {
+    return handleChatInteractionTool(
+      name as ChatInteractionToolName,
+      args,
+      (prompt) => {
+        send("chat:streamInfo", {
+          requestId,
+          kind: "coachPrompt",
+          prompt
+        });
+      }
+    );
+  }
   if (isChatWorkoutTool(name)) {
     return handleChatWorkoutTool(name as ChatWorkoutToolName, args, {
       onPlanDraft: (preview: PlanDraftPreview) => {
@@ -1157,21 +1199,42 @@ async function resolveModelAndOpenStream(
 
   let lastDetail = "";
   for (const model of candidates) {
-    const response = await fetch(RESPONSES_URL, {
-      method: "POST",
-      signal,
-      headers: {
-        Authorization: `Bearer ${token.access_token}`,
-        "Content-Type": "application/json",
-        Accept: "text/event-stream",
-        "OpenAI-Beta": "responses=experimental",
-        originator: RESPONSES_ORIGINATOR,
-        "User-Agent": RESPONSES_USER_AGENT,
-        session_id: requestId,
-        ...(token.account_id ? { "chatgpt-account-id": token.account_id } : {})
-      },
-      body: JSON.stringify(buildResponsesRequest(model, instructions, input, tools))
-    });
+    const open = (includeReasoningSummary: boolean) =>
+      fetch(RESPONSES_URL, {
+        method: "POST",
+        signal,
+        headers: {
+          Authorization: `Bearer ${token.access_token}`,
+          "Content-Type": "application/json",
+          Accept: "text/event-stream",
+          "OpenAI-Beta": "responses=experimental",
+          originator: RESPONSES_ORIGINATOR,
+          "User-Agent": RESPONSES_USER_AGENT,
+          session_id: requestId,
+          ...(token.account_id ? { "chatgpt-account-id": token.account_id } : {})
+        },
+        body: JSON.stringify(
+          buildResponsesRequest(
+            model,
+            instructions,
+            input,
+            tools,
+            includeReasoningSummary
+          )
+        )
+      });
+
+    let response = await open(true);
+    let responseDetail = "";
+    if (!response.ok && response.status === 400) {
+      responseDetail = await response.text().catch(() => "");
+      if (/reasoning|summary/i.test(responseDetail)) {
+        // Some plan/model combinations do not expose summaries. Preserve the
+        // Coach response and tool progress rather than failing the whole turn.
+        response = await open(false);
+        responseDetail = "";
+      }
+    }
 
     if (response.ok && response.body) {
       if (model !== cached) setSetting(SETTINGS.model, model);
@@ -1185,7 +1248,8 @@ async function resolveModelAndOpenStream(
       };
     }
 
-    lastDetail = await response.text().catch(() => "");
+    lastDetail =
+      responseDetail || (await response.text().catch(() => ""));
     // Unsupported-model rejection: drop a stale cached choice and try the next.
     if (response.status === 400 && /is not supported/i.test(lastDetail)) {
       if (model === cached) deleteSettings([SETTINGS.model]);
@@ -1201,26 +1265,6 @@ async function resolveModelAndOpenStream(
     error: `No supported chat model for this ChatGPT account. ${truncate(lastDetail, 600)}`,
     authError: false
   };
-}
-
-function buildResponsesRequest(
-  model: string,
-  instructions: string,
-  input: Record<string, unknown>[],
-  tools: Record<string, unknown>[]
-): Record<string, unknown> {
-  const request: Record<string, unknown> = {
-    model,
-    instructions,
-    input,
-    stream: true,
-    store: false
-  };
-  if (tools.length > 0) {
-    request.tools = tools;
-    request.tool_choice = "auto";
-  }
-  return request;
 }
 
 /** A COROS message turned into a Responses-API input item. */
@@ -1257,11 +1301,15 @@ function withLiveToolInstructions(
   }
   const activityTools = tools.filter((tool) => isChatActivityTool(tool.name));
   const analyticsTools = tools.filter((tool) => isChatAnalyticsTool(tool.name));
+  const interactionTools = tools.filter((tool) =>
+    isChatInteractionTool(tool.name)
+  );
   const mcpTools = tools.filter(
     (tool) =>
       !isChatWorkoutTool(tool.name) &&
       !isChatActivityTool(tool.name) &&
-      !isChatAnalyticsTool(tool.name)
+      !isChatAnalyticsTool(tool.name) &&
+      !isChatInteractionTool(tool.name)
   );
   const corosMcpTools = mcpTools.filter((tool) =>
     tool.name.startsWith("coros__")
@@ -1328,6 +1376,15 @@ function withLiveToolInstructions(
       buildCoachSportCapabilityGuide()
     );
   }
+  if (interactionTools.length > 0) {
+    sections.push(
+      "",
+      "## Athlete questions",
+      "When you need an answer before continuing, call request_coach_input with one concise question and 2–5 distinct choices. " +
+        "Put the recommended choice first and explain important tradeoffs in each choice description. " +
+        "Do not ask a clarification question only in prose. After calling request_coach_input, stop and wait for the athlete's next message."
+    );
+  }
   return sections.join("\n");
 }
 
@@ -1335,16 +1392,6 @@ interface FunctionCall {
   call_id: string;
   name: string;
   arguments: string;
-}
-
-/** Pulls incremental assistant text out of a Responses-API SSE event. */
-function extractDelta(event: unknown): string {
-  if (!event || typeof event !== "object") return "";
-  const evt = event as { type?: string; delta?: unknown };
-  if (evt.type === "response.output_text.delta" && typeof evt.delta === "string") {
-    return evt.delta;
-  }
-  return "";
 }
 
 /** Detects a completed function tool call in a Responses-API SSE event. */

--- a/electron/chatService.ts
+++ b/electron/chatService.ts
@@ -950,9 +950,10 @@ export function cancelChat(requestId: string): void {
 
 export async function uploadTrainingPlanDraft(
   draftId: string,
-  unitSystem: UnitSystem = "metric"
+  unitSystem: UnitSystem = "metric",
+  destination: import("./types").TrainingPlanDestination = "workoutLibrary"
 ): Promise<UploadPlanResult> {
-  return uploadPlanDraftById(draftId, normalizeUnitSystem(unitSystem));
+  return uploadPlanDraftById(draftId, normalizeUnitSystem(unitSystem), destination);
 }
 
 export async function confirmWorkoutDelete(

--- a/electron/chatWorkoutTools.ts
+++ b/electron/chatWorkoutTools.ts
@@ -27,12 +27,16 @@ import type {
   DeleteWorkoutResult,
   PlanDraftPreview,
   PlanWorkoutEntryInput,
+  TrainingPlanDestination,
+  TrainingPlanDocument,
   UploadPlanResult,
   WorkoutDeletePreview,
   UnitSystem
 } from "./types";
 import { buildDraftTrainingPlanInputSchema } from "./workoutCapabilities";
 import { formatDistanceValue } from "./unitSystem.js";
+import { createTrainingPlan } from "./trainingPlanDomain";
+import { saveLocalTrainingPlan } from "./trainingLibraryService";
 
 interface StoredPlanDraft {
   draftId: string;
@@ -156,8 +160,8 @@ export function getChatWorkoutTools(): CorosMcpTool[] {
     {
       name: "upload_training_plan",
       description:
-        "Upload a previously drafted plan to COROS. Only call after the athlete confirms " +
-        "via the Upload button in chat — otherwise tell them to review the preview first.",
+        "Compatibility guard for plan uploads. Plan writes can only be initiated by the athlete " +
+        "from the confirmation card; this tool never performs a remote write.",
       inputSchema: {
         type: "object",
         properties: {
@@ -306,6 +310,101 @@ export function buildTrainingPlanUploadInput(
   };
 }
 
+function normalizePlanDate(value?: string): string | undefined {
+  if (!value) return undefined;
+  const digits = value.replace(/-/g, "");
+  if (!/^\d{8}$/.test(digits)) return undefined;
+  return `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`;
+}
+
+function dateDayOffset(start: string, current: string): number {
+  const startDate = new Date(`${start}T12:00:00`);
+  const currentDate = new Date(`${current}T12:00:00`);
+  return Math.max(0, Math.round((currentDate.valueOf() - startDate.valueOf()) / 86_400_000));
+}
+
+function saveDraftAsLocalTemplate(
+  draftId: string,
+  plan: CorosTrainingPlanDraft
+): TrainingPlanDocument {
+  const scheduledDates = plan.workouts
+    .map((entry) => normalizePlanDate(entry.schedule_date))
+    .filter((date): date is string => Boolean(date))
+    .sort();
+  const startDate = scheduledDates[0];
+  const document = createTrainingPlan(plan.name, "template");
+  document.id = `template:coach:${draftId}`;
+  document.description = "Generated in Coach and saved locally for reuse.";
+  document.startDate = startDate;
+  document.entries = plan.workouts.map((workout, index) => {
+    const scheduledDate = normalizePlanDate(workout.schedule_date);
+    const offset = startDate && scheduledDate
+      ? dateDayOffset(startDate, scheduledDate)
+      : undefined;
+    return {
+      id: `entry:${draftId}:${workout.key || index}`,
+      kind: "workout" as const,
+      weekIndex: offset === undefined ? Math.floor(index / 7) : Math.floor(offset / 7),
+      dayIndex: offset === undefined ? undefined : offset % 7,
+      sortOrder: workout.sort_no ?? index,
+      title: workout.name,
+      workout: {
+        key: workout.key,
+        name: workout.name,
+        description: workout.description,
+        sport: workout.sport ?? "run",
+        sport_options: workout.sport_options,
+        steps: workout.steps,
+        distance_km: workout.distance_km,
+        schedule_date: workout.schedule_date,
+        sort_no: workout.sort_no,
+        save_to_library: workout.save_to_library
+      }
+    };
+  });
+  document.weekCount = Math.max(
+    1,
+    ...document.entries.map((entry) => entry.weekIndex + 1)
+  );
+  document.sportMix = [
+    ...new Set(plan.workouts.map((entry) => entry.sport ?? "run"))
+  ];
+  return saveLocalTrainingPlan(document);
+}
+
+function inputForDestination(
+  plan: CorosTrainingPlanDraft,
+  destination: TrainingPlanDestination
+): CorosTrainingPlanDraftInput {
+  const input = buildTrainingPlanUploadInput(plan);
+  if (destination === "workoutLibrary") {
+    return {
+      ...input,
+      workouts: input.workouts.map((workout) => ({
+        ...workout,
+        schedule_date: undefined,
+        save_to_library: true
+      }))
+    };
+  }
+  if (destination === "calendar") {
+    const unscheduled = input.workouts.filter((workout) => !workout.schedule_date);
+    if (unscheduled.length > 0) {
+      throw new Error(
+        `${unscheduled.length} workout${unscheduled.length === 1 ? " is" : "s are"} missing a date. Add dates before choosing Calendar.`
+      );
+    }
+    return {
+      ...input,
+      workouts: input.workouts.map((workout) => ({
+        ...workout,
+        save_to_library: false
+      }))
+    };
+  }
+  return input;
+}
+
 async function detectScheduleConflicts(
   draft: CorosTrainingPlanDraft
 ): Promise<string[]> {
@@ -418,11 +517,9 @@ async function handleDraftTrainingPlan(
 
 async function handleUploadTrainingPlan(
   args: Record<string, unknown>,
-  unitSystem: UnitSystem
+  _unitSystem: UnitSystem
 ): Promise<string> {
   const draftId = String(args.draft_id ?? args.draftId ?? "").trim();
-  const confirmed = args.confirmed === true;
-
   if (!draftId) {
     return JSON.stringify({ ok: false, error: "draft_id is required." });
   }
@@ -444,31 +541,11 @@ async function handleUploadTrainingPlan(
     });
   }
 
-  if (!confirmed) {
-    return JSON.stringify({
-      ok: false,
-      error:
-        "Upload requires athlete confirmation. Ask them to click Upload to COROS in the chat preview, " +
-        "or pass confirmed: true only after they explicitly approve."
-    });
-  }
-
-  const input = buildTrainingPlanUploadInput(stored.plan);
-
-  const result = await uploadTrainingPlan(input, unitSystem);
-  stored.uploadedAt = Date.now();
-  stored.preview.uploadedAt = stored.uploadedAt;
-  stored.preview.uploadResult = {
-    workoutsScheduled: result.workoutsScheduled,
-    workoutsCreated: result.workoutsCreated
-  };
-  persistPlanDraft(stored);
-  markChatPlanDraftUploaded(draftId, stored.uploadedAt);
-
   return JSON.stringify({
-    ok: true,
-    result: summarizeUploadResult(result),
-    message: `Uploaded "${result.planName}" — ${result.workoutsScheduled} scheduled, ${result.workoutsCreated} saved to library.`
+    ok: false,
+    confirmation_required: true,
+    error:
+      "Plan writes cannot run from an AI tool call. Ask the athlete to choose a destination and confirm the plan card."
   });
 }
 
@@ -757,7 +834,8 @@ export async function confirmWorkoutDeleteById(
 
 export async function uploadPlanDraftById(
   draftId: string,
-  unitSystem: UnitSystem = "metric"
+  unitSystem: UnitSystem = "metric",
+  destination: TrainingPlanDestination = "workoutLibrary"
 ): Promise<UploadPlanResult> {
   const stored = loadStoredPlanDraft(draftId);
   if (!stored) {
@@ -769,14 +847,45 @@ export async function uploadPlanDraftById(
     throw new Error("This training plan was already uploaded.");
   }
 
-  const input = buildTrainingPlanUploadInput(stored.plan);
+  if (destination === "nativePlan" || destination === "nativePlanAndCalendar") {
+    throw new Error(
+      "Native COROS plan writes are unavailable because the create/update payload has not been live-verified safely. Choose Workout Library, Calendar, or Local template."
+    );
+  }
 
-  const result = await uploadTrainingPlan(input, unitSystem);
+  let result: UploadPlanResult;
+  if (destination === "localTemplate") {
+    const saved = saveDraftAsLocalTemplate(draftId, stored.plan);
+    result = {
+      planName: saved.name,
+      workoutsCreated: 0,
+      workoutsScheduled: 0,
+      entries: [],
+      destination,
+      localPlanId: saved.id,
+      groupedPlanCreated: false,
+      remoteWrites: []
+    };
+  } else {
+    const input = inputForDestination(stored.plan, destination);
+    const uploaded = await uploadTrainingPlan(input, unitSystem);
+    result = {
+      ...uploaded,
+      destination,
+      groupedPlanCreated: false,
+      remoteWrites: destination === "calendar"
+        ? input.workouts.map((workout) => `Schedule ${workout.name} on ${workout.schedule_date}`)
+        : input.workouts.map((workout) => `Create workout ${workout.name}`)
+    };
+  }
   stored.uploadedAt = Date.now();
   stored.preview.uploadedAt = stored.uploadedAt;
   stored.preview.uploadResult = {
     workoutsScheduled: result.workoutsScheduled,
-    workoutsCreated: result.workoutsCreated
+    workoutsCreated: result.workoutsCreated,
+    destination,
+    localPlanId: result.localPlanId,
+    groupedPlanCreated: result.groupedPlanCreated
   };
   persistPlanDraft(stored);
   markChatPlanDraftUploaded(draftId, stored.uploadedAt);

--- a/electron/chatWorkoutTools.ts
+++ b/electron/chatWorkoutTools.ts
@@ -473,8 +473,8 @@ async function handleDraftTrainingPlan(
         message: issue.message
       })),
       action: exerciseResolution.issues.every((issue) => issue.candidates.length > 0)
-        ? "Update each affected step to the exact best-matching candidate and call draft_training_plan again now. Ask the athlete only when the candidates materially change the intended movement."
-        : "At least one exercise is unavailable. Ask the athlete for a supported alternative, then call draft_training_plan again."
+        ? "Update each affected step to the exact best-matching candidate and call draft_training_plan again now. If the candidates materially change the intended movement, call request_coach_input with the exact candidates as clickable choices."
+        : "At least one exercise is unavailable. Call request_coach_input with supported alternatives as clickable choices, then wait for the athlete before calling draft_training_plan again."
     });
   }
   const resolvedDraft = exerciseResolution.draft;

--- a/electron/corosTrainingPlanAdapter.ts
+++ b/electron/corosTrainingPlanAdapter.ts
@@ -1,0 +1,182 @@
+import {
+  getWorkoutProgramDetail,
+  readNativeTrainingPlanEndpoint
+} from "./trainingHubService";
+import type {
+  NativeCorosPlanDetail,
+  NativeCorosPlanEntity,
+  NativeCorosPlanProgram,
+  NativeCorosPlanSummary,
+  TrainingHubScheduledExercise
+} from "./types";
+
+type RawPlan = Record<string, unknown>;
+
+function numberValue(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const parsed = String(value).trim();
+  return parsed || undefined;
+}
+
+function objectArray(value: unknown): RawPlan[] {
+  return Array.isArray(value)
+    ? value.filter(
+        (item): item is RawPlan => typeof item === "object" && item !== null
+      )
+    : [];
+}
+
+function mapEntity(raw: RawPlan): NativeCorosPlanEntity {
+  return {
+    idInPlan: stringValue(raw.idInPlan) ?? stringValue(raw.id) ?? "",
+    planProgramId: stringValue(raw.planProgramId),
+    happenDay: stringValue(raw.happenDay),
+    dayNo: numberValue(raw.dayNo),
+    sortNo: numberValue(raw.sortNo),
+    sortNoInPlan: numberValue(raw.sortNoInPlan),
+    sortNoInSchedule: numberValue(raw.sortNoInSchedule),
+    status: numberValue(raw.status) ?? numberValue(raw.executeStatus)
+  };
+}
+
+function mapProgram(raw: RawPlan): NativeCorosPlanProgram {
+  return {
+    id: stringValue(raw.id),
+    idInPlan: stringValue(raw.idInPlan),
+    planProgramId: stringValue(raw.planProgramId),
+    name: stringValue(raw.name) ?? "Workout",
+    overview: stringValue(raw.overview),
+    sportType: numberValue(raw.sportType),
+    planDistance: numberValue(raw.planDistance) ?? numberValue(raw.distance),
+    planDuration: numberValue(raw.planDuration) ?? numberValue(raw.duration),
+    planTrainingLoad:
+      numberValue(raw.planTrainingLoad) ?? numberValue(raw.trainingLoad),
+    planSets: numberValue(raw.planSets) ?? numberValue(raw.totalSets),
+    exercises: objectArray(raw.exercises) as unknown as TrainingHubScheduledExercise[]
+  };
+}
+
+function mapSummary(raw: RawPlan, syncedAt: string): NativeCorosPlanSummary {
+  const programs = objectArray(raw.programs).map(mapProgram);
+  const sportTypes = [
+    ...new Set(
+      programs
+        .map((program) => program.sportType)
+        .filter((value): value is number => value !== undefined)
+    )
+  ];
+  const sum = (pick: (program: NativeCorosPlanProgram) => number | undefined) =>
+    programs.reduce((total, program) => total + (pick(program) ?? 0), 0);
+  return {
+    remoteId: stringValue(raw.id) ?? "",
+    name: stringValue(raw.name) ?? "Training Plan",
+    overview: stringValue(raw.overview) ?? "",
+    totalDay: numberValue(raw.totalDay) ?? 0,
+    minWeeks: numberValue(raw.minWeeks),
+    maxWeeks: numberValue(raw.maxWeeks),
+    startDay: stringValue(raw.startDay),
+    endDay: stringValue(raw.endDay),
+    executeStatus: numberValue(raw.executeStatus),
+    inSchedule: numberValue(raw.inSchedule) === 1,
+    workoutCount: programs.length,
+    sportTypes,
+    trainingLoad: sum((program) => program.planTrainingLoad) || undefined,
+    durationSeconds: sum((program) => program.planDuration) || undefined,
+    distanceMeters: sum((program) => program.planDistance) || undefined,
+    version: numberValue(raw.version),
+    updateTimestamp: numberValue(raw.updateTimestamp),
+    syncState: "synced",
+    lastSyncedAt: syncedAt
+  };
+}
+
+export function parseNativeCorosPlan(
+  raw: RawPlan,
+  syncedAt = new Date().toISOString()
+): NativeCorosPlanDetail {
+  const summary = mapSummary(raw, syncedAt);
+  return {
+    ...summary,
+    entities: objectArray(raw.entities)
+      .map(mapEntity)
+      .filter((entity) => entity.idInPlan),
+    programs: objectArray(raw.programs).map(mapProgram),
+    weekStages: objectArray(raw.weekStages).map((stage) => ({
+      weekNo: numberValue(stage.weekNo) ?? 1,
+      stage:
+        typeof stage.stage === "string" || typeof stage.stage === "number"
+          ? stage.stage
+          : undefined,
+      planDistance: numberValue(stage.planDistance),
+      planDuration: numberValue(stage.planDuration),
+      planTrainingLoad: numberValue(stage.planTrainingLoad)
+    })),
+    rawPayload: raw
+  };
+}
+
+export async function listNativeCorosPlans(): Promise<NativeCorosPlanDetail[]> {
+  const data = await readNativeTrainingPlanEndpoint<unknown>(
+    "/training/plan/query",
+    { method: "POST", body: {} }
+  );
+  const syncedAt = new Date().toISOString();
+  return objectArray(data)
+    .map((raw) => parseNativeCorosPlan(raw, syncedAt))
+    .filter((plan) => plan.remoteId);
+}
+
+export async function readNativeCorosPlan(
+  remoteId: string
+): Promise<NativeCorosPlanDetail> {
+  const plans = await listNativeCorosPlans();
+  const listPlan = plans.find((plan) => plan.remoteId === remoteId);
+  const rawDetail = await readNativeTrainingPlanEndpoint<RawPlan>(
+    "/training/plan/detail",
+    {
+      method: "GET",
+      params: { id: remoteId, supportRestExercise: 1 }
+    }
+  );
+  const detail = parseNativeCorosPlan(rawDetail);
+  const groupedRaw = detail.programs.length > 0 || !listPlan
+    ? rawDetail
+    : {
+        ...listPlan.rawPayload,
+        ...rawDetail,
+        programs: listPlan.rawPayload.programs,
+        entities: listPlan.rawPayload.entities,
+        weekStages: listPlan.rawPayload.weekStages
+      };
+
+  // Plan query/detail can contain intentionally lightweight program records.
+  // Resolve their already-verified read-only workout details only when a user
+  // opens a plan, keeping library refreshes inexpensive while surfacing richer
+  // metrics and step structures whenever COROS exposes them for that program.
+  const programs = objectArray(groupedRaw.programs);
+  const enrichedPrograms = await Promise.all(
+    programs.map(async (program) => {
+      const id = stringValue(program.id);
+      if (!id) return program;
+      const programDetail = await getWorkoutProgramDetail(id);
+      if (!programDetail) return program;
+      return {
+        ...program,
+        ...programDetail,
+        idInPlan: program.idInPlan ?? programDetail.idInPlan,
+        planProgramId: program.planProgramId ?? programDetail.planProgramId
+      };
+    })
+  );
+
+  return parseNativeCorosPlan(
+    { ...groupedRaw, programs: enrichedPrograms },
+    detail.lastSyncedAt
+  );
+}

--- a/electron/corosWorkoutBuilder.ts
+++ b/electron/corosWorkoutBuilder.ts
@@ -148,6 +148,9 @@ export interface PlanDraftPreview {
   uploadResult?: {
     workoutsScheduled: number;
     workoutsCreated: number;
+    destination?: import("./types").TrainingPlanDestination;
+    localPlanId?: string;
+    groupedPlanCreated?: boolean;
   };
 }
 

--- a/electron/database.ts
+++ b/electron/database.ts
@@ -8,11 +8,17 @@ import type {
   CachedCorosMapPackage,
   GeneratedRoute,
   LocalTrack,
+  NativeCorosPlanDetail,
   SpotifySyncTrack,
   SpotifySyncTrackStatus,
   StrengthDetail,
   StrengthSession,
+  TrainingActivityMatch,
+  TrainingCollection,
   TrainingHubActivity,
+  TrainingHubLibraryWorkout,
+  TrainingPlanDocument,
+  TrainingWorkoutMetadata,
   YouTubeHistoryEntry,
   YouTubeHistoryEntryType
 } from "./types";
@@ -256,6 +262,82 @@ export function initializeDatabase(userDataPath: string): Database.Database {
 
     CREATE INDEX IF NOT EXISTS idx_chat_plan_drafts_created
       ON chat_plan_drafts(created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS training_plans (
+      id TEXT PRIMARY KEY,
+      remote_id TEXT UNIQUE,
+      source TEXT NOT NULL,
+      name TEXT NOT NULL,
+      document_json TEXT NOT NULL,
+      raw_remote_json TEXT,
+      remote_version INTEGER,
+      remote_updated_at INTEGER,
+      sync_state TEXT NOT NULL DEFAULT 'local',
+      last_synced_at TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      archived_at TEXT
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_training_plans_source_updated
+      ON training_plans(source, updated_at DESC);
+
+    CREATE TABLE IF NOT EXISTS training_workout_metadata (
+      program_id TEXT PRIMARY KEY,
+      favorite INTEGER NOT NULL DEFAULT 0,
+      tags_json TEXT NOT NULL DEFAULT '[]',
+      collection_id TEXT,
+      source TEXT NOT NULL DEFAULT 'coros',
+      sync_state TEXT NOT NULL DEFAULT 'synced',
+      last_used_at TEXT,
+      last_synced_at TEXT,
+      cached_version TEXT,
+      cached_payload_json TEXT
+    );
+
+    CREATE TABLE IF NOT EXISTS training_collections (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      description TEXT,
+      color TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS training_plan_workout_links (
+      plan_id TEXT NOT NULL,
+      entry_id TEXT NOT NULL,
+      program_id TEXT,
+      happen_day TEXT,
+      remote_plan_program_id TEXT,
+      PRIMARY KEY (plan_id, entry_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_training_plan_workout_program
+      ON training_plan_workout_links(program_id);
+
+    CREATE TABLE IF NOT EXISTS training_activity_matches (
+      id TEXT PRIMARY KEY,
+      plan_id TEXT,
+      plan_entry_id TEXT,
+      schedule_plan_id TEXT NOT NULL,
+      schedule_id_in_plan TEXT NOT NULL,
+      activity_id TEXT,
+      happen_day TEXT NOT NULL,
+      status TEXT NOT NULL,
+      confidence REAL,
+      manual INTEGER NOT NULL DEFAULT 0,
+      planned_duration_seconds REAL,
+      completed_duration_seconds REAL,
+      planned_distance_meters REAL,
+      completed_distance_meters REAL,
+      planned_training_load REAL,
+      completed_training_load REAL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_training_activity_match_schedule
+      ON training_activity_matches(schedule_plan_id, schedule_id_in_plan);
 
     CREATE TABLE IF NOT EXISTS mcp_servers (
       id TEXT PRIMARY KEY,
@@ -1649,4 +1731,378 @@ export function deleteChatPlanDraft(draftId: string): void {
   requireDatabase()
     .prepare("DELETE FROM chat_plan_drafts WHERE draft_id = ?")
     .run(draftId);
+}
+
+interface TrainingPlanRow {
+  id: string;
+  document_json: string;
+  raw_remote_json: string | null;
+}
+
+interface TrainingWorkoutMetadataRow {
+  program_id: string;
+  favorite: number;
+  tags_json: string;
+  collection_id: string | null;
+  source: TrainingWorkoutMetadata["source"];
+  sync_state: TrainingWorkoutMetadata["syncState"];
+  last_used_at: string | null;
+  last_synced_at: string | null;
+  cached_version: string | null;
+}
+
+interface TrainingCollectionRow {
+  id: string;
+  name: string;
+  description: string | null;
+  color: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface TrainingActivityMatchRow {
+  id: string;
+  plan_id: string | null;
+  plan_entry_id: string | null;
+  schedule_plan_id: string;
+  schedule_id_in_plan: string;
+  activity_id: string | null;
+  happen_day: string;
+  status: TrainingActivityMatch["status"];
+  confidence: number | null;
+  manual: number;
+  planned_duration_seconds: number | null;
+  completed_duration_seconds: number | null;
+  planned_distance_meters: number | null;
+  completed_distance_meters: number | null;
+  planned_training_load: number | null;
+  completed_training_load: number | null;
+  updated_at: string;
+}
+
+function parseStoredJson<T>(value: string, fallback: T): T {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function saveTrainingPlanDocument(
+  document: TrainingPlanDocument,
+  rawRemote?: Record<string, unknown>
+): void {
+  const database = requireDatabase();
+  database.transaction(() => {
+    database
+      .prepare(
+        `INSERT INTO training_plans (
+           id, remote_id, source, name, document_json, raw_remote_json,
+           remote_version, remote_updated_at, sync_state, last_synced_at,
+           created_at, updated_at, archived_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           remote_id = excluded.remote_id,
+           source = excluded.source,
+           name = excluded.name,
+           document_json = excluded.document_json,
+           raw_remote_json = COALESCE(excluded.raw_remote_json, training_plans.raw_remote_json),
+           remote_version = excluded.remote_version,
+           remote_updated_at = excluded.remote_updated_at,
+           sync_state = excluded.sync_state,
+           last_synced_at = excluded.last_synced_at,
+           updated_at = excluded.updated_at,
+           archived_at = excluded.archived_at`
+      )
+      .run(
+        document.id,
+        document.remoteId ?? null,
+        document.source,
+        document.name,
+        JSON.stringify(document),
+        rawRemote ? JSON.stringify(rawRemote) : null,
+        document.remoteVersion ?? null,
+        document.remoteUpdatedAt ?? null,
+        document.syncState,
+        document.lastSyncedAt ?? null,
+        document.createdAt,
+        document.updatedAt,
+        document.archived ? document.updatedAt : null
+      );
+
+    database
+      .prepare("DELETE FROM training_plan_workout_links WHERE plan_id = ?")
+      .run(document.id);
+    const insertLink = database.prepare(
+      `INSERT INTO training_plan_workout_links
+       (plan_id, entry_id, program_id, happen_day, remote_plan_program_id)
+       VALUES (?, ?, ?, ?, ?)`
+    );
+    for (const entry of document.entries) {
+      insertLink.run(
+        document.id,
+        entry.id,
+        entry.programId ?? null,
+        entry.workout?.schedule_date ?? null,
+        entry.remotePlanProgramId ?? null
+      );
+    }
+  })();
+}
+
+export function listTrainingPlanDocuments(): TrainingPlanDocument[] {
+  const rows = requireDatabase()
+    .prepare(
+      `SELECT id, document_json, raw_remote_json
+       FROM training_plans
+       ORDER BY updated_at DESC`
+    )
+    .all() as TrainingPlanRow[];
+  return rows
+    .map((row) => parseStoredJson<TrainingPlanDocument | undefined>(row.document_json, undefined))
+    .filter((plan): plan is TrainingPlanDocument => Boolean(plan));
+}
+
+export function getTrainingPlanDocument(
+  id: string
+): TrainingPlanDocument | undefined {
+  const row = requireDatabase()
+    .prepare(
+      `SELECT id, document_json, raw_remote_json
+       FROM training_plans
+       WHERE id = ? OR remote_id = ?`
+    )
+    .get(id, id) as TrainingPlanRow | undefined;
+  return row
+    ? parseStoredJson<TrainingPlanDocument | undefined>(row.document_json, undefined)
+    : undefined;
+}
+
+export function getNativePlanRawPayload(
+  id: string
+): NativeCorosPlanDetail["rawPayload"] | undefined {
+  const row = requireDatabase()
+    .prepare(
+      `SELECT id, document_json, raw_remote_json
+       FROM training_plans
+       WHERE id = ? OR remote_id = ?`
+    )
+    .get(id, id) as TrainingPlanRow | undefined;
+  return row?.raw_remote_json
+    ? parseStoredJson<Record<string, unknown> | undefined>(row.raw_remote_json, undefined)
+    : undefined;
+}
+
+export function deleteTrainingPlanDocument(id: string): void {
+  const database = requireDatabase();
+  database.transaction(() => {
+    database.prepare("DELETE FROM training_plan_workout_links WHERE plan_id = ?").run(id);
+    database.prepare("DELETE FROM training_plans WHERE id = ?").run(id);
+  })();
+}
+
+export function listTrainingWorkoutMetadata(): TrainingWorkoutMetadata[] {
+  const rows = requireDatabase()
+    .prepare(
+      `SELECT program_id, favorite, tags_json, collection_id, source, sync_state,
+              last_used_at, last_synced_at, cached_version
+       FROM training_workout_metadata`
+    )
+    .all() as TrainingWorkoutMetadataRow[];
+  return rows.map((row) => ({
+    programId: row.program_id,
+    favorite: Boolean(row.favorite),
+    tags: parseStoredJson<string[]>(row.tags_json, []),
+    collectionId: row.collection_id ?? undefined,
+    source: row.source,
+    syncState: row.sync_state,
+    lastUsedAt: row.last_used_at ?? undefined,
+    lastSyncedAt: row.last_synced_at ?? undefined,
+    cachedVersion: row.cached_version ?? undefined
+  }));
+}
+
+export function listCachedTrainingLibraryWorkouts(): TrainingHubLibraryWorkout[] {
+  const rows = requireDatabase()
+    .prepare(
+      `SELECT cached_payload_json
+       FROM training_workout_metadata
+       WHERE cached_payload_json IS NOT NULL`
+    )
+    .all() as Array<{ cached_payload_json: string }>;
+  return rows
+    .map((row) =>
+      parseStoredJson<TrainingHubLibraryWorkout | undefined>(
+        row.cached_payload_json,
+        undefined
+      )
+    )
+    .filter((item): item is TrainingHubLibraryWorkout => Boolean(item?.id));
+}
+
+export function saveTrainingWorkoutMetadata(
+  metadata: TrainingWorkoutMetadata,
+  cachedPayload?: Record<string, unknown>
+): void {
+  requireDatabase()
+    .prepare(
+      `INSERT INTO training_workout_metadata (
+         program_id, favorite, tags_json, collection_id, source, sync_state,
+         last_used_at, last_synced_at, cached_version, cached_payload_json
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(program_id) DO UPDATE SET
+         favorite = excluded.favorite,
+         tags_json = excluded.tags_json,
+         collection_id = excluded.collection_id,
+         source = excluded.source,
+         sync_state = excluded.sync_state,
+         last_used_at = excluded.last_used_at,
+         last_synced_at = excluded.last_synced_at,
+         cached_version = excluded.cached_version,
+         cached_payload_json = COALESCE(excluded.cached_payload_json, training_workout_metadata.cached_payload_json)`
+    )
+    .run(
+      metadata.programId,
+      metadata.favorite ? 1 : 0,
+      JSON.stringify(metadata.tags),
+      metadata.collectionId ?? null,
+      metadata.source,
+      metadata.syncState,
+      metadata.lastUsedAt ?? null,
+      metadata.lastSyncedAt ?? null,
+      metadata.cachedVersion ?? null,
+      cachedPayload ? JSON.stringify(cachedPayload) : null
+    );
+}
+
+export function listTrainingCollections(): TrainingCollection[] {
+  const rows = requireDatabase()
+    .prepare(
+      `SELECT id, name, description, color, created_at, updated_at
+       FROM training_collections
+       ORDER BY name COLLATE NOCASE`
+    )
+    .all() as TrainingCollectionRow[];
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    description: row.description ?? undefined,
+    color: row.color ?? undefined,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  }));
+}
+
+export function saveTrainingCollection(collection: TrainingCollection): void {
+  requireDatabase()
+    .prepare(
+      `INSERT INTO training_collections
+       (id, name, description, color, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         name = excluded.name,
+         description = excluded.description,
+         color = excluded.color,
+         updated_at = excluded.updated_at`
+    )
+    .run(
+      collection.id,
+      collection.name,
+      collection.description ?? null,
+      collection.color ?? null,
+      collection.createdAt,
+      collection.updatedAt
+    );
+}
+
+export function deleteTrainingCollection(id: string): void {
+  const database = requireDatabase();
+  database.transaction(() => {
+    database
+      .prepare("UPDATE training_workout_metadata SET collection_id = NULL WHERE collection_id = ?")
+      .run(id);
+    database.prepare("DELETE FROM training_collections WHERE id = ?").run(id);
+  })();
+}
+
+function toTrainingActivityMatch(row: TrainingActivityMatchRow): TrainingActivityMatch {
+  return {
+    id: row.id,
+    planId: row.plan_id ?? undefined,
+    planEntryId: row.plan_entry_id ?? undefined,
+    schedulePlanId: row.schedule_plan_id,
+    scheduleIdInPlan: row.schedule_id_in_plan,
+    activityId: row.activity_id ?? undefined,
+    happenDay: row.happen_day,
+    status: row.status,
+    confidence: row.confidence ?? undefined,
+    manual: Boolean(row.manual),
+    plannedDurationSeconds: row.planned_duration_seconds ?? undefined,
+    completedDurationSeconds: row.completed_duration_seconds ?? undefined,
+    plannedDistanceMeters: row.planned_distance_meters ?? undefined,
+    completedDistanceMeters: row.completed_distance_meters ?? undefined,
+    plannedTrainingLoad: row.planned_training_load ?? undefined,
+    completedTrainingLoad: row.completed_training_load ?? undefined,
+    updatedAt: row.updated_at
+  };
+}
+
+export function listTrainingActivityMatches(): TrainingActivityMatch[] {
+  return (
+    requireDatabase()
+      .prepare(
+        `SELECT id, plan_id, plan_entry_id, schedule_plan_id, schedule_id_in_plan,
+                activity_id, happen_day, status, confidence, manual,
+                planned_duration_seconds, completed_duration_seconds,
+                planned_distance_meters, completed_distance_meters,
+                planned_training_load, completed_training_load, updated_at
+         FROM training_activity_matches
+         ORDER BY happen_day DESC`
+      )
+      .all() as TrainingActivityMatchRow[]
+  ).map(toTrainingActivityMatch);
+}
+
+export function saveTrainingActivityMatch(match: TrainingActivityMatch): void {
+  requireDatabase()
+    .prepare(
+      `INSERT INTO training_activity_matches (
+         id, plan_id, plan_entry_id, schedule_plan_id, schedule_id_in_plan,
+         activity_id, happen_day, status, confidence, manual,
+         planned_duration_seconds, completed_duration_seconds,
+         planned_distance_meters, completed_distance_meters,
+         planned_training_load, completed_training_load, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         plan_id = excluded.plan_id,
+         plan_entry_id = excluded.plan_entry_id,
+         activity_id = excluded.activity_id,
+         happen_day = excluded.happen_day,
+         status = excluded.status,
+         confidence = excluded.confidence,
+         manual = excluded.manual,
+         completed_duration_seconds = excluded.completed_duration_seconds,
+         completed_distance_meters = excluded.completed_distance_meters,
+         completed_training_load = excluded.completed_training_load,
+         updated_at = excluded.updated_at`
+    )
+    .run(
+      match.id,
+      match.planId ?? null,
+      match.planEntryId ?? null,
+      match.schedulePlanId,
+      match.scheduleIdInPlan,
+      match.activityId ?? null,
+      match.happenDay,
+      match.status,
+      match.confidence ?? null,
+      match.manual ? 1 : 0,
+      match.plannedDurationSeconds ?? null,
+      match.completedDurationSeconds ?? null,
+      match.plannedDistanceMeters ?? null,
+      match.completedDistanceMeters ?? null,
+      match.plannedTrainingLoad ?? null,
+      match.completedTrainingLoad ?? null,
+      match.updatedAt
+    );
 }

--- a/electron/database.ts
+++ b/electron/database.ts
@@ -227,6 +227,23 @@ export function initializeDatabase(userDataPath: string): Database.Database {
       fetched_at TEXT NOT NULL
     );
 
+    CREATE TABLE IF NOT EXISTS hevy_workouts (
+      workout_id TEXT PRIMARY KEY,
+      start_time INTEGER NOT NULL,
+      updated_at TEXT,
+      payload_json TEXT NOT NULL,
+      synced_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_hevy_workouts_start_time
+      ON hevy_workouts(start_time);
+
+    CREATE TABLE IF NOT EXISTS hevy_exercise_templates (
+      template_id TEXT PRIMARY KEY,
+      payload_json TEXT NOT NULL,
+      synced_at TEXT NOT NULL
+    );
+
     CREATE TABLE IF NOT EXISTS cached_coros_maps (
       package_id TEXT PRIMARY KEY,
       title TEXT NOT NULL,
@@ -1505,6 +1522,8 @@ export function listStoredStrengthSessions(
     }
     sessions.push({
       activityId: row.activity_id,
+      source: "coros",
+      sourceIds: { coros: row.activity_id },
       sportType: row.sport_type,
       name: row.name ?? undefined,
       sportName: row.sport_name ?? undefined,
@@ -1518,6 +1537,140 @@ export function listStoredStrengthSessions(
     });
   }
   return sessions;
+}
+
+export interface StoredHevyWorkout {
+  workoutId: string;
+  startTime: number;
+  updatedAt?: string;
+  payload: Record<string, unknown>;
+}
+
+/** Persist the provider payload so settings can re-normalize it without I/O. */
+export function upsertHevyWorkout(
+  workoutId: string,
+  startTime: number,
+  updatedAt: string | undefined,
+  payload: Record<string, unknown>
+): void {
+  requireDatabase()
+    .prepare(
+      `INSERT INTO hevy_workouts
+         (workout_id, start_time, updated_at, payload_json, synced_at)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(workout_id) DO UPDATE SET
+         start_time = excluded.start_time,
+         updated_at = excluded.updated_at,
+         payload_json = excluded.payload_json,
+         synced_at = excluded.synced_at`
+    )
+    .run(
+      workoutId,
+      startTime,
+      updatedAt ?? null,
+      JSON.stringify(payload),
+      new Date().toISOString()
+    );
+}
+
+export function deleteHevyWorkout(workoutId: string): void {
+  requireDatabase().prepare("DELETE FROM hevy_workouts WHERE workout_id = ?").run(workoutId);
+}
+
+export function listStoredHevyWorkouts(sinceEpochSeconds: number): StoredHevyWorkout[] {
+  const rows = requireDatabase()
+    .prepare(
+      `SELECT workout_id, start_time, updated_at, payload_json
+       FROM hevy_workouts
+       WHERE start_time >= ?
+       ORDER BY start_time DESC`
+    )
+    .all(sinceEpochSeconds) as Array<{
+    workout_id: string;
+    start_time: number;
+    updated_at: string | null;
+    payload_json: string;
+  }>;
+
+  const workouts: StoredHevyWorkout[] = [];
+  for (const row of rows) {
+    try {
+      const payload = JSON.parse(row.payload_json) as unknown;
+      if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+        continue;
+      }
+      workouts.push({
+        workoutId: row.workout_id,
+        startTime: row.start_time,
+        updatedAt: row.updated_at ?? undefined,
+        payload: payload as Record<string, unknown>
+      });
+    } catch {
+      // A single corrupt cache entry must not hide the rest of the history.
+    }
+  }
+  return workouts;
+}
+
+/** Remove stale rows in a fully reconciled history window. */
+export function reconcileHevyWorkoutIds(
+  sinceEpochSeconds: number,
+  retainedIds: Set<string>
+): void {
+  const database = requireDatabase();
+  const rows = database
+    .prepare("SELECT workout_id FROM hevy_workouts WHERE start_time >= ?")
+    .all(sinceEpochSeconds) as Array<{ workout_id: string }>;
+  const remove = database.prepare("DELETE FROM hevy_workouts WHERE workout_id = ?");
+  const transaction = database.transaction(() => {
+    for (const row of rows) {
+      if (!retainedIds.has(row.workout_id)) {
+        remove.run(row.workout_id);
+      }
+    }
+  });
+  transaction();
+}
+
+export function upsertHevyExerciseTemplate(
+  templateId: string,
+  payload: Record<string, unknown>
+): void {
+  requireDatabase()
+    .prepare(
+      `INSERT INTO hevy_exercise_templates (template_id, payload_json, synced_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(template_id) DO UPDATE SET
+         payload_json = excluded.payload_json,
+         synced_at = excluded.synced_at`
+    )
+    .run(templateId, JSON.stringify(payload), new Date().toISOString());
+}
+
+export function listStoredHevyExerciseTemplates(): Map<string, Record<string, unknown>> {
+  const rows = requireDatabase()
+    .prepare("SELECT template_id, payload_json FROM hevy_exercise_templates")
+    .all() as Array<{ template_id: string; payload_json: string }>;
+  const templates = new Map<string, Record<string, unknown>>();
+  for (const row of rows) {
+    try {
+      const payload = JSON.parse(row.payload_json) as unknown;
+      if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+        templates.set(row.template_id, payload as Record<string, unknown>);
+      }
+    } catch {
+      // Ignore corrupt template rows; title-based analytics still work.
+    }
+  }
+  return templates;
+}
+
+export function clearHevyCache(): void {
+  const database = requireDatabase();
+  database.transaction(() => {
+    database.prepare("DELETE FROM hevy_workouts").run();
+    database.prepare("DELETE FROM hevy_exercise_templates").run();
+  })();
 }
 
 function toCachedCorosMap(row: CachedCorosMapRow): CachedCorosMapPackage {

--- a/electron/hevyModel.ts
+++ b/electron/hevyModel.ts
@@ -1,0 +1,182 @@
+import type {
+  StrengthExercise,
+  StrengthSession,
+  StrengthSet,
+  StrengthSetType
+} from "./types";
+
+type JsonRecord = Record<string, unknown>;
+
+function record(value: unknown): JsonRecord | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function finite(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function nonNegative(value: unknown): number {
+  return Math.max(0, finite(value) ?? 0);
+}
+
+function isoEpochSeconds(value: unknown): number | undefined {
+  const text = stringValue(value);
+  if (!text) return undefined;
+  const milliseconds = Date.parse(text);
+  return Number.isFinite(milliseconds) ? Math.floor(milliseconds / 1000) : undefined;
+}
+
+function setType(value: unknown): StrengthSetType {
+  return value === "warmup" ||
+    value === "dropset" ||
+    value === "failure" ||
+    value === "normal"
+    ? value
+    : "normal";
+}
+
+/**
+ * Cross-provider exercise identity. Hevy writes equipment as a suffix while
+ * COROS usually prefixes dumbbell movements and treats a barbell as default.
+ */
+export function canonicalStrengthExerciseName(value: string): string {
+  let normalized = value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .trim()
+    .toLowerCase();
+  const equipment = normalized.match(/\s*\((barbell|dumbbell|machine)\)\s*$/)?.[1];
+  if (equipment) {
+    normalized = normalized.replace(/\s*\((barbell|dumbbell|machine)\)\s*$/, "").trim();
+  }
+  if (equipment === "dumbbell" && !normalized.startsWith("dumbbell ")) {
+    normalized = `dumbbell ${normalized}`;
+  } else if (equipment === "machine" && !normalized.includes("machine")) {
+    normalized = `${normalized} machine`;
+  }
+  return normalized.replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+export function hevyWorkoutId(raw: JsonRecord): string | undefined {
+  return stringValue(raw.id);
+}
+
+export function hevyWorkoutStartTime(raw: JsonRecord): number | undefined {
+  return isoEpochSeconds(raw.start_time);
+}
+
+function normalizeSet(raw: JsonRecord, exerciseType: string | undefined): StrengthSet {
+  const rawWeight = nonNegative(raw.weight_kg);
+  // Assisted weight is assistance, not load lifted. Other bodyweight variants
+  // may carry explicit added weight, which is safe to preserve as external load.
+  const weightKg = exerciseType === "bodyweight_assisted_reps" ? 0 : rawWeight;
+  const rpeValue = finite(raw.rpe);
+  return {
+    reps: nonNegative(raw.reps),
+    weightKg,
+    workSec: nonNegative(raw.duration_seconds),
+    restSec: 0,
+    calories: 0,
+    type: setType(raw.type),
+    ...(rpeValue !== undefined && rpeValue >= 0 && rpeValue <= 10
+      ? { rpe: rpeValue }
+      : {})
+  };
+}
+
+function normalizeExercise(
+  raw: JsonRecord,
+  templates: Map<string, JsonRecord>,
+  includeWarmups: boolean
+): StrengthExercise | undefined {
+  const templateId = stringValue(raw.exercise_template_id);
+  const template = templateId ? templates.get(templateId) : undefined;
+  const title = stringValue(raw.title) ?? stringValue(template?.title) ?? "Unnamed exercise";
+  const exerciseType = stringValue(template?.type);
+  const rawSets = Array.isArray(raw.sets) ? raw.sets : [];
+  const entries = rawSets
+    .map(record)
+    .filter((entry): entry is JsonRecord => Boolean(entry))
+    .sort((left, right) => (finite(left.index) ?? 0) - (finite(right.index) ?? 0))
+    .filter((entry) => includeWarmups || setType(entry.type) !== "warmup")
+    .map((entry) => normalizeSet(entry, exerciseType));
+
+  if (entries.length === 0) return undefined;
+  const secondary = Array.isArray(template?.secondary_muscle_groups)
+    ? template.secondary_muscle_groups
+        .map(stringValue)
+        .filter((value): value is string => Boolean(value))
+    : undefined;
+  return {
+    nameKey: title,
+    rawName: title,
+    externalId: templateId,
+    exerciseType,
+    primaryMuscleGroup: stringValue(template?.primary_muscle_group),
+    secondaryMuscleGroups: secondary,
+    sets: entries.length,
+    totalReps: entries.reduce((sum, entry) => sum + entry.reps, 0),
+    entries
+  };
+}
+
+/** Convert a raw Hevy workout into the provider-neutral Strength model. */
+export function normalizeHevyWorkout(
+  raw: JsonRecord,
+  templates: Map<string, JsonRecord>,
+  includeWarmups: boolean
+): StrengthSession | undefined {
+  const id = hevyWorkoutId(raw);
+  const startTime = hevyWorkoutStartTime(raw);
+  if (!id || startTime === undefined) return undefined;
+
+  const exercises = (Array.isArray(raw.exercises) ? raw.exercises : [])
+    .map(record)
+    .filter((entry): entry is JsonRecord => Boolean(entry))
+    .sort((left, right) => (finite(left.index) ?? 0) - (finite(right.index) ?? 0))
+    .map((exercise) => normalizeExercise(exercise, templates, includeWarmups))
+    .filter((exercise): exercise is StrengthExercise => Boolean(exercise));
+  if (exercises.length === 0) return undefined;
+
+  const endTime = isoEpochSeconds(raw.end_time);
+  const durationSec = endTime === undefined ? 0 : Math.max(0, endTime - startTime);
+  const sets = exercises.reduce((sum, exercise) => sum + exercise.entries.length, 0);
+  const totalReps = exercises.reduce((sum, exercise) => sum + exercise.totalReps, 0);
+  const totalWeightKg = exercises.reduce(
+    (total, exercise) =>
+      total +
+      exercise.entries.reduce(
+        (exerciseTotal, entry) => exerciseTotal + entry.reps * entry.weightKg,
+        0
+      ),
+    0
+  );
+
+  return {
+    activityId: `hevy:${id}`,
+    source: "hevy",
+    sourceIds: { hevy: id },
+    sportType: 402,
+    sportName: "Strength",
+    name: stringValue(raw.title) ?? "Hevy workout",
+    startTime,
+    duration: durationSec,
+    detail: {
+      summary: {
+        sets,
+        totalReps,
+        totalWeightKg,
+        exercises: exercises.length,
+        calories: 0,
+        durationSec
+      },
+      exercises
+    }
+  };
+}

--- a/electron/hevyService.ts
+++ b/electron/hevyService.ts
@@ -1,0 +1,350 @@
+import { safeStorage } from "electron";
+import {
+  clearHevyCache,
+  deleteHevyWorkout,
+  deleteSettings,
+  getSetting,
+  listStoredHevyExerciseTemplates,
+  listStoredHevyWorkouts,
+  reconcileHevyWorkoutIds,
+  setSetting,
+  upsertHevyExerciseTemplate,
+  upsertHevyWorkout
+} from "./database";
+import {
+  hevyWorkoutId,
+  hevyWorkoutStartTime,
+  normalizeHevyWorkout
+} from "./hevyModel";
+import type {
+  HevySettingsInput,
+  HevyStatus,
+  StrengthSession
+} from "./types";
+
+type JsonRecord = Record<string, unknown>;
+
+const BASE_URL = "https://api.hevyapp.com/v1";
+const INITIAL_HISTORY_DAYS = 365;
+const SETTINGS = {
+  apiKey: "hevy.apiKey",
+  identity: "hevy.identity",
+  includeWarmups: "hevy.includeWarmups",
+  eventCursor: "hevy.eventCursor",
+  coverageSince: "hevy.coverageSince",
+  lastSyncedAt: "hevy.lastSyncedAt"
+};
+
+interface CredentialStorage {
+  isEncryptionAvailable(): boolean;
+  encryptString(value: string): Buffer;
+  decryptString(value: Buffer): string;
+}
+
+let credentialStorage: CredentialStorage = safeStorage;
+
+/** Test seam; production always uses Electron safeStorage. */
+export function setHevyCredentialStorageForTests(storage: CredentialStorage): void {
+  credentialStorage = storage;
+}
+
+interface HevyIdentity {
+  userId: string;
+  displayName?: string;
+  profileUrl?: string;
+}
+
+interface HevySyncResult {
+  sessions: StrengthSession[];
+  fetched: number;
+}
+
+function record(value: unknown): JsonRecord | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parseIdentity(): HevyIdentity | undefined {
+  const raw = getSetting(SETTINGS.identity);
+  if (!raw) return undefined;
+  try {
+    const parsed = record(JSON.parse(raw));
+    const userId = stringValue(parsed?.userId);
+    if (!userId) return undefined;
+    return {
+      userId,
+      displayName: stringValue(parsed?.displayName),
+      profileUrl: stringValue(parsed?.profileUrl)
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function readApiKey(): string | undefined {
+  const encrypted = getSetting(SETTINGS.apiKey);
+  if (!encrypted || !credentialStorage.isEncryptionAvailable()) return undefined;
+  try {
+    return credentialStorage.decryptString(Buffer.from(encrypted, "base64"));
+  } catch {
+    return undefined;
+  }
+}
+
+function storeApiKey(apiKey: string): void {
+  if (!credentialStorage.isEncryptionAvailable()) {
+    throw new Error(
+      "Secure credential storage is unavailable. CorosLink did not save the Hevy API key."
+    );
+  }
+  setSetting(
+    SETTINGS.apiKey,
+    credentialStorage.encryptString(apiKey).toString("base64")
+  );
+}
+
+function includeWarmups(): boolean {
+  return getSetting(SETTINGS.includeWarmups) === "true";
+}
+
+function windowStartEpochSeconds(days: number): number {
+  const start = new Date();
+  start.setHours(0, 0, 0, 0);
+  start.setDate(start.getDate() - days);
+  return Math.floor(start.getTime() / 1000);
+}
+
+async function hevyRequest(
+  path: string,
+  apiKey: string,
+  search?: Record<string, string | number>
+): Promise<JsonRecord> {
+  const url = new URL(`${BASE_URL}${path}`);
+  for (const [key, value] of Object.entries(search ?? {})) {
+    url.searchParams.set(key, String(value));
+  }
+  const response = await fetch(url, { headers: { "api-key": apiKey } });
+  const payload = await response.json().catch(() => undefined);
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      throw new Error("Hevy rejected the API key. Reconnect Hevy with a current Pro API key.");
+    }
+    const message = stringValue(record(payload)?.error);
+    throw new Error(message ?? `Hevy API request failed (${response.status}).`);
+  }
+  const parsed = record(payload);
+  if (!parsed) throw new Error("Hevy returned an invalid response.");
+  return parsed;
+}
+
+async function fetchIdentity(apiKey: string): Promise<HevyIdentity> {
+  const response = await hevyRequest("/user/info", apiKey);
+  const data = record(response.data);
+  const userId = stringValue(data?.id);
+  if (!userId) throw new Error("Hevy did not return an account identity.");
+  return {
+    userId,
+    displayName: stringValue(data?.name),
+    profileUrl: stringValue(data?.url)
+  };
+}
+
+export function getHevyStatus(): HevyStatus {
+  const identity = parseIdentity();
+  return {
+    connected: Boolean(readApiKey() && identity),
+    userId: identity?.userId,
+    displayName: identity?.displayName,
+    profileUrl: identity?.profileUrl,
+    lastSyncedAt: getSetting(SETTINGS.lastSyncedAt),
+    includeWarmups: includeWarmups()
+  };
+}
+
+export async function connectHevy(apiKey: string): Promise<HevyStatus> {
+  const key = apiKey.trim();
+  if (!key) throw new Error("Enter a Hevy API key.");
+  if (!credentialStorage.isEncryptionAvailable()) {
+    throw new Error("Secure credential storage is unavailable on this system.");
+  }
+  const identity = await fetchIdentity(key);
+  const previous = parseIdentity();
+  if (previous && previous.userId !== identity.userId) {
+    clearHevyCache();
+    deleteSettings([
+      SETTINGS.eventCursor,
+      SETTINGS.coverageSince,
+      SETTINGS.lastSyncedAt
+    ]);
+  }
+  storeApiKey(key);
+  setSetting(SETTINGS.identity, JSON.stringify(identity));
+  if (getSetting(SETTINGS.includeWarmups) === undefined) {
+    setSetting(SETTINGS.includeWarmups, "false");
+  }
+  return getHevyStatus();
+}
+
+export function updateHevySettings(input: HevySettingsInput): HevyStatus {
+  setSetting(SETTINGS.includeWarmups, input.includeWarmups ? "true" : "false");
+  return getHevyStatus();
+}
+
+export function disconnectHevy(): void {
+  clearHevyCache();
+  deleteSettings(Object.values(SETTINGS));
+}
+
+async function syncExerciseTemplates(apiKey: string): Promise<void> {
+  for (let page = 1; ; page += 1) {
+    const response = await hevyRequest("/exercise_templates", apiKey, {
+      page,
+      pageSize: 100
+    });
+    const templates = Array.isArray(response.exercise_templates)
+      ? response.exercise_templates.map(record).filter((item): item is JsonRecord => Boolean(item))
+      : [];
+    for (const template of templates) {
+      const id = stringValue(template.id);
+      if (id) upsertHevyExerciseTemplate(id, template);
+    }
+    const pageCount = Math.max(1, numberValue(response.page_count) ?? page);
+    if (page >= pageCount) break;
+  }
+}
+
+async function ensureExerciseTemplates(
+  apiKey: string,
+  workouts: JsonRecord[]
+): Promise<void> {
+  const known = listStoredHevyExerciseTemplates();
+  const missing = new Set<string>();
+  for (const workout of workouts) {
+    const exercises = Array.isArray(workout.exercises) ? workout.exercises : [];
+    for (const rawExercise of exercises) {
+      const id = stringValue(record(rawExercise)?.exercise_template_id);
+      if (id && !known.has(id)) missing.add(id);
+    }
+  }
+  for (const id of missing) {
+    try {
+      const template = await hevyRequest(`/exercise_templates/${encodeURIComponent(id)}`, apiKey);
+      upsertHevyExerciseTemplate(id, template);
+    } catch {
+      // Names in workout payloads are enough for analytics; metadata is fallback only.
+    }
+  }
+}
+
+async function fullSync(apiKey: string): Promise<number> {
+  const startedAt = new Date().toISOString();
+  const since = windowStartEpochSeconds(INITIAL_HISTORY_DAYS);
+  await syncExerciseTemplates(apiKey);
+  const retainedIds = new Set<string>();
+  let fetched = 0;
+
+  for (let page = 1; ; page += 1) {
+    const response = await hevyRequest("/workouts", apiKey, { page, pageSize: 10 });
+    const workouts = Array.isArray(response.workouts)
+      ? response.workouts.map(record).filter((item): item is JsonRecord => Boolean(item))
+      : [];
+    let reachedBoundary = false;
+    for (const workout of workouts) {
+      const id = hevyWorkoutId(workout);
+      const startTime = hevyWorkoutStartTime(workout);
+      if (!id || startTime === undefined) continue;
+      if (startTime < since) {
+        reachedBoundary = true;
+        continue;
+      }
+      retainedIds.add(id);
+      upsertHevyWorkout(id, startTime, stringValue(workout.updated_at), workout);
+      fetched += 1;
+    }
+    const pageCount = Math.max(1, numberValue(response.page_count) ?? page);
+    if (reachedBoundary || page >= pageCount || workouts.length === 0) break;
+  }
+
+  reconcileHevyWorkoutIds(since, retainedIds);
+  setSetting(SETTINGS.coverageSince, String(since));
+  setSetting(SETTINGS.eventCursor, startedAt);
+  setSetting(SETTINGS.lastSyncedAt, new Date().toISOString());
+  return fetched;
+}
+
+async function incrementalSync(apiKey: string, cursor: string): Promise<number> {
+  const startedAt = new Date().toISOString();
+  const oldest = windowStartEpochSeconds(INITIAL_HISTORY_DAYS);
+  const updatedWorkouts: JsonRecord[] = [];
+  let fetched = 0;
+
+  for (let page = 1; ; page += 1) {
+    const response = await hevyRequest("/workouts/events", apiKey, {
+      page,
+      pageSize: 10,
+      since: cursor
+    });
+    const events = Array.isArray(response.events)
+      ? response.events.map(record).filter((item): item is JsonRecord => Boolean(item))
+      : [];
+    for (const event of events) {
+      if (event.type === "deleted") {
+        const id = stringValue(event.id);
+        if (id) deleteHevyWorkout(id);
+        continue;
+      }
+      const workout = record(event.workout);
+      const id = workout ? hevyWorkoutId(workout) : undefined;
+      const startTime = workout ? hevyWorkoutStartTime(workout) : undefined;
+      if (!workout || !id || startTime === undefined) continue;
+      if (startTime < oldest) {
+        deleteHevyWorkout(id);
+        continue;
+      }
+      upsertHevyWorkout(id, startTime, stringValue(workout.updated_at), workout);
+      updatedWorkouts.push(workout);
+      fetched += 1;
+    }
+    const pageCount = Math.max(1, numberValue(response.page_count) ?? page);
+    if (page >= pageCount || events.length === 0) break;
+  }
+
+  await ensureExerciseTemplates(apiKey, updatedWorkouts);
+  // Cursor movement is deliberately last: partial event application is safely replayed.
+  setSetting(SETTINGS.eventCursor, startedAt);
+  setSetting(SETTINGS.lastSyncedAt, new Date().toISOString());
+  return fetched;
+}
+
+export function getStoredHevyStrengthSessions(days: number): StrengthSession[] {
+  const templates = listStoredHevyExerciseTemplates();
+  return listStoredHevyWorkouts(windowStartEpochSeconds(days))
+    .map((stored) => normalizeHevyWorkout(stored.payload, templates, includeWarmups()))
+    .filter((session): session is StrengthSession => Boolean(session));
+}
+
+export async function syncHevyStrengthHistory(
+  days = 90,
+  force = false
+): Promise<HevySyncResult> {
+  const apiKey = readApiKey();
+  if (!apiKey) throw new Error("Connect Hevy before syncing strength workouts.");
+  const requestedSince = windowStartEpochSeconds(days);
+  const coverageSince = Number(getSetting(SETTINGS.coverageSince));
+  const cursor = getSetting(SETTINGS.eventCursor);
+  const needsFullSync =
+    force || !cursor || !Number.isFinite(coverageSince) || coverageSince > requestedSince;
+  const fetched = needsFullSync
+    ? await fullSync(apiKey)
+    : await incrementalSync(apiKey, cursor);
+  return { sessions: getStoredHevyStrengthSessions(days), fetched };
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -53,11 +53,13 @@ import {
   listTrainingHubActivities,
   listScheduledWorkoutEntries,
   listLibraryWorkouts,
+  duplicateLibraryWorkout,
   listWorkoutExercises,
   getWorkoutEditorContext,
   scheduleLibraryWorkout,
   syncStrengthHistory,
   createAndScheduleWorkout,
+  createLibraryWorkout,
   rescheduleScheduledWorkout,
   removeScheduledWorkout,
   getWorkoutForEdit,
@@ -73,6 +75,19 @@ import {
   uploadTrainingPlan
 } from "./trainingHubService";
 import type { UnitSystem, WorkoutSport } from "./types";
+import {
+  deleteLocalTrainingPlan,
+  deleteTrainingLibraryWorkouts,
+  getNativeTrainingPlan,
+  getTrainingLibrarySnapshot,
+  refreshTrainingActivityMatches,
+  removeTrainingCollection,
+  saveLocalTrainingPlan,
+  saveManualActivityMatch,
+  updateWorkoutMetadata,
+  updateTrainingPlanMetadata,
+  upsertTrainingCollection
+} from "./trainingLibraryService";
 import { normalizeUnitSystem } from "./unitSystem.js";
 import {
   cacheCorosWatchfaceProjectPreview,
@@ -1355,8 +1370,8 @@ function registerIpcHandlers(): void {
     await disconnectMcpServer(id, { clearAuthorization: false });
   });
 
-  ipcMain.handle("chat:uploadPlanDraft", (_event, draftId: string, unitSystem?: UnitSystem) =>
-    uploadTrainingPlanDraft(draftId, normalizeUnitSystem(unitSystem))
+  ipcMain.handle("chat:uploadPlanDraft", (_event, draftId: string, unitSystem?: UnitSystem, destination?: import("./types").TrainingPlanDestination) =>
+    uploadTrainingPlanDraft(draftId, normalizeUnitSystem(unitSystem), destination)
   );
 
   ipcMain.handle("chat:confirmWorkoutDelete", (_event, requestId: string) =>
@@ -1464,6 +1479,50 @@ function registerIpcHandlers(): void {
   ipcMain.handle("trainingHub:listLibraryWorkouts", () =>
     listLibraryWorkouts()
   );
+  ipcMain.handle(
+    "trainingHub:duplicateLibraryWorkout",
+    (_event, programId: string, name: string, targetSportType?: number) =>
+      duplicateLibraryWorkout(programId, name, targetSportType)
+  );
+
+  ipcMain.handle("trainingLibrary:snapshot", () =>
+    getTrainingLibrarySnapshot()
+  );
+  ipcMain.handle("trainingLibrary:getNativePlan", (_event, remoteId: string) =>
+    getNativeTrainingPlan(remoteId)
+  );
+  ipcMain.handle("trainingLibrary:savePlan", (_event, plan) =>
+    saveLocalTrainingPlan(plan)
+  );
+  ipcMain.handle("trainingLibrary:updatePlanMetadata", (_event, id, patch) =>
+    updateTrainingPlanMetadata(id, patch)
+  );
+  ipcMain.handle(
+    "trainingLibrary:deletePlan",
+    (_event, id: string, confirmed: boolean) => deleteLocalTrainingPlan(id, confirmed)
+  );
+  ipcMain.handle(
+    "trainingLibrary:updateWorkoutMetadata",
+    (_event, programIds, patch) => updateWorkoutMetadata(programIds, patch)
+  );
+  ipcMain.handle("trainingLibrary:saveCollection", (_event, collection) =>
+    upsertTrainingCollection(collection)
+  );
+  ipcMain.handle(
+    "trainingLibrary:deleteCollection",
+    (_event, id: string, confirmed: boolean) => removeTrainingCollection(id, confirmed)
+  );
+  ipcMain.handle("trainingLibrary:deleteWorkouts", (_event, request) =>
+    deleteTrainingLibraryWorkouts(request)
+  );
+  ipcMain.handle(
+    "trainingLibrary:refreshMatches",
+    (_event, startDay: string, endDay: string) =>
+      refreshTrainingActivityMatches(startDay, endDay)
+  );
+  ipcMain.handle("trainingLibrary:saveManualMatch", (_event, match) =>
+    saveManualActivityMatch(match)
+  );
 
   ipcMain.handle(
     "trainingHub:listWorkoutExercises",
@@ -1525,6 +1584,12 @@ function registerIpcHandlers(): void {
           : normalizeUnitSystem(unitSystem),
         saveToLibrary
       )
+  );
+
+  ipcMain.handle(
+    "trainingHub:createLibraryWorkout",
+    (_event, entry: PlanWorkoutEntryInput, unitSystem?: UnitSystem) =>
+      createLibraryWorkout(entry, normalizeUnitSystem(unitSystem))
   );
 
   ipcMain.handle(

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -57,7 +57,6 @@ import {
   listWorkoutExercises,
   getWorkoutEditorContext,
   scheduleLibraryWorkout,
-  syncStrengthHistory,
   createAndScheduleWorkout,
   createLibraryWorkout,
   rescheduleScheduledWorkout,
@@ -74,13 +73,29 @@ import {
   uploadActivityFitToCoros,
   uploadTrainingPlan
 } from "./trainingHubService";
-import type { UnitSystem, WorkoutSport } from "./types";
+import { syncStrengthHistory } from "./strengthHistoryService";
 import {
+  connectHevy,
+  disconnectHevy,
+  getHevyStatus,
+  updateHevySettings
+} from "./hevyService";
+import type {
+  HevySettingsInput,
+  StrengthHistoryRequest,
+  UnitSystem,
+  WorkoutSport
+} from "./types";
+import {
+  addTrainingPlanToCalendar,
   deleteLocalTrainingPlan,
   deleteTrainingLibraryWorkouts,
   getNativeTrainingPlan,
   getTrainingLibrarySnapshot,
   refreshTrainingActivityMatches,
+  previewTrainingPlanCalendar,
+  previewTrainingPlanCalendarRemoval,
+  removeTrainingPlanFromCalendar,
   removeTrainingCollection,
   saveLocalTrainingPlan,
   saveManualActivityMatch,
@@ -1502,6 +1517,22 @@ function registerIpcHandlers(): void {
     (_event, id: string, confirmed: boolean) => deleteLocalTrainingPlan(id, confirmed)
   );
   ipcMain.handle(
+    "trainingLibrary:previewPlanCalendar",
+    (_event, planId: string, startDate: string) => previewTrainingPlanCalendar(planId, startDate)
+  );
+  ipcMain.handle(
+    "trainingLibrary:addPlanToCalendar",
+    (_event, previewId: string, confirmed: boolean) => addTrainingPlanToCalendar(previewId, confirmed)
+  );
+  ipcMain.handle(
+    "trainingLibrary:previewPlanCalendarRemoval",
+    (_event, planId: string) => previewTrainingPlanCalendarRemoval(planId)
+  );
+  ipcMain.handle(
+    "trainingLibrary:removePlanFromCalendar",
+    (_event, previewId: string, confirmed: boolean) => removeTrainingPlanFromCalendar(previewId, confirmed)
+  );
+  ipcMain.handle(
     "trainingLibrary:updateWorkoutMetadata",
     (_event, programIds, patch) => updateWorkoutMetadata(programIds, patch)
   );
@@ -1710,9 +1741,15 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle(
     "trainingHub:syncStrengthHistory",
-    (_event, days?: number, force?: boolean) =>
-      syncStrengthHistory(days, force)
+    (_event, request?: StrengthHistoryRequest) => syncStrengthHistory(request)
   );
+
+  ipcMain.handle("hevy:getStatus", () => getHevyStatus());
+  ipcMain.handle("hevy:connect", (_event, apiKey: string) => connectHevy(apiKey));
+  ipcMain.handle("hevy:updateSettings", (_event, input: HevySettingsInput) =>
+    updateHevySettings(input)
+  );
+  ipcMain.handle("hevy:disconnect", () => disconnectHevy());
 
   ipcMain.handle("trainingHub:getSportTypeMap", () => getSportTypeMap());
 

--- a/electron/planWorkoutEditor.ts
+++ b/electron/planWorkoutEditor.ts
@@ -1,0 +1,176 @@
+import type {
+  PlanWorkoutEntryInput,
+  RunWorkoutCreateStep,
+  RunWorkoutEditorDraft,
+  RunWorkoutEditorNode,
+  RunWorkoutEditorStep,
+  RunWorkoutEditorStepKind,
+  RunWorkoutEditorTarget,
+  RunWorkoutStepInput,
+  TrainingPlanEntry,
+  WorkoutSport
+} from "./types";
+import { WORKOUT_SPORT_CAPABILITIES, workoutSportType } from "./workoutCapabilities";
+
+let planEditorNodeCounter = 0;
+
+function editorNodeId(prefix: string): string {
+  planEditorNodeCounter += 1;
+  return `${prefix}-plan-${planEditorNodeCounter}`;
+}
+
+function editorKind(kind: RunWorkoutCreateStep["kind"]): RunWorkoutEditorStepKind {
+  return kind === "interval" ? "training" : kind;
+}
+
+function editorTarget(step: RunWorkoutCreateStep): RunWorkoutEditorTarget {
+  switch (step.target_type) {
+    case "distance":
+      return { type: "distance", meters: Math.max(0, step.target_distance_meters ?? 0) };
+    case "load":
+      return { type: "load", load: Math.max(0, step.target_load ?? 0) };
+    case "hrRecovery":
+      return { type: "hrRecovery", bpm: Math.max(0, step.target_hr_recovery_bpm ?? 0) };
+    case "open":
+      return { type: "open" };
+    case "reps":
+      return { type: "reps", count: Math.max(0, step.target_reps ?? 0) };
+    case "elevationGain":
+      return { type: "elevationGain", meters: Math.max(0, step.target_elevation_gain_meters ?? 0) };
+    case "routes":
+      return { type: "routes", count: Math.max(0, step.target_routes ?? 0) };
+    case "time":
+    default:
+      return { type: "time", seconds: Math.max(0, step.target_duration_seconds ?? 0) };
+  }
+}
+
+function editorStep(step: RunWorkoutCreateStep, sport: WorkoutSport): RunWorkoutEditorStep {
+  return {
+    id: editorNodeId("step"),
+    nodeType: "step",
+    kind: editorKind(step.kind),
+    name: step.name?.trim() || (step.kind === "interval" ? "Training" : step.kind),
+    target: editorTarget(step),
+    intensity: structuredClone(step.intensity ?? WORKOUT_SPORT_CAPABILITIES[sport].defaultIntensity),
+    exerciseId: step.exercise_id,
+    exerciseName: step.exercise_name,
+    exerciseKind: step.exercise_kind,
+    sendOffSeconds: step.send_off_seconds,
+    editable: true
+  };
+}
+
+function editorNodes(steps: RunWorkoutStepInput[], sport: WorkoutSport): RunWorkoutEditorNode[] {
+  return steps.map((node) => {
+    if ("repeat" in node) {
+      return {
+        id: editorNodeId("repeat"),
+        nodeType: "repeat" as const,
+        name: node.name?.trim() || "Repeat",
+        repeat: Math.max(1, Math.round(node.repeat)),
+        steps: node.steps.map((step) => editorStep(step, sport)),
+        editable: true
+      };
+    }
+    return editorStep(node, sport);
+  });
+}
+
+export function planWorkoutInputToEditorDraft(input: PlanWorkoutEntryInput): RunWorkoutEditorDraft {
+  const sport = input.sport ?? "run";
+  const sourceSteps = input.steps?.length
+    ? input.steps
+    : input.distance_km
+      ? [{
+          kind: "training" as const,
+          target_type: "distance" as const,
+          target_distance_meters: input.distance_km * 1_000,
+          intensity: structuredClone(WORKOUT_SPORT_CAPABILITIES[sport].defaultIntensity)
+        }]
+      : [];
+  return {
+    name: input.name,
+    overview: input.description ?? "",
+    sportType: workoutSportType(sport),
+    sport,
+    sportOptions: input.sport_options ? structuredClone(input.sport_options) : undefined,
+    nodes: editorNodes(sourceSteps, sport)
+  };
+}
+
+function inputTarget(target: RunWorkoutEditorTarget): Partial<RunWorkoutCreateStep> {
+  switch (target.type) {
+    case "distance":
+      return { target_type: "distance", target_distance_meters: target.meters };
+    case "load":
+      return { target_type: "load", target_load: target.load };
+    case "hrRecovery":
+      return { target_type: "hrRecovery", target_hr_recovery_bpm: target.bpm };
+    case "open":
+      return { target_type: "open" };
+    case "reps":
+      return { target_type: "reps", target_reps: target.count };
+    case "elevationGain":
+      return { target_type: "elevationGain", target_elevation_gain_meters: target.meters };
+    case "routes":
+      return { target_type: "routes", target_routes: target.count };
+    case "time":
+      return { target_type: "time", target_duration_seconds: target.seconds };
+  }
+}
+
+function inputStep(step: RunWorkoutEditorStep): RunWorkoutCreateStep {
+  return {
+    kind: step.kind,
+    ...(step.name.trim() ? { name: step.name.trim() } : {}),
+    ...inputTarget(step.target),
+    intensity: structuredClone(step.intensity),
+    ...(step.exerciseId?.trim() ? { exercise_id: step.exerciseId.trim() } : {}),
+    ...(step.exerciseName?.trim() ? { exercise_name: step.exerciseName.trim() } : {}),
+    ...(step.exerciseKind !== undefined ? { exercise_kind: step.exerciseKind } : {}),
+    ...(step.sendOffSeconds !== undefined ? { send_off_seconds: step.sendOffSeconds } : {})
+  };
+}
+
+export function editorDraftToPlanWorkoutInput(
+  draft: RunWorkoutEditorDraft,
+  previous: PlanWorkoutEntryInput
+): PlanWorkoutEntryInput {
+  return {
+    key: previous.key,
+    name: draft.name.trim(),
+    description: draft.overview.trim() || undefined,
+    sport: draft.sport,
+    sport_options: draft.sportOptions ? structuredClone(draft.sportOptions) : undefined,
+    steps: draft.nodes.map((node) =>
+      node.nodeType === "repeat"
+        ? {
+            repeat: Math.max(1, Math.round(node.repeat)),
+            name: node.name.trim() || undefined,
+            steps: node.steps.map(inputStep)
+          }
+        : inputStep(node)
+    ),
+    schedule_date: previous.schedule_date,
+    sort_no: previous.sort_no,
+    save_to_library: false
+  };
+}
+
+/** Replace a plan-owned workout copy without mutating its linked library source. */
+export function replaceTrainingPlanEntryWorkout(
+  entry: TrainingPlanEntry,
+  workout: PlanWorkoutEntryInput
+): TrainingPlanEntry {
+  return {
+    ...entry,
+    title: workout.name,
+    workout: structuredClone(workout),
+    programId: undefined,
+    plannedDurationSeconds: undefined,
+    plannedDistanceMeters: undefined,
+    plannedTrainingLoad: undefined,
+    plannedStrengthSets: undefined
+  };
+}

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -50,6 +50,14 @@ import type {
   TrainingHubUpcomingWorkout,
   TrainingHubScheduledWorkoutEntry,
   TrainingHubLibraryWorkout,
+  TrainingActivityMatch,
+  TrainingCollection,
+  TrainingLibraryDeleteRequest,
+  TrainingLibrarySnapshot,
+  TrainingPlanDocument,
+  TrainingPlanDestination,
+  TrainingPlanMetadataPatch,
+  WorkoutMetadataPatch,
   UnitSystem,
   PlanWorkoutEntryInput,
   RunWorkoutEditorDraft,
@@ -513,6 +521,55 @@ const api = {
     ipcRenderer.invoke("trainingHub:listScheduledWorkouts", startDay, endDay),
   listLibraryWorkouts: (): Promise<TrainingHubLibraryWorkout[]> =>
     ipcRenderer.invoke("trainingHub:listLibraryWorkouts"),
+  duplicateLibraryWorkout: (
+    programId: string,
+    name: string,
+    targetSportType?: number
+  ): Promise<TrainingHubLibraryWorkout> =>
+    ipcRenderer.invoke(
+      "trainingHub:duplicateLibraryWorkout",
+      programId,
+      name,
+      targetSportType
+    ),
+  getTrainingLibrarySnapshot: (): Promise<TrainingLibrarySnapshot> =>
+    ipcRenderer.invoke("trainingLibrary:snapshot"),
+  getNativeTrainingPlan: (remoteId: string): Promise<TrainingPlanDocument> =>
+    ipcRenderer.invoke("trainingLibrary:getNativePlan", remoteId),
+  saveLocalTrainingPlan: (plan: TrainingPlanDocument): Promise<TrainingPlanDocument> =>
+    ipcRenderer.invoke("trainingLibrary:savePlan", plan),
+  updateTrainingPlanMetadata: (
+    id: string,
+    patch: TrainingPlanMetadataPatch
+  ): Promise<TrainingPlanDocument> =>
+    ipcRenderer.invoke("trainingLibrary:updatePlanMetadata", id, patch),
+  deleteLocalTrainingPlan: (id: string, confirmed: boolean): Promise<void> =>
+    ipcRenderer.invoke("trainingLibrary:deletePlan", id, confirmed),
+  updateWorkoutMetadata: (
+    programIds: string[],
+    patch: WorkoutMetadataPatch
+  ): Promise<void> =>
+    ipcRenderer.invoke("trainingLibrary:updateWorkoutMetadata", programIds, patch),
+  saveTrainingCollection: (
+    collection: Pick<TrainingCollection, "id" | "name"> &
+      Partial<Pick<TrainingCollection, "description" | "color">>
+  ): Promise<TrainingCollection> =>
+    ipcRenderer.invoke("trainingLibrary:saveCollection", collection),
+  deleteTrainingCollection: (id: string, confirmed: boolean): Promise<void> =>
+    ipcRenderer.invoke("trainingLibrary:deleteCollection", id, confirmed),
+  deleteTrainingLibraryWorkouts: (
+    request: TrainingLibraryDeleteRequest
+  ): Promise<string[]> =>
+    ipcRenderer.invoke("trainingLibrary:deleteWorkouts", request),
+  refreshTrainingActivityMatches: (
+    startDay: string,
+    endDay: string
+  ): Promise<TrainingActivityMatch[]> =>
+    ipcRenderer.invoke("trainingLibrary:refreshMatches", startDay, endDay),
+  saveManualActivityMatch: (
+    match: TrainingActivityMatch
+  ): Promise<TrainingActivityMatch> =>
+    ipcRenderer.invoke("trainingLibrary:saveManualMatch", match),
   listWorkoutExercises: (sport: WorkoutSport): Promise<WorkoutExerciseOption[]> =>
     ipcRenderer.invoke("trainingHub:listWorkoutExercises", sport),
   getWorkoutEditorContext: (unitSystem: UnitSystem): Promise<WorkoutEditorContext> =>
@@ -554,6 +611,11 @@ const api = {
       unitSystem,
       saveToLibrary
     ),
+  createLibraryWorkout: (
+    entry: PlanWorkoutEntryInput,
+    unitSystem: UnitSystem
+  ): Promise<{ programId?: string }> =>
+    ipcRenderer.invoke("trainingHub:createLibraryWorkout", entry, unitSystem),
   rescheduleWorkout: (
     entry: {
       planId: string;
@@ -919,9 +981,10 @@ const api = {
     ipcRenderer.invoke("mcp:setBearer", id, token),
   uploadTrainingPlanDraft: (
     draftId: string,
-    unitSystem: UnitSystem
+    unitSystem: UnitSystem,
+    destination?: TrainingPlanDestination
   ): Promise<UploadPlanResult> =>
-    ipcRenderer.invoke("chat:uploadPlanDraft", draftId, unitSystem),
+    ipcRenderer.invoke("chat:uploadPlanDraft", draftId, unitSystem, destination),
   confirmWorkoutDelete: (requestId: string): Promise<DeleteWorkoutResult> =>
     ipcRenderer.invoke("chat:confirmWorkoutDelete", requestId),
   setWindowBackground: (color: string): Promise<void> =>

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -33,7 +33,10 @@ import type {
   SpotifySyncResult,
   SpotifySyncTrack,
   SpotifySyncUpdate,
+  HevySettingsInput,
+  HevyStatus,
   StrengthHistory,
+  StrengthHistoryRequest,
   TrainingHubActivity,
   TrainingHubActivityDetail,
   TrainingHubActivityFileType,
@@ -55,6 +58,8 @@ import type {
   TrainingLibraryDeleteRequest,
   TrainingLibrarySnapshot,
   TrainingPlanDocument,
+  TrainingPlanCalendarMutationResult,
+  TrainingPlanCalendarPreview,
   TrainingPlanDestination,
   TrainingPlanMetadataPatch,
   WorkoutMetadataPatch,
@@ -545,6 +550,14 @@ const api = {
     ipcRenderer.invoke("trainingLibrary:updatePlanMetadata", id, patch),
   deleteLocalTrainingPlan: (id: string, confirmed: boolean): Promise<void> =>
     ipcRenderer.invoke("trainingLibrary:deletePlan", id, confirmed),
+  previewTrainingPlanCalendar: (planId: string, startDate: string): Promise<TrainingPlanCalendarPreview> =>
+    ipcRenderer.invoke("trainingLibrary:previewPlanCalendar", planId, startDate),
+  addTrainingPlanToCalendar: (previewId: string, confirmed: boolean): Promise<TrainingPlanCalendarMutationResult> =>
+    ipcRenderer.invoke("trainingLibrary:addPlanToCalendar", previewId, confirmed),
+  previewTrainingPlanCalendarRemoval: (planId: string): Promise<TrainingPlanCalendarPreview> =>
+    ipcRenderer.invoke("trainingLibrary:previewPlanCalendarRemoval", planId),
+  removeTrainingPlanFromCalendar: (previewId: string, confirmed: boolean): Promise<TrainingPlanCalendarMutationResult> =>
+    ipcRenderer.invoke("trainingLibrary:removePlanFromCalendar", previewId, confirmed),
   updateWorkoutMetadata: (
     programIds: string[],
     patch: WorkoutMetadataPatch
@@ -693,8 +706,14 @@ const api = {
     ipcRenderer.invoke("trainingHub:getDashboard"),
   getDailyMetrics: (dateList: string[]): Promise<TrainingHubDailyMetrics> =>
     ipcRenderer.invoke("trainingHub:getDailyMetrics", dateList),
-  syncStrengthHistory: (days?: number, force?: boolean): Promise<StrengthHistory> =>
-    ipcRenderer.invoke("trainingHub:syncStrengthHistory", days, force),
+  syncStrengthHistory: (request?: StrengthHistoryRequest): Promise<StrengthHistory> =>
+    ipcRenderer.invoke("trainingHub:syncStrengthHistory", request),
+  getHevyStatus: (): Promise<HevyStatus> => ipcRenderer.invoke("hevy:getStatus"),
+  connectHevy: (apiKey: string): Promise<HevyStatus> =>
+    ipcRenderer.invoke("hevy:connect", apiKey),
+  updateHevySettings: (input: HevySettingsInput): Promise<HevyStatus> =>
+    ipcRenderer.invoke("hevy:updateSettings", input),
+  disconnectHevy: (): Promise<void> => ipcRenderer.invoke("hevy:disconnect"),
   startRpeBackfill: (): Promise<void> =>
     ipcRenderer.invoke("trainingHub:startRpeBackfill"),
   getRpeBackfillStatus: (): Promise<{ pending: number; running: boolean }> =>

--- a/electron/strengthHistoryService.ts
+++ b/electron/strengthHistoryService.ts
@@ -1,0 +1,79 @@
+import { listStoredStrengthSessions } from "./database";
+import {
+  getStoredHevyStrengthSessions,
+  getHevyStatus,
+  syncHevyStrengthHistory
+} from "./hevyService";
+import { selectStrengthSessions } from "./strengthSessionMerge";
+import {
+  getTrainingHubStatus,
+  syncStrengthHistory as syncCorosStrengthHistory
+} from "./trainingHubService";
+import type {
+  StrengthHistory,
+  StrengthHistoryRequest,
+  StrengthSession
+} from "./types";
+
+function windowStartEpochSeconds(days: number): number {
+  const start = new Date();
+  start.setHours(0, 0, 0, 0);
+  start.setDate(start.getDate() - days);
+  return Math.floor(start.getTime() / 1000);
+}
+function errorMessage(provider: string, error: unknown): string {
+  const detail = error instanceof Error ? error.message : String(error);
+  return `${provider} refresh failed: ${detail}`;
+}
+
+export async function syncStrengthHistory(
+  request: StrengthHistoryRequest = {}
+): Promise<StrengthHistory> {
+  const days = Math.max(1, Math.min(365, Math.round(request.days ?? 90)));
+  const source = request.source ?? "combined";
+  const wantsCoros = source === "combined" || source === "coros";
+  const wantsHevy = source === "combined" || source === "hevy";
+  const corosConnected = getTrainingHubStatus().authenticated;
+  const hevyConnected = getHevyStatus().connected;
+  const warnings: string[] = [];
+
+  let corosSessions: StrengthSession[] = [];
+  let hevySessions: StrengthSession[] = [];
+  let corosPending = 0;
+  let corosFetched = 0;
+  let hevyFetched = 0;
+
+  if (wantsCoros && corosConnected) {
+    try {
+      const result = await syncCorosStrengthHistory(days, request.force ?? false);
+      corosSessions = result.sessions;
+      corosPending = result.pending;
+      corosFetched = result.fetched;
+    } catch (error) {
+      warnings.push(errorMessage("COROS", error));
+      corosSessions = listStoredStrengthSessions(windowStartEpochSeconds(days));
+    }
+  }
+
+  if (wantsHevy && hevyConnected) {
+    try {
+      const result = await syncHevyStrengthHistory(days, request.force ?? false);
+      hevySessions = result.sessions;
+      hevyFetched = result.fetched;
+    } catch (error) {
+      warnings.push(errorMessage("Hevy", error));
+      hevySessions = getStoredHevyStrengthSessions(days);
+    }
+  }
+
+  return {
+    sessions: selectStrengthSessions(source, corosSessions, hevySessions),
+    pending: corosPending,
+    fetched: corosFetched + hevyFetched,
+    days,
+    source,
+    pendingBySource: { coros: corosPending, hevy: 0 },
+    fetchedBySource: { coros: corosFetched, hevy: hevyFetched },
+    ...(warnings.length > 0 ? { warnings } : {})
+  };
+}

--- a/electron/strengthSessionMerge.ts
+++ b/electron/strengthSessionMerge.ts
@@ -1,0 +1,191 @@
+import { canonicalStrengthExerciseName } from "./hevyModel";
+import type {
+  StrengthDataSource,
+  StrengthSession,
+  StrengthSourceIds
+} from "./types";
+
+function localDay(timestamp?: number): string | undefined {
+  if (timestamp === undefined) return undefined;
+  const date = new Date(timestamp * 1000);
+  return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+}
+function durationOf(session: StrengthSession): number {
+  return Math.max(0, session.detail.summary.durationSec || session.duration || 0);
+}
+
+function intervalOverlapRatio(left: StrengthSession, right: StrengthSession): number {
+  if (left.startTime === undefined || right.startTime === undefined) return 0;
+  const leftDuration = durationOf(left);
+  const rightDuration = durationOf(right);
+  if (leftDuration <= 0 || rightDuration <= 0) return 0;
+  const overlap = Math.max(
+    0,
+    Math.min(left.startTime + leftDuration, right.startTime + rightDuration) -
+      Math.max(left.startTime, right.startTime)
+  );
+  return overlap / Math.min(leftDuration, rightDuration);
+}
+
+function exerciseIdentities(session: StrengthSession): Set<string> {
+  return new Set(
+    session.detail.exercises
+      .map((exercise) =>
+        canonicalStrengthExerciseName(exercise.rawName ?? exercise.nameKey)
+      )
+      .filter(Boolean)
+  );
+}
+
+interface MatchCandidate {
+  corosIndex: number;
+  hevyIndex: number;
+  sharedExercises: number;
+  exerciseSimilarity: number;
+  startDifference: number;
+  durationDifference: number;
+}
+
+function matchCandidate(
+  coros: StrengthSession,
+  hevy: StrengthSession,
+  corosIndex: number,
+  hevyIndex: number
+): MatchCandidate | undefined {
+  if (
+    coros.startTime === undefined ||
+    hevy.startTime === undefined ||
+    localDay(coros.startTime) !== localDay(hevy.startTime)
+  ) {
+    return undefined;
+  }
+  const startDifference = Math.abs(coros.startTime - hevy.startTime);
+  const overlaps = intervalOverlapRatio(coros, hevy) >= 0.6;
+  if (startDifference > 30 * 60 && !overlaps) return undefined;
+
+  const corosExercises = exerciseIdentities(coros);
+  const hevyExercises = exerciseIdentities(hevy);
+  const sharedExercises = [...corosExercises].filter((name) => hevyExercises.has(name)).length;
+  const union = new Set([...corosExercises, ...hevyExercises]).size;
+  const exerciseSimilarity = union > 0 ? sharedExercises / union : 0;
+  const durationDifference = Math.abs(durationOf(coros) - durationOf(hevy));
+  const strictTimeFallback = startDifference <= 5 * 60 && durationDifference <= 15 * 60;
+  if (sharedExercises === 0 && !strictTimeFallback) return undefined;
+
+  return {
+    corosIndex,
+    hevyIndex,
+    sharedExercises,
+    exerciseSimilarity,
+    startDifference,
+    durationDifference
+  };
+}
+
+function sourceIdsOf(session: StrengthSession): StrengthSourceIds {
+  if (session.sourceIds) return session.sourceIds;
+  return session.source === "hevy"
+    ? { hevy: session.activityId.replace(/^hevy:/, "") }
+    : { coros: session.activityId };
+}
+
+export function mergeStrengthSessionPair(
+  coros: StrengthSession,
+  hevy: StrengthSession
+): StrengthSession {
+  const corosId = sourceIdsOf(coros).coros ?? coros.activityId;
+  const hevyId = sourceIdsOf(hevy).hevy ?? hevy.activityId.replace(/^hevy:/, "");
+  const calories = coros.calories ?? coros.detail.summary.calories;
+  const avgHr = coros.avgHr ?? coros.detail.summary.avgHr;
+  const maxHr = coros.maxHr ?? coros.detail.summary.maxHr;
+  const trainingLoad = coros.trainingLoad ?? coros.detail.summary.trainingLoad;
+  return {
+    ...hevy,
+    activityId: `combined:${hevyId}:${corosId}`,
+    source: "combined",
+    sourceIds: { hevy: hevyId, coros: corosId },
+    calories,
+    avgHr,
+    maxHr,
+    trainingLoad,
+    detail: {
+      ...hevy.detail,
+      summary: {
+        ...hevy.detail.summary,
+        calories: calories ?? hevy.detail.summary.calories,
+        avgHr,
+        maxHr,
+        trainingLoad
+      }
+    }
+  };
+}
+
+export function combineStrengthSessions(
+  corosSessions: StrengthSession[],
+  hevySessions: StrengthSession[]
+): StrengthSession[] {
+  const coros = corosSessions.map((session) => ({
+    ...session,
+    source: "coros" as const,
+    sourceIds: sourceIdsOf({ ...session, source: "coros" })
+  }));
+  const candidates: MatchCandidate[] = [];
+  for (let corosIndex = 0; corosIndex < coros.length; corosIndex += 1) {
+    for (let hevyIndex = 0; hevyIndex < hevySessions.length; hevyIndex += 1) {
+      const candidate = matchCandidate(
+        coros[corosIndex],
+        hevySessions[hevyIndex],
+        corosIndex,
+        hevyIndex
+      );
+      if (candidate) candidates.push(candidate);
+    }
+  }
+  candidates.sort(
+    (left, right) =>
+      right.sharedExercises - left.sharedExercises ||
+      right.exerciseSimilarity - left.exerciseSimilarity ||
+      left.startDifference - right.startDifference ||
+      left.durationDifference - right.durationDifference
+  );
+
+  const usedCoros = new Set<number>();
+  const usedHevy = new Set<number>();
+  const merged: StrengthSession[] = [];
+  for (const candidate of candidates) {
+    if (usedCoros.has(candidate.corosIndex) || usedHevy.has(candidate.hevyIndex)) {
+      continue;
+    }
+    usedCoros.add(candidate.corosIndex);
+    usedHevy.add(candidate.hevyIndex);
+    merged.push(
+      mergeStrengthSessionPair(
+        coros[candidate.corosIndex],
+        hevySessions[candidate.hevyIndex]
+      )
+    );
+  }
+
+  return [
+    ...merged,
+    ...coros.filter((_, index) => !usedCoros.has(index)),
+    ...hevySessions.filter((_, index) => !usedHevy.has(index))
+  ].sort((left, right) => (right.startTime ?? 0) - (left.startTime ?? 0));
+}
+
+export function selectStrengthSessions(
+  source: StrengthDataSource,
+  coros: StrengthSession[],
+  hevy: StrengthSession[]
+): StrengthSession[] {
+  if (source === "coros") {
+    return coros.map((session) => ({
+      ...session,
+      source: "coros",
+      sourceIds: sourceIdsOf({ ...session, source: "coros" })
+    }));
+  }
+  if (source === "hevy") return hevy;
+  return combineStrengthSessions(coros, hevy);
+}

--- a/electron/trainingHubService.ts
+++ b/electron/trainingHubService.ts
@@ -1746,6 +1746,54 @@ export async function listLibraryWorkouts(): Promise<TrainingHubLibraryWorkout[]
     .sort((left, right) => (right.createTimestamp ?? 0) - (left.createTimestamp ?? 0));
 }
 
+export async function duplicateLibraryWorkout(
+  programId: string,
+  name: string,
+  targetSportType?: number
+): Promise<TrainingHubLibraryWorkout> {
+  const source = await getWorkoutProgramDetail(programId);
+  if (!source) throw new Error("Workout could not be loaded from COROS.");
+  const sourceSport = toOptionalNumber(source.sportType);
+  const targetSport = targetSportType ?? sourceSport;
+  if (!sourceSport || !targetSport) throw new Error("Workout sport is unavailable.");
+  const crossSport = sourceSport !== targetSport;
+  const runTrailCompatible =
+    (sourceSport === 1 && targetSport === 5) ||
+    (sourceSport === 5 && targetSport === 1);
+  if (crossSport && !runTrailCompatible) {
+    throw new Error(
+      "This sport conversion is not compatible with the workout's targets and intensities. Duplicate it in the same sport instead."
+    );
+  }
+  if (
+    sourceSport === 5 &&
+    targetSport === 1 &&
+    Array.isArray(source.exercises) &&
+    source.exercises.some(
+      (exercise) =>
+        typeof exercise === "object" &&
+        exercise !== null &&
+        toOptionalNumber((exercise as Record<string, unknown>).targetType) === 8
+    )
+  ) {
+    throw new Error(
+      "Trail elevation-gain targets are not supported by Run. Remove that target before converting the workout."
+    );
+  }
+  const duplicate = resetProgramForCreate(source);
+  duplicate.name = name.trim() || `${String(source.name ?? "Workout")} Copy`;
+  duplicate.sportType = targetSport;
+  const created = await createWorkoutProgram(duplicate);
+  return {
+    id: created.programId,
+    name: String(created.program.name ?? duplicate.name),
+    sportType: toOptionalNumber(created.program.sportType),
+    volume: formatUpcomingWorkoutVolume(created.program, {}),
+    trainingLoad: resolveUpcomingWorkoutLoad(created.program, {}),
+    createTimestamp: Date.now()
+  };
+}
+
 async function resolveWorkoutEditSource(ref: WorkoutEditRef): Promise<WorkoutEditSource> {
   if (ref.kind === "library") {
     const program = await trainingHubGet<Record<string, unknown>>(
@@ -2597,6 +2645,27 @@ export async function uploadTrainingPlan(
   };
 }
 
+export async function createLibraryWorkout(
+  entry: PlanWorkoutEntryInput,
+  unitSystem: UnitSystem = "metric"
+): Promise<{ programId?: string }> {
+  const result = await uploadTrainingPlan(
+    {
+      name: entry.name,
+      workouts: [
+        {
+          ...entry,
+          key: entry.key || `library-${Date.now()}`,
+          schedule_date: undefined,
+          save_to_library: true
+        }
+      ]
+    },
+    unitSystem
+  );
+  return { programId: result.entries[0]?.programId };
+}
+
 async function loadExistingScheduleDates(
   draft: CorosTrainingPlanDraft
 ): Promise<Map<string, string[]>> {
@@ -2663,7 +2732,7 @@ async function findLibraryWorkoutById(
   return programs.find((program) => String(program.id ?? "") === programId);
 }
 
-async function getWorkoutProgramDetail(
+export async function getWorkoutProgramDetail(
   programId: string
 ): Promise<Record<string, unknown> | undefined> {
   try {
@@ -5728,6 +5797,27 @@ async function trainingHubGet<T>(
   params?: Record<string, string | number>
 ): Promise<T> {
   return trainingHubRequest<T>(path, { method: "GET", params });
+}
+
+/**
+ * Narrow read-only bridge for the native training-plan adapter. Keeping the
+ * allowlist here prevents plan discovery from becoming a generic raw API
+ * escape hatch or accidentally issuing an unverified write.
+ */
+export async function readNativeTrainingPlanEndpoint<T>(
+  path: "/training/plan/query" | "/training/plan/detail",
+  options:
+    | { method: "POST"; body: Record<string, unknown> }
+    | { method: "GET"; params: Record<string, string | number> }
+): Promise<T> {
+  if (path === "/training/plan/query" && options.method === "POST") {
+    const result = await trainingHubPost<T>(path, options.body);
+    return result as T;
+  }
+  if (path === "/training/plan/detail" && options.method === "GET") {
+    return trainingHubGet<T>(path, options.params);
+  }
+  throw new Error("Unsupported native training-plan read operation.");
 }
 
 interface TrainingHubRequestOptions extends RequestInit {

--- a/electron/trainingHubService.ts
+++ b/electron/trainingHubService.ts
@@ -795,9 +795,46 @@ export async function reconnectTrainingHub(): Promise<TrainingHubLoginResult> {
   return { twoFactorRequired: false, status: getTrainingHubStatus() };
 }
 
-export async function listTrainingHubActivities(
-  page = 1,
-  size = 50,
+const COROS_ACTIVITY_PAGE_SIZE_LIMIT = 100;
+
+export function buildTrainingHubActivityPagePlan(
+  page: number,
+  size: number
+): { requests: Array<{ page: number; size: number }>; sliceStart: number } {
+  if (!Number.isSafeInteger(page) || page < 1) {
+    throw new Error("Activity page must be a positive integer.");
+  }
+  if (!Number.isSafeInteger(size) || size < 1) {
+    throw new Error("Activity page size must be a positive integer.");
+  }
+
+  if (size <= COROS_ACTIVITY_PAGE_SIZE_LIMIT) {
+    return { requests: [{ page, size }], sliceStart: 0 };
+  }
+
+  const firstIndex = (page - 1) * size;
+  const lastIndex = firstIndex + size - 1;
+  if (!Number.isSafeInteger(firstIndex) || !Number.isSafeInteger(lastIndex)) {
+    throw new Error("Activity page is too large.");
+  }
+
+  const firstRemotePage = Math.floor(firstIndex / COROS_ACTIVITY_PAGE_SIZE_LIMIT) + 1;
+  const lastRemotePage = Math.floor(lastIndex / COROS_ACTIVITY_PAGE_SIZE_LIMIT) + 1;
+  return {
+    requests: Array.from(
+      { length: lastRemotePage - firstRemotePage + 1 },
+      (_, index) => ({
+        page: firstRemotePage + index,
+        size: COROS_ACTIVITY_PAGE_SIZE_LIMIT
+      })
+    ),
+    sliceStart: firstIndex % COROS_ACTIVITY_PAGE_SIZE_LIMIT
+  };
+}
+
+async function queryTrainingHubActivityPage(
+  page: number,
+  size: number,
   startDay?: string,
   endDay?: string
 ): Promise<TrainingHubActivity[]> {
@@ -816,8 +853,32 @@ export async function listTrainingHubActivities(
     params
   );
 
+  return (data.dataList ?? []).map(mapTrainingHubActivity);
+}
+
+export async function listTrainingHubActivities(
+  page = 1,
+  size = 50,
+  startDay?: string,
+  endDay?: string
+): Promise<TrainingHubActivity[]> {
+  const plan = buildTrainingHubActivityPagePlan(page, size);
+  const fetched: TrainingHubActivity[] = [];
+  for (const request of plan.requests) {
+    const batch = await queryTrainingHubActivityPage(
+      request.page,
+      request.size,
+      startDay,
+      endDay
+    );
+    fetched.push(...batch);
+    if (batch.length < request.size) {
+      break;
+    }
+  }
+
   const activities = enrichActivitiesWithSportNames(
-    (data.dataList ?? []).map(mapTrainingHubActivity)
+    fetched.slice(plan.sliceStart, plan.sliceStart + size)
   );
   // Persist a local copy so analytics (e.g. personal pace) work offline and
   // across sessions without re-fetching from COROS.

--- a/electron/trainingLibraryService.ts
+++ b/electron/trainingLibraryService.ts
@@ -18,12 +18,18 @@ import {
   readNativeCorosPlan
 } from "./corosTrainingPlanAdapter";
 import {
+  createAndScheduleWorkout,
   deleteWorkoutProgram,
   listLibraryWorkouts,
   listScheduledWorkoutEntries,
-  listTrainingHubActivities
+  listTrainingHubActivities,
+  removeScheduledWorkout,
+  scheduleLibraryWorkout
 } from "./trainingHubService";
 import {
+  activeTrainingPlanCalendarInstall,
+  shiftTrainingPlan,
+  trainingPlanCalendarRevision,
   validateTrainingPlan,
   workoutSportFromType
 } from "./trainingPlanDomain";
@@ -39,6 +45,11 @@ import type {
   TrainingLibrarySnapshot,
   TrainingLibraryWorkout,
   TrainingPlanDocument,
+  TrainingPlanCalendarFailure,
+  TrainingPlanCalendarInstall,
+  TrainingPlanCalendarMutationResult,
+  TrainingPlanCalendarPreview,
+  TrainingPlanCalendarPreviewEntry,
   TrainingPlanMetadataPatch,
   TrainingPlanWriteCapabilities,
   TrainingWorkoutMetadata,
@@ -47,7 +58,7 @@ import type {
 } from "./types";
 
 const UNVERIFIED_WRITE_REASON =
-  "Native COROS plan writes are disabled until the cleanup-safe opt-in verifier confirms this account and API version. Local templates and individual workout/calendar upload remain available.";
+  "Native COROS plan writes are unavailable.";
 
 export function getNativePlanWriteCapabilities(): TrainingPlanWriteCapabilities {
   return {
@@ -365,7 +376,470 @@ export function deleteLocalTrainingPlan(id: string, confirmed: boolean): void {
   if (plan.source === "coros") {
     throw new Error(UNVERIFIED_WRITE_REASON);
   }
+  if (activeTrainingPlanCalendarInstall(plan)) {
+    throw new Error("Remove this plan's future calendar workouts before deleting the plan.");
+  }
   deleteTrainingPlanDocument(id);
+}
+
+interface StoredPlanCalendarPreview {
+  preview: TrainingPlanCalendarPreview;
+  projectedPlan: TrainingPlanDocument;
+  calendarFingerprint: string;
+  rangeStart: string;
+  rangeEnd: string;
+  installId?: string;
+}
+
+interface TrainingPlanCalendarAdapter {
+  listScheduled: typeof listScheduledWorkoutEntries;
+  scheduleLibrary: typeof scheduleLibraryWorkout;
+  createAndSchedule: typeof createAndScheduleWorkout;
+  removeScheduled: typeof removeScheduledWorkout;
+}
+
+const defaultTrainingPlanCalendarAdapter: TrainingPlanCalendarAdapter = {
+  listScheduled: listScheduledWorkoutEntries,
+  scheduleLibrary: scheduleLibraryWorkout,
+  createAndSchedule: createAndScheduleWorkout,
+  removeScheduled: removeScheduledWorkout
+};
+
+let trainingPlanCalendarAdapter = defaultTrainingPlanCalendarAdapter;
+
+/** Test seam for calendar mutation simulations. Never used by the renderer. */
+export function setTrainingPlanCalendarAdapterForTests(
+  overrides?: Partial<TrainingPlanCalendarAdapter>
+): void {
+  trainingPlanCalendarAdapter = overrides
+    ? { ...defaultTrainingPlanCalendarAdapter, ...overrides }
+    : defaultTrainingPlanCalendarAdapter;
+}
+
+const PLAN_CALENDAR_PREVIEW_TTL_MS = 15 * 60_000;
+const planCalendarPreviews = new Map<string, StoredPlanCalendarPreview>();
+
+function normalizedCalendarDay(value: string): string {
+  const day = value.replace(/-/g, "");
+  if (!/^\d{8}$/.test(day)) throw new Error("Calendar dates must use YYYY-MM-DD.");
+  return day;
+}
+
+function dashedCalendarDay(value: string): string {
+  const day = normalizedCalendarDay(value);
+  return `${day.slice(0, 4)}-${day.slice(4, 6)}-${day.slice(6)}`;
+}
+
+function addCalendarDays(value: string, offset: number): string {
+  const date = parsePlanDay(value);
+  if (!date) throw new Error("Calendar dates must use YYYY-MM-DD.");
+  date.setDate(date.getDate() + offset);
+  return dateKey(date);
+}
+
+function scheduleIdentity(entry: TrainingHubScheduledWorkoutEntry): string {
+  return `${entry.planId}:${entry.idInPlan}`;
+}
+
+function fingerprintCalendar(entries: TrainingHubScheduledWorkoutEntry[]): string {
+  const serialized = entries
+    .map((entry) => ({
+      planId: entry.planId,
+      idInPlan: entry.idInPlan,
+      planProgramId: entry.planProgramId,
+      happenDay: entry.happenDay,
+      name: entry.name
+    }))
+    .sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+  return crypto.createHash("sha256").update(JSON.stringify(serialized)).digest("hex");
+}
+
+function latestInstallForPlan(plan: TrainingPlanDocument): TrainingPlanCalendarInstall | undefined {
+  const today = dateKey(new Date());
+  return [...(plan.calendarInstalls ?? [])]
+    .filter((install) => install.state === "partial" || (
+      install.state !== "removed" && install.occurrences.some((occurrence) => !occurrence.removedAt && occurrence.happenDay >= today)
+    ))
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))[0];
+}
+
+export function buildTrainingPlanCalendarProjection(
+  plan: TrainingPlanDocument,
+  startDate: string,
+  scheduled: TrainingHubScheduledWorkoutEntry[],
+  today = dateKey(new Date())
+): Pick<TrainingPlanCalendarPreview, "startDate" | "entries" | "conflicts" | "blockers"> & {
+  projectedPlan: TrainingPlanDocument;
+} {
+  if (plan.source === "coros") {
+    throw new Error("Native COROS plans are read-only in the Training Library.");
+  }
+  const startDay = normalizedCalendarDay(startDate);
+  const start = parsePlanDay(startDay)!;
+  if (start.getDay() !== 1) throw new Error("The plan start date must be a Monday.");
+  if (startDay < today) throw new Error("A training plan cannot be installed in the past.");
+  const projectedPlan = shiftTrainingPlan(plan, dashedCalendarDay(startDay));
+  const planRevision = trainingPlanCalendarRevision(projectedPlan);
+  const existingInstall = latestInstallForPlan(plan);
+  const blockers: string[] = [];
+  if (existingInstall?.state === "active") {
+    blockers.push("This plan already has an active calendar installation.");
+  } else if (existingInstall) {
+    if (existingInstall.lastOperation === "remove") {
+      blockers.push("Finish removing the partial calendar installation before reinstalling.");
+    }
+    if (normalizedCalendarDay(existingInstall.startDate) !== startDay) {
+      blockers.push("Remove the partial calendar installation before choosing a new start date.");
+    }
+    if (existingInstall.planRevision !== planRevision) {
+      blockers.push("The plan changed after its partial calendar installation. Remove it before reinstalling.");
+    }
+    if (existingInstall.failures.some((failure) => failure.writeMayHaveSucceeded && failure.happenDay >= today)) {
+      blockers.push("COROS may have accepted an unverified workout. Refresh the calendar before retrying.");
+    }
+  }
+  const owned = new Set(
+    existingInstall?.occurrences
+      .filter((occurrence) => !occurrence.removedAt)
+      .map((occurrence) => `${occurrence.planEntryId}:${occurrence.happenDay}`) ?? []
+  );
+  const entries: TrainingPlanCalendarPreviewEntry[] = [];
+  for (const entry of projectedPlan.entries) {
+    if (entry.kind !== "workout") continue;
+    if (entry.dayIndex === undefined) {
+      blockers.push(`"${entry.title ?? "Untitled workout"}" is still in the holding area.`);
+      continue;
+    }
+    const happenDay = addCalendarDays(startDay, entry.weekIndex * 7 + entry.dayIndex);
+    if (owned.has(`${entry.id}:${happenDay}`)) continue;
+    if (!entry.programId && !entry.workout) {
+      blockers.push(`"${entry.title ?? "Untitled workout"}" has no workout definition.`);
+      continue;
+    }
+    entries.push({
+      planEntryId: entry.id,
+      name: entry.title ?? entry.workout?.name ?? "Workout",
+      happenDay,
+      sport: entry.workout?.sport
+    });
+  }
+  const conflicts = [...new Set(entries.map((entry) => entry.happenDay))]
+    .map((happenDay) => ({
+      happenDay,
+      existing: scheduled
+        .filter((entry) => entry.happenDay === happenDay)
+        .map((entry) => ({
+          name: entry.name,
+          schedulePlanId: entry.planId,
+          scheduleIdInPlan: entry.idInPlan
+        }))
+    }))
+    .filter((conflict) => conflict.existing.length > 0);
+  return {
+    projectedPlan,
+    startDate: dashedCalendarDay(startDay),
+    entries,
+    conflicts,
+    blockers: [...new Set(blockers)]
+  };
+}
+
+function rememberPlanCalendarPreview(
+  preview: Omit<TrainingPlanCalendarPreview, "previewId" | "expiresAt">,
+  projectedPlan: TrainingPlanDocument,
+  calendarEntries: TrainingHubScheduledWorkoutEntry[],
+  rangeStart: string,
+  rangeEnd: string,
+  installId?: string
+): TrainingPlanCalendarPreview {
+  for (const [id, record] of planCalendarPreviews) {
+    if (Date.parse(record.preview.expiresAt) <= Date.now()) planCalendarPreviews.delete(id);
+  }
+  const previewId = crypto.randomUUID().replaceAll("-", "").slice(0, 16);
+  const saved: TrainingPlanCalendarPreview = {
+    ...preview,
+    previewId,
+    expiresAt: new Date(Date.now() + PLAN_CALENDAR_PREVIEW_TTL_MS).toISOString()
+  };
+  planCalendarPreviews.set(previewId, {
+    preview: saved,
+    projectedPlan,
+    calendarFingerprint: fingerprintCalendar(calendarEntries),
+    rangeStart,
+    rangeEnd,
+    installId
+  });
+  return saved;
+}
+
+export async function previewTrainingPlanCalendar(
+  planId: string,
+  startDate: string
+): Promise<TrainingPlanCalendarPreview> {
+  const plan = getTrainingPlanDocument(planId);
+  if (!plan) throw new Error("Training plan was not found.");
+  const startDay = normalizedCalendarDay(startDate);
+  const rangeEnd = addCalendarDays(startDay, Math.max(0, plan.weekCount * 7 - 1));
+  const scheduled = await trainingPlanCalendarAdapter.listScheduled(startDay, rangeEnd);
+  const projection = buildTrainingPlanCalendarProjection(plan, startDate, scheduled);
+  return rememberPlanCalendarPreview(
+    {
+      operation: "install",
+      planId: plan.id,
+      planName: plan.name,
+      planRevision: trainingPlanCalendarRevision(projection.projectedPlan),
+      startDate: projection.startDate,
+      entries: projection.entries,
+      conflicts: projection.conflicts,
+      blockers: projection.blockers
+    },
+    projection.projectedPlan,
+    scheduled,
+    startDay,
+    rangeEnd,
+    latestInstallForPlan(plan)?.id
+  );
+}
+
+export async function previewTrainingPlanCalendarRemoval(
+  planId: string
+): Promise<TrainingPlanCalendarPreview> {
+  const plan = getTrainingPlanDocument(planId);
+  if (!plan) throw new Error("Training plan was not found.");
+  const today = dateKey(new Date());
+  const install = activeTrainingPlanCalendarInstall(plan, today);
+  if (!install) throw new Error("This plan has no future calendar workouts to remove.");
+  const occurrences = install.occurrences.filter(
+    (occurrence) => !occurrence.removedAt && occurrence.happenDay >= today
+  );
+  const rangeStart = occurrences.map((entry) => entry.happenDay).sort()[0] ?? today;
+  const rangeEnd = occurrences.map((entry) => entry.happenDay).sort().at(-1) ?? today;
+  const scheduled = await trainingPlanCalendarAdapter.listScheduled(rangeStart, rangeEnd);
+  const entries: TrainingPlanCalendarPreviewEntry[] = occurrences.map((occurrence) => ({
+    planEntryId: occurrence.planEntryId,
+    name: plan.entries.find((entry) => entry.id === occurrence.planEntryId)?.title ?? "Workout",
+    happenDay: occurrence.happenDay,
+    schedulePlanId: occurrence.schedulePlanId,
+    scheduleIdInPlan: occurrence.scheduleIdInPlan,
+    planProgramId: occurrence.planProgramId,
+    pbVersion: occurrence.pbVersion
+  }));
+  return rememberPlanCalendarPreview(
+    {
+      operation: "remove",
+      planId: plan.id,
+      planName: plan.name,
+      planRevision: trainingPlanCalendarRevision(plan),
+      startDate: install.startDate,
+      entries,
+      conflicts: [],
+      blockers: []
+    },
+    plan,
+    scheduled,
+    rangeStart,
+    rangeEnd,
+    install.id
+  );
+}
+
+async function requireCurrentCalendarPreview(
+  previewId: string,
+  operation: "install" | "remove",
+  confirmed: boolean
+): Promise<{ record: StoredPlanCalendarPreview; plan: TrainingPlanDocument }> {
+  if (!confirmed) throw new Error("Calendar changes require confirmation.");
+  const record = planCalendarPreviews.get(previewId);
+  if (!record || record.preview.operation !== operation || Date.parse(record.preview.expiresAt) <= Date.now()) {
+    planCalendarPreviews.delete(previewId);
+    throw new Error("This calendar preview expired. Refresh it before confirming.");
+  }
+  if (record.preview.blockers.length > 0) {
+    throw new Error(record.preview.blockers.join(" "));
+  }
+  const plan = getTrainingPlanDocument(record.preview.planId);
+  if (!plan) throw new Error("Training plan was not found.");
+  const revision = operation === "install"
+    ? trainingPlanCalendarRevision(shiftTrainingPlan(plan, record.preview.startDate))
+    : trainingPlanCalendarRevision(plan);
+  if (revision !== record.preview.planRevision) {
+    throw new Error("The plan changed after this preview. Refresh before confirming.");
+  }
+  const scheduled = await trainingPlanCalendarAdapter.listScheduled(record.rangeStart, record.rangeEnd);
+  if (fingerprintCalendar(scheduled) !== record.calendarFingerprint) {
+    throw new Error("The COROS calendar changed after this preview. Refresh before confirming.");
+  }
+  return { record, plan };
+}
+
+function waitForCalendar(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function captureScheduledIdentity(
+  previewEntry: TrainingPlanCalendarPreviewEntry,
+  before: Set<string>
+): Promise<TrainingHubScheduledWorkoutEntry | undefined> {
+  for (const delayMs of [0, 250, 600, 1_200]) {
+    if (delayMs) await waitForCalendar(delayMs);
+    const current = await trainingPlanCalendarAdapter.listScheduled(previewEntry.happenDay, previewEntry.happenDay);
+    const added = current.filter((entry) => !before.has(scheduleIdentity(entry)));
+    const exact = added.filter((entry) => entry.name === previewEntry.name);
+    if (exact.length === 1) return exact[0];
+    if (added.length === 1) return added[0];
+  }
+  return undefined;
+}
+
+export async function addTrainingPlanToCalendar(
+  previewId: string,
+  confirmed: boolean
+): Promise<TrainingPlanCalendarMutationResult> {
+  const { record, plan } = await requireCurrentCalendarPreview(previewId, "install", confirmed);
+  const projectedPlan = shiftTrainingPlan(plan, record.preview.startDate);
+  const now = new Date().toISOString();
+  let install = projectedPlan.calendarInstalls?.find((item) => item.id === record.installId && item.state === "partial");
+  if (!install) {
+    install = {
+      id: crypto.randomUUID(),
+      startDate: record.preview.startDate,
+      planRevision: record.preview.planRevision,
+      state: "partial",
+      lastOperation: "install",
+      occurrences: [],
+      failures: [],
+      createdAt: now,
+      updatedAt: now
+    };
+  }
+  install.lastOperation = "install";
+  const installs = (projectedPlan.calendarInstalls ?? []).filter((item) => item.id !== install!.id);
+  let nextPlan: TrainingPlanDocument = { ...projectedPlan, calendarInstalls: [...installs, install] };
+  saveTrainingPlanDocument(nextPlan);
+  let scheduledCount = 0;
+  for (const previewEntry of record.preview.entries) {
+    const planEntry = nextPlan.entries.find((entry) => entry.id === previewEntry.planEntryId);
+    if (!planEntry || planEntry.kind !== "workout") continue;
+    if (install.occurrences.some((occurrence) => !occurrence.removedAt && occurrence.planEntryId === planEntry.id && occurrence.happenDay === previewEntry.happenDay)) {
+      continue;
+    }
+    install.failures = install.failures.filter((failure) => !(failure.planEntryId === planEntry.id && failure.happenDay === previewEntry.happenDay));
+    let writeMayHaveSucceeded = false;
+    try {
+      const beforeEntries = await trainingPlanCalendarAdapter.listScheduled(previewEntry.happenDay, previewEntry.happenDay);
+      const before = new Set(beforeEntries.map(scheduleIdentity));
+      writeMayHaveSucceeded = true;
+      if (planEntry.programId) {
+        await trainingPlanCalendarAdapter.scheduleLibrary(planEntry.programId, previewEntry.happenDay);
+      } else if (planEntry.workout) {
+        await trainingPlanCalendarAdapter.createAndSchedule(
+          { ...planEntry.workout, schedule_date: previewEntry.happenDay, save_to_library: false },
+          previewEntry.happenDay,
+          "metric",
+          false
+        );
+      } else {
+        throw new Error("The plan workout definition is missing.");
+      }
+      const captured = await captureScheduledIdentity(previewEntry, before);
+      if (!captured) throw new Error("COROS accepted the workout, but its schedule identity could not be verified yet.");
+      install.occurrences.push({
+        planEntryId: planEntry.id,
+        happenDay: captured.happenDay,
+        schedulePlanId: captured.planId,
+        scheduleIdInPlan: captured.idInPlan,
+        planProgramId: captured.planProgramId,
+        createdAt: new Date().toISOString()
+      });
+      scheduledCount += 1;
+    } catch (cause) {
+      install.failures.push({
+        planEntryId: planEntry.id,
+        happenDay: previewEntry.happenDay,
+        message: cause instanceof Error ? cause.message : String(cause),
+        writeMayHaveSucceeded
+      });
+    }
+    install.updatedAt = new Date().toISOString();
+    install.state = "partial";
+    nextPlan = { ...nextPlan, calendarInstalls: [...installs, structuredClone(install)] };
+    saveTrainingPlanDocument(nextPlan);
+  }
+  install.state = install.failures.length > 0 ? "partial" : "active";
+  install.updatedAt = new Date().toISOString();
+  nextPlan = { ...nextPlan, calendarInstalls: [...installs, structuredClone(install)] };
+  saveTrainingPlanDocument(nextPlan);
+  planCalendarPreviews.delete(previewId);
+  return {
+    plan: nextPlan,
+    scheduledCount,
+    removedCount: 0,
+    failures: structuredClone(install.failures)
+  };
+}
+
+export async function removeTrainingPlanFromCalendar(
+  previewId: string,
+  confirmed: boolean
+): Promise<TrainingPlanCalendarMutationResult> {
+  const { record, plan } = await requireCurrentCalendarPreview(previewId, "remove", confirmed);
+  const install = plan.calendarInstalls?.find((item) => item.id === record.installId);
+  if (!install) throw new Error("The calendar installation was not found.");
+  install.lastOperation = "remove";
+  install.state = "partial";
+  install.updatedAt = new Date().toISOString();
+  saveTrainingPlanDocument(plan);
+  let removedCount = 0;
+  const failures: TrainingPlanCalendarFailure[] = [];
+  for (const previewEntry of record.preview.entries) {
+    const occurrence = install.occurrences.find((item) =>
+      item.planEntryId === previewEntry.planEntryId &&
+      item.schedulePlanId === previewEntry.schedulePlanId &&
+      item.scheduleIdInPlan === previewEntry.scheduleIdInPlan &&
+      !item.removedAt
+    );
+    if (!occurrence) continue;
+    try {
+      const current = await trainingPlanCalendarAdapter.listScheduled(occurrence.happenDay, occurrence.happenDay);
+      const present = current.some((entry) =>
+        entry.planId === occurrence.schedulePlanId && entry.idInPlan === occurrence.scheduleIdInPlan
+      );
+      if (present) {
+        await trainingPlanCalendarAdapter.removeScheduled({
+          planId: occurrence.schedulePlanId,
+          idInPlan: occurrence.scheduleIdInPlan,
+          planProgramId: occurrence.planProgramId,
+          pbVersion: occurrence.pbVersion
+        });
+        removedCount += 1;
+      }
+      occurrence.removedAt = new Date().toISOString();
+    } catch (cause) {
+      failures.push({
+        planEntryId: occurrence.planEntryId,
+        happenDay: occurrence.happenDay,
+        message: cause instanceof Error ? cause.message : String(cause)
+      });
+    }
+    install.updatedAt = new Date().toISOString();
+    saveTrainingPlanDocument(plan);
+  }
+  const today = dateKey(new Date());
+  const futureOwned = install.occurrences.some((occurrence) => !occurrence.removedAt && occurrence.happenDay >= today);
+  const unresolved = install.failures.some((failure) => failure.writeMayHaveSucceeded && failure.happenDay >= today);
+  install.state = futureOwned || unresolved || failures.length > 0 ? "partial" : "removed";
+  install.updatedAt = new Date().toISOString();
+  saveTrainingPlanDocument(plan);
+  planCalendarPreviews.delete(previewId);
+  return {
+    plan,
+    scheduledCount: 0,
+    removedCount,
+    failures: [
+      ...failures,
+      ...install.failures.filter((failure) => failure.writeMayHaveSucceeded && failure.happenDay >= today)
+    ]
+  };
 }
 
 export function updateWorkoutMetadata(

--- a/electron/trainingLibraryService.ts
+++ b/electron/trainingLibraryService.ts
@@ -1,0 +1,539 @@
+import crypto from "node:crypto";
+import {
+  deleteTrainingCollection,
+  deleteTrainingPlanDocument,
+  getTrainingPlanDocument,
+  listCachedTrainingLibraryWorkouts,
+  listTrainingActivityMatches,
+  listTrainingCollections,
+  listTrainingPlanDocuments,
+  listTrainingWorkoutMetadata,
+  saveTrainingActivityMatch,
+  saveTrainingCollection,
+  saveTrainingPlanDocument,
+  saveTrainingWorkoutMetadata
+} from "./database";
+import {
+  listNativeCorosPlans,
+  readNativeCorosPlan
+} from "./corosTrainingPlanAdapter";
+import {
+  deleteWorkoutProgram,
+  listLibraryWorkouts,
+  listScheduledWorkoutEntries,
+  listTrainingHubActivities
+} from "./trainingHubService";
+import {
+  validateTrainingPlan,
+  workoutSportFromType
+} from "./trainingPlanDomain";
+import type {
+  NativeCorosPlanDetail,
+  NativeCorosPlanSummary,
+  TrainingActivityMatch,
+  TrainingCollection,
+  TrainingHubActivity,
+  TrainingHubLibraryWorkout,
+  TrainingHubScheduledWorkoutEntry,
+  TrainingLibraryDeleteRequest,
+  TrainingLibrarySnapshot,
+  TrainingLibraryWorkout,
+  TrainingPlanDocument,
+  TrainingPlanMetadataPatch,
+  TrainingPlanWriteCapabilities,
+  TrainingWorkoutMetadata,
+  WorkoutMetadataPatch,
+  WorkoutSport
+} from "./types";
+
+const UNVERIFIED_WRITE_REASON =
+  "Native COROS plan writes are disabled until the cleanup-safe opt-in verifier confirms this account and API version. Local templates and individual workout/calendar upload remain available.";
+
+export function getNativePlanWriteCapabilities(): TrainingPlanWriteCapabilities {
+  return {
+    create: false,
+    update: false,
+    duplicate: false,
+    delete: false,
+    activate: false,
+    removeActive: false,
+    reason: UNVERIFIED_WRITE_REASON
+  };
+}
+
+function dateKey(date: Date): string {
+  return `${date.getFullYear()}${String(date.getMonth() + 1).padStart(2, "0")}${String(date.getDate()).padStart(2, "0")}`;
+}
+
+function relativeDateKey(offsetDays: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() + offsetDays);
+  return dateKey(date);
+}
+
+function parsePlanDay(value?: string): Date | undefined {
+  if (!value) return undefined;
+  const digits = value.replace(/-/g, "");
+  if (!/^\d{8}$/.test(digits)) return undefined;
+  const date = new Date(
+    Number(digits.slice(0, 4)),
+    Number(digits.slice(4, 6)) - 1,
+    Number(digits.slice(6, 8)),
+    12
+  );
+  return Number.isNaN(date.valueOf()) ? undefined : date;
+}
+
+function mondayForPlan(value?: string): Date | undefined {
+  const date = parsePlanDay(value);
+  if (!date) return undefined;
+  const mondayOffset = (date.getDay() + 6) % 7;
+  date.setDate(date.getDate() - mondayOffset);
+  return date;
+}
+
+function dashedPlanDay(date?: Date): string | undefined {
+  if (!date) return undefined;
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+function sportMixFromNative(plan: NativeCorosPlanDetail): WorkoutSport[] {
+  return plan.sportTypes
+    .map(workoutSportFromType)
+    .filter((sport): sport is WorkoutSport => Boolean(sport));
+}
+
+function nativePlanToDocument(plan: NativeCorosPlanDetail): TrainingPlanDocument {
+  const existing = getTrainingPlanDocument(`coros:${plan.remoteId}`);
+  const now = new Date().toISOString();
+  const programByPlanId = new Map<string, NativeCorosPlanDetail["programs"][number]>();
+  for (const program of plan.programs) {
+    for (const id of [program.idInPlan, program.planProgramId, program.id]) {
+      if (id) programByPlanId.set(id, program);
+    }
+  }
+  const firstOccurrence = plan.entities
+    .map((entity) => entity.happenDay)
+    .filter((value): value is string => Boolean(value))
+    .sort()[0];
+  const gridStart = mondayForPlan(firstOccurrence ?? plan.startDay);
+  const entries = plan.entities
+    .filter((entity) => entity.status !== 3)
+    .map((entity, index) => {
+      const program =
+        programByPlanId.get(entity.idInPlan) ??
+        (entity.planProgramId
+          ? programByPlanId.get(entity.planProgramId)
+          : undefined);
+      const occurrenceDate = parsePlanDay(entity.happenDay);
+      const dayNo = gridStart && occurrenceDate
+        ? Math.max(
+            0,
+            Math.round((occurrenceDate.valueOf() - gridStart.valueOf()) / 86_400_000)
+          )
+        : entity.dayNo ?? index;
+      const sport = workoutSportFromType(program?.sportType);
+      return {
+        id: `coros:${plan.remoteId}:${entity.idInPlan}`,
+        kind: "workout" as const,
+        weekIndex: Math.max(0, Math.floor(dayNo / 7)),
+        dayIndex: Math.max(0, dayNo % 7),
+        sortOrder: entity.sortNoInSchedule ?? entity.sortNo ?? index,
+        title: program?.name ?? "Workout",
+        workout: {
+          key: `coros:${entity.idInPlan}`,
+          name: program?.name ?? "Workout",
+          description: program?.overview,
+          sport,
+          schedule_date: entity.happenDay,
+          save_to_library: false
+        },
+        programId: program?.id,
+        remotePlanProgramId: entity.planProgramId ?? program?.planProgramId,
+        plannedDurationSeconds: program?.planDuration,
+        plannedDistanceMeters: program?.planDistance,
+        plannedTrainingLoad: program?.planTrainingLoad,
+        plannedStrengthSets: program?.planSets
+      };
+    });
+  return {
+    id: `coros:${plan.remoteId}`,
+    remoteId: plan.remoteId,
+    name: plan.name,
+    description: plan.overview,
+    goal: existing?.goal ?? "",
+    difficulty: existing?.difficulty ?? "custom",
+    notes: existing?.notes ?? "",
+    source: "coros",
+    sportMix: sportMixFromNative(plan),
+    weekCount: Math.max(1, Math.ceil(plan.totalDay / 7)),
+    startDate: dashedPlanDay(gridStart) ?? existing?.startDate,
+    phases: plan.weekStages.map((stage, index) => ({
+      id: `coros:${plan.remoteId}:phase:${index}`,
+      name: typeof stage.stage === "string" ? stage.stage : `Phase ${index + 1}`,
+      kind: "custom",
+      startWeek: stage.weekNo,
+      endWeek: stage.weekNo
+    })),
+    entries,
+    tags: existing?.tags ?? [],
+    collectionId: existing?.collectionId,
+    favorite: existing?.favorite ?? false,
+    archived: existing?.archived ?? false,
+    syncState: "synced",
+    remoteVersion: plan.version,
+    remoteUpdatedAt: plan.updateTimestamp,
+    lastSyncedAt: plan.lastSyncedAt,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now
+  };
+}
+
+function metadataByProgram(): Map<string, TrainingWorkoutMetadata> {
+  return new Map(
+    listTrainingWorkoutMetadata().map((metadata) => [metadata.programId, metadata])
+  );
+}
+
+function mergeWorkout(
+  workout: TrainingHubLibraryWorkout,
+  metadata: TrainingWorkoutMetadata | undefined,
+  plans: TrainingPlanDocument[],
+  schedule: TrainingHubScheduledWorkoutEntry[]
+): TrainingLibraryWorkout {
+  const usedByPlanIds = plans
+    .filter((plan) =>
+      plan.entries.some((entry) => entry.programId === workout.id)
+    )
+    .map((plan) => plan.id);
+  return {
+    ...workout,
+    favorite: metadata?.favorite ?? false,
+    tags: metadata?.tags ?? [],
+    collectionId: metadata?.collectionId,
+    source: metadata?.source ?? "coros",
+    syncState: metadata?.syncState ?? "synced",
+    lastUsedAt: metadata?.lastUsedAt,
+    lastSyncedAt: metadata?.lastSyncedAt,
+    usedByPlanIds,
+    scheduledCount: schedule.filter((entry) => entry.programId === workout.id).length
+  };
+}
+
+export async function getTrainingLibrarySnapshot(): Promise<TrainingLibrarySnapshot> {
+  const cachedAt = new Date().toISOString();
+  const partialFailures: string[] = [];
+  const localPlans = listTrainingPlanDocuments();
+  const [workoutsResult, nativeResult, scheduleResult] = await Promise.allSettled([
+    listLibraryWorkouts(),
+    listNativeCorosPlans(),
+    listScheduledWorkoutEntries(relativeDateKey(-180), relativeDateKey(365))
+  ]);
+
+  let baseWorkouts: TrainingHubLibraryWorkout[];
+  if (workoutsResult.status === "fulfilled") {
+    baseWorkouts = workoutsResult.value;
+    const previous = metadataByProgram();
+    for (const workout of baseWorkouts) {
+      const metadata = previous.get(workout.id);
+      saveTrainingWorkoutMetadata(
+        {
+          programId: workout.id,
+          favorite: metadata?.favorite ?? false,
+          tags: metadata?.tags ?? [],
+          collectionId: metadata?.collectionId,
+          source: metadata?.source ?? "coros",
+          syncState: "synced",
+          lastUsedAt: metadata?.lastUsedAt,
+          lastSyncedAt: cachedAt,
+          cachedVersion: metadata?.cachedVersion
+        },
+        workout as unknown as Record<string, unknown>
+      );
+    }
+  } else {
+    partialFailures.push(`Workouts: ${String(workoutsResult.reason?.message ?? workoutsResult.reason)}`);
+    baseWorkouts = listCachedTrainingLibraryWorkouts();
+  }
+
+  let nativePlans: NativeCorosPlanSummary[] = localPlans
+    .filter((plan) => plan.source === "coros" && plan.remoteId)
+    .map((plan) => ({
+      remoteId: plan.remoteId!,
+      name: plan.name,
+      overview: plan.description,
+      totalDay: plan.weekCount * 7,
+      workoutCount: plan.entries.filter((entry) => entry.kind === "workout").length,
+      sportTypes: [],
+      version: plan.remoteVersion,
+      updateTimestamp: plan.remoteUpdatedAt,
+      syncState: "stale" as const,
+      lastSyncedAt: plan.lastSyncedAt
+    }));
+  if (nativeResult.status === "fulfilled") {
+    nativePlans = nativeResult.value;
+    for (const native of nativeResult.value) {
+      saveTrainingPlanDocument(nativePlanToDocument(native), native.rawPayload);
+    }
+  } else {
+    partialFailures.push(`Training plans: ${String(nativeResult.reason?.message ?? nativeResult.reason)}`);
+  }
+
+  const schedule = scheduleResult.status === "fulfilled" ? scheduleResult.value : [];
+  if (scheduleResult.status === "rejected") {
+    partialFailures.push(`Schedule: ${String(scheduleResult.reason?.message ?? scheduleResult.reason)}`);
+  }
+  const plans = listTrainingPlanDocuments();
+  const metadata = metadataByProgram();
+  return {
+    workouts: baseWorkouts.map((workout) =>
+      mergeWorkout(workout, metadata.get(workout.id), plans, schedule)
+    ),
+    plans,
+    nativePlans,
+    collections: listTrainingCollections(),
+    matches: listTrainingActivityMatches(),
+    cachedAt,
+    stale: partialFailures.length > 0,
+    offline: partialFailures.length === 3,
+    partialFailures,
+    nativePlanWrites: getNativePlanWriteCapabilities()
+  };
+}
+
+export async function getNativeTrainingPlan(
+  remoteId: string
+): Promise<TrainingPlanDocument> {
+  const native = await readNativeCorosPlan(remoteId);
+  const document = nativePlanToDocument(native);
+  saveTrainingPlanDocument(document, native.rawPayload);
+  return document;
+}
+
+export function saveLocalTrainingPlan(
+  input: TrainingPlanDocument
+): TrainingPlanDocument {
+  const errors = validateTrainingPlan(input).filter((issue) => issue.severity === "error");
+  if (errors.length > 0) {
+    throw new Error(errors.map((issue) => issue.message).join(" "));
+  }
+  const now = new Date().toISOString();
+  const forkNative = input.source === "coros";
+  const targetId = forkNative ? `plan:${crypto.randomUUID()}` : input.id;
+  const existing = forkNative ? undefined : getTrainingPlanDocument(targetId);
+  const document: TrainingPlanDocument = {
+    ...structuredClone(input),
+    id: targetId,
+    name: forkNative ? `${input.name} Local Copy` : input.name,
+    source: forkNative ? "local" : input.source,
+    remoteId: forkNative ? undefined : input.remoteId,
+    remoteVersion: forkNative ? undefined : input.remoteVersion,
+    remoteUpdatedAt: forkNative ? undefined : input.remoteUpdatedAt,
+    syncState: "local",
+    createdAt: existing?.createdAt ?? input.createdAt ?? now,
+    updatedAt: now
+  };
+  saveTrainingPlanDocument(document);
+  return document;
+}
+
+export function updateTrainingPlanMetadata(
+  id: string,
+  patch: TrainingPlanMetadataPatch
+): TrainingPlanDocument {
+  const plan = getTrainingPlanDocument(id);
+  if (!plan) throw new Error("Training plan was not found.");
+  const updated: TrainingPlanDocument = {
+    ...plan,
+    favorite: patch.favorite ?? plan.favorite,
+    tags: patch.tags ?? plan.tags,
+    collectionId:
+      patch.collectionId === null
+        ? undefined
+        : patch.collectionId ?? plan.collectionId,
+    archived: patch.archived ?? plan.archived,
+    updatedAt: new Date().toISOString()
+  };
+  saveTrainingPlanDocument(updated);
+  return updated;
+}
+
+export function deleteLocalTrainingPlan(id: string, confirmed: boolean): void {
+  if (!confirmed) throw new Error("Deleting a training plan requires confirmation.");
+  const plan = getTrainingPlanDocument(id);
+  if (!plan) return;
+  if (plan.source === "coros") {
+    throw new Error(UNVERIFIED_WRITE_REASON);
+  }
+  deleteTrainingPlanDocument(id);
+}
+
+export function updateWorkoutMetadata(
+  programIds: string[],
+  patch: WorkoutMetadataPatch
+): TrainingWorkoutMetadata[] {
+  const current = metadataByProgram();
+  const updated: TrainingWorkoutMetadata[] = [];
+  for (const programId of [...new Set(programIds)]) {
+    const previous = current.get(programId);
+    const metadata: TrainingWorkoutMetadata = {
+      programId,
+      favorite: patch.favorite ?? previous?.favorite ?? false,
+      tags: patch.tags ?? previous?.tags ?? [],
+      collectionId:
+        patch.collectionId === null
+          ? undefined
+          : patch.collectionId ?? previous?.collectionId,
+      source: patch.source ?? previous?.source ?? "coros",
+      syncState: previous?.syncState ?? "synced",
+      lastUsedAt: patch.lastUsedAt ?? previous?.lastUsedAt,
+      lastSyncedAt: previous?.lastSyncedAt,
+      cachedVersion: previous?.cachedVersion
+    };
+    saveTrainingWorkoutMetadata(metadata);
+    updated.push(metadata);
+  }
+  return updated;
+}
+
+export function upsertTrainingCollection(
+  input: Pick<TrainingCollection, "id" | "name"> &
+    Partial<Pick<TrainingCollection, "description" | "color">>
+): TrainingCollection {
+  if (!input.name.trim()) throw new Error("Collection name is required.");
+  const existing = listTrainingCollections().find((item) => item.id === input.id);
+  const now = new Date().toISOString();
+  const collection: TrainingCollection = {
+    id: input.id || crypto.randomUUID(),
+    name: input.name.trim(),
+    description: input.description?.trim() || undefined,
+    color: input.color,
+    createdAt: existing?.createdAt ?? now,
+    updatedAt: now
+  };
+  saveTrainingCollection(collection);
+  return collection;
+}
+
+export function removeTrainingCollection(id: string, confirmed: boolean): void {
+  if (!confirmed) throw new Error("Deleting a collection requires confirmation.");
+  deleteTrainingCollection(id);
+}
+
+export async function deleteTrainingLibraryWorkouts(
+  request: TrainingLibraryDeleteRequest
+): Promise<string[]> {
+  const ids = [...new Set(request.programIds.map((id) => id.trim()).filter(Boolean))];
+  if (!request.confirmed) throw new Error("Deleting workouts requires confirmation.");
+  if (ids.length === 0) throw new Error("Select at least one workout to delete.");
+  for (const id of ids) await deleteWorkoutProgram(id);
+  return ids;
+}
+
+export function activityDay(activity: TrainingHubActivity): string | undefined {
+  if (!activity.startTime) return undefined;
+  const raw = activity.startTime > 10_000_000_000 ? activity.startTime : activity.startTime * 1000;
+  return dateKey(new Date(raw));
+}
+
+export function scheduledActivityScore(
+  scheduled: TrainingHubScheduledWorkoutEntry,
+  activity: TrainingHubActivity
+): number {
+  let score = 0.35;
+  if (scheduled.sportType && scheduled.sportType === activity.sportType) score += 0.35;
+  const plannedLoad = scheduled.trainingLoad;
+  if (plannedLoad && activity.trainingLoad !== undefined) {
+    score += 0.2 * Math.max(0, 1 - Math.abs(activity.trainingLoad - plannedLoad) / plannedLoad);
+  }
+  const normalizedName = scheduled.name.trim().toLowerCase();
+  if (normalizedName && activity.name?.trim().toLowerCase() === normalizedName) score += 0.1;
+  return Math.min(1, score);
+}
+
+export function buildTrainingActivityMatches(
+  scheduled: TrainingHubScheduledWorkoutEntry[],
+  activities: TrainingHubActivity[],
+  previous: TrainingActivityMatch[],
+  today = dateKey(new Date())
+): TrainingActivityMatch[] {
+  const existing = new Map(
+    previous.map((match) => [
+      `${match.schedulePlanId}:${match.scheduleIdInPlan}`,
+      match
+    ])
+  );
+  const usedActivities = new Set<string>();
+  const results: TrainingActivityMatch[] = [];
+  for (const entry of scheduled) {
+    const key = `${entry.planId}:${entry.idInPlan}`;
+    const manual = existing.get(key);
+    let activity = manual?.manual
+      ? activities.find((candidate) => candidate.activityId === manual.activityId)
+      : undefined;
+    let confidence = manual?.manual ? manual.confidence : undefined;
+    if (!manual?.manual) {
+      const candidates = activities
+        .filter((candidate) => activityDay(candidate) === entry.happenDay)
+        .filter((candidate) => !usedActivities.has(candidate.activityId))
+        .map((candidate) => ({ candidate, score: scheduledActivityScore(entry, candidate) }))
+        .sort((left, right) => right.score - left.score);
+      if (candidates[0]?.score >= 0.5) {
+        activity = candidates[0].candidate;
+        confidence = candidates[0].score;
+      }
+    }
+    if (activity) usedActivities.add(activity.activityId);
+    const ratio = entry.trainingLoad && activity?.trainingLoad !== undefined
+      ? activity.trainingLoad / entry.trainingLoad
+      : undefined;
+    const status: TrainingActivityMatch["status"] = manual?.status === "skipped"
+      ? "skipped"
+      : activity
+        ? ratio !== undefined && ratio < 0.75 ? "partial" : "completed"
+        : entry.happenDay < today ? "missed" : "upcoming";
+    results.push({
+      id: manual?.id ?? crypto.randomUUID(),
+      planId: manual?.planId,
+      planEntryId: manual?.planEntryId,
+      schedulePlanId: entry.planId,
+      scheduleIdInPlan: entry.idInPlan,
+      activityId: activity?.activityId,
+      happenDay: entry.happenDay,
+      status,
+      confidence,
+      manual: manual?.manual ?? false,
+      completedDurationSeconds: activity?.duration,
+      completedDistanceMeters: activity?.distance,
+      plannedTrainingLoad: entry.trainingLoad,
+      completedTrainingLoad: activity?.trainingLoad,
+      updatedAt: new Date().toISOString()
+    });
+  }
+  return results;
+}
+
+export async function refreshTrainingActivityMatches(
+  startDay: string,
+  endDay: string
+): Promise<TrainingActivityMatch[]> {
+  const [scheduled, activities] = await Promise.all([
+    listScheduledWorkoutEntries(startDay, endDay),
+    listTrainingHubActivities(1, 500, startDay, endDay)
+  ]);
+  const results = buildTrainingActivityMatches(
+    scheduled,
+    activities,
+    listTrainingActivityMatches()
+  );
+  for (const match of results) {
+    saveTrainingActivityMatch(match);
+  }
+  return results;
+}
+
+export function saveManualActivityMatch(match: TrainingActivityMatch): TrainingActivityMatch {
+  const next = { ...match, manual: true, updatedAt: new Date().toISOString() };
+  saveTrainingActivityMatch(next);
+  return next;
+}

--- a/electron/trainingPlanDomain.ts
+++ b/electron/trainingPlanDomain.ts
@@ -1,10 +1,12 @@
 import type {
   PlanWorkoutEntryInput,
+  PlanDraftPreview,
   RunWorkoutCreateRepeatGroup,
   RunWorkoutCreateStep,
   RunWorkoutStepInput,
   TrainingPlanDocument,
   TrainingPlanEntry,
+  TrainingPlanGenerationRequest,
   TrainingPlanPhase,
   WorkoutSport
 } from "./types";
@@ -71,6 +73,191 @@ function isoNow(): string {
 function uniqueId(prefix: string): string {
   const random = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
   return `${prefix}:${random}`;
+}
+
+function normalizedPlanDate(value: string): Date | undefined {
+  const digits = value.replace(/-/g, "");
+  if (!/^\d{8}$/.test(digits)) return undefined;
+  const date = new Date(
+    Number(digits.slice(0, 4)),
+    Number(digits.slice(4, 6)) - 1,
+    Number(digits.slice(6, 8)),
+    12
+  );
+  return Number.isNaN(date.valueOf()) ? undefined : date;
+}
+
+function dayOffset(startDate: string, value: string): number | undefined {
+  const start = normalizedPlanDate(startDate);
+  const date = normalizedPlanDate(value);
+  if (!start || !date) return undefined;
+  return Math.round((date.valueOf() - start.valueOf()) / 86_400_000);
+}
+
+export function trainingPlanFromDraftPreview(
+  preview: PlanDraftPreview,
+  request: TrainingPlanGenerationRequest
+): TrainingPlanDocument {
+  if (!request.goal.trim()) throw new Error("Add a training goal before generating a plan.");
+  if (request.weeks < 1 || request.weeks > 24) throw new Error("Generated plans must contain 1 to 24 weeks.");
+  if (request.sessionsPerWeek < 1 || request.sessionsPerWeek > 7) throw new Error("Sessions per week must be between 1 and 7.");
+  if (request.sports.length === 0) throw new Error("Choose at least one sport.");
+  if (request.availableDayIndexes.some((day) => !Number.isInteger(day) || day < 0 || day > 6)) throw new Error("Available days must be Monday through Sunday.");
+  if (request.availableDayIndexes.length < request.sessionsPerWeek) throw new Error("Choose at least as many available days as weekly sessions.");
+  if (request.maxSessionMinutes !== undefined && request.maxSessionMinutes <= 0) throw new Error("The session-duration limit must be greater than zero.");
+  const start = normalizedPlanDate(request.startDate);
+  if (!start || start.getDay() !== 1) throw new Error("Week 1 must start on a Monday.");
+  if (!preview.name.trim()) throw new Error("Training Coach returned a plan without a name.");
+
+  const document = createTrainingPlan(preview.name, "coach");
+  document.id = `plan:coach:${preview.draftId}`;
+  document.description = preview.summary.trim() || "Generated with Training Coach from your current training context.";
+  document.goal = request.goal.trim();
+  document.difficulty = request.difficulty;
+  document.notes = [request.constraints?.trim(), ...preview.warnings].filter(Boolean).join("\n");
+  document.startDate = request.startDate;
+  document.weekCount = request.weeks;
+  document.entries = preview.entries.map((entry, index) => {
+    if (!entry.source) throw new Error(`Generated workout "${entry.name}" is missing its structured definition.`);
+    const scheduleDate = entry.source.schedule_date ?? entry.scheduleDate;
+    if (!scheduleDate) throw new Error(`Generated workout "${entry.name}" is missing a schedule date.`);
+    const offset = dayOffset(request.startDate, scheduleDate);
+    if (offset === undefined || offset < 0 || offset >= request.weeks * 7) {
+      throw new Error(`Generated workout "${entry.name}" falls outside the requested plan dates.`);
+    }
+    const dayIndex = offset % 7;
+    if (!request.availableDayIndexes.includes(dayIndex)) {
+      throw new Error(`Generated workout "${entry.name}" was placed on an unavailable day.`);
+    }
+    const sport = entry.source.sport ?? "run";
+    if (!request.sports.includes(sport)) {
+      throw new Error(`Generated workout "${entry.name}" uses a sport that was not requested.`);
+    }
+    return {
+      id: `entry:${preview.draftId}:${entry.key || index}`,
+      kind: "workout" as const,
+      weekIndex: Math.floor(offset / 7),
+      dayIndex,
+      sortOrder: entry.source.sort_no ?? index,
+      title: entry.name,
+      workout: {
+        ...structuredClone(entry.source),
+        schedule_date: scheduleDate,
+        save_to_library: false
+      }
+    };
+  });
+  const weekCounts = new Map<number, number>();
+  for (const entry of document.entries) {
+    weekCounts.set(entry.weekIndex, (weekCounts.get(entry.weekIndex) ?? 0) + 1);
+  }
+  for (let weekIndex = 0; weekIndex < request.weeks; weekIndex += 1) {
+    const count = weekCounts.get(weekIndex) ?? 0;
+    if (count !== request.sessionsPerWeek) {
+      throw new Error(`Generated week ${weekIndex + 1} has ${count} workouts instead of ${request.sessionsPerWeek}.`);
+    }
+  }
+  if (request.maxSessionMinutes) {
+    const overLimit = document.entries.find((entry) => workoutMetrics(entry.workout).durationSeconds > request.maxSessionMinutes! * 60);
+    if (overLimit) {
+      throw new Error(`Generated workout "${overLimit.title ?? "Untitled workout"}" exceeds the session-duration limit.`);
+    }
+  }
+  document.sportMix = [...new Set(document.entries.map((entry) => entry.workout?.sport).filter((sport): sport is WorkoutSport => Boolean(sport)))];
+  return document;
+}
+
+/** Convert an arbitrary Coach plan card into an unsaved, editable library plan. */
+export function trainingPlanFromCoachDraftPreview(
+  preview: PlanDraftPreview
+): TrainingPlanDocument {
+  if (!preview.name.trim()) throw new Error("Training Coach returned a plan without a name.");
+  const datedEntries = preview.entries
+    .map((entry) => entry.source?.schedule_date ?? entry.scheduleDate)
+    .map((value) => value ? normalizedPlanDate(value) : undefined)
+    .filter((value): value is Date => Boolean(value))
+    .sort((left, right) => left.valueOf() - right.valueOf());
+  const firstDate = datedEntries[0];
+  const start = firstDate ? new Date(firstDate) : undefined;
+  if (start) start.setDate(start.getDate() - ((start.getDay() + 6) % 7));
+
+  const document = createTrainingPlan(preview.name, "coach");
+  document.id = `plan:coach:${preview.draftId}`;
+  document.description = preview.summary.trim() || "Created in Training Coach for review in the Training Library.";
+  document.notes = [
+    ...preview.warnings,
+    ...preview.conflicts.map((conflict) => `Calendar conflict: ${conflict}`)
+  ].join("\n");
+  document.startDate = start ? formatPlanDate(start, true) : undefined;
+  document.entries = preview.entries.map((entry, index) => {
+    const source: PlanWorkoutEntryInput = entry.source
+      ? structuredClone(entry.source)
+      : {
+          key: entry.key || `coach-${index + 1}`,
+          name: entry.name,
+          sport: entry.sport ?? "run",
+          save_to_library: false
+        };
+    const rawDate = source.schedule_date ?? entry.scheduleDate;
+    const date = rawDate ? normalizedPlanDate(rawDate) : undefined;
+    const offset = start && date
+      ? Math.max(0, Math.round((date.valueOf() - start.valueOf()) / 86_400_000))
+      : undefined;
+    return {
+      id: `entry:${preview.draftId}:${entry.key || index}`,
+      kind: "workout" as const,
+      weekIndex: offset === undefined ? 0 : Math.floor(offset / 7),
+      dayIndex: offset === undefined ? undefined : offset % 7,
+      sortOrder: source.sort_no ?? index,
+      title: entry.name,
+      workout: {
+        ...source,
+        name: entry.name,
+        ...(rawDate ? { schedule_date: rawDate } : {}),
+        save_to_library: false
+      }
+    };
+  });
+  document.weekCount = Math.max(1, ...document.entries.map((entry) => entry.weekIndex + 1));
+  document.sportMix = [...new Set(document.entries.map((entry) => entry.workout?.sport ?? "run"))];
+  return document;
+}
+
+/** Stable hash of only the plan content that changes calendar writes. */
+export function trainingPlanCalendarRevision(plan: TrainingPlanDocument): string {
+  const serialized = JSON.stringify({
+    name: plan.name,
+    startDate: plan.startDate,
+    weekCount: plan.weekCount,
+    entries: plan.entries.map((entry) => ({
+      id: entry.id,
+      kind: entry.kind,
+      weekIndex: entry.weekIndex,
+      dayIndex: entry.dayIndex,
+      sortOrder: entry.sortOrder,
+      title: entry.title,
+      programId: entry.programId,
+      workout: entry.workout
+    }))
+  });
+  let hash = 2166136261;
+  for (let index = 0; index < serialized.length; index += 1) {
+    hash ^= serialized.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+export function activeTrainingPlanCalendarInstall(
+  plan: TrainingPlanDocument,
+  today = formatPlanDate(new Date(), false)
+) {
+  return plan.calendarInstalls?.find((install) =>
+    install.state !== "removed" && (
+      install.occurrences.some((occurrence) => !occurrence.removedAt && occurrence.happenDay >= today) ||
+      install.failures.some((failure) => failure.happenDay >= today && failure.writeMayHaveSucceeded)
+    )
+  );
 }
 
 export function createTrainingPlan(

--- a/electron/trainingPlanDomain.ts
+++ b/electron/trainingPlanDomain.ts
@@ -1,0 +1,475 @@
+import type {
+  PlanWorkoutEntryInput,
+  RunWorkoutCreateRepeatGroup,
+  RunWorkoutCreateStep,
+  RunWorkoutStepInput,
+  TrainingPlanDocument,
+  TrainingPlanEntry,
+  TrainingPlanPhase,
+  WorkoutSport
+} from "./types";
+
+export interface TrainingPlanValidationIssue {
+  path: string;
+  message: string;
+  severity: "error" | "warning";
+}
+
+export interface TrainingPlanWeekSummary {
+  weekIndex: number;
+  workouts: number;
+  durationSeconds: number;
+  distanceMeters: number;
+  trainingLoad: number;
+}
+
+export interface TrainingPlanSummary {
+  planId: string;
+  name: string;
+  weekCount: number;
+  workouts: number;
+  durationSeconds: number;
+  distanceMeters: number;
+  trainingLoad: number;
+  strengthSets: number;
+  restDays: number;
+  sportDistribution: Partial<Record<WorkoutSport, number>>;
+  intensityDistribution: Record<string, number>;
+  weekly: TrainingPlanWeekSummary[];
+  longestWorkout?: { name: string; durationSeconds: number; distanceMeters: number };
+  peakWeek?: number;
+  taperDetected: boolean;
+  conflictCount: number;
+}
+
+export interface TrainingPlanComparison {
+  summaries: TrainingPlanSummary[];
+  sharedWorkoutNames: string[];
+  insights: string[];
+}
+
+const SPORT_BY_TYPE: Record<number, WorkoutSport> = {
+  1: "run",
+  2: "bike",
+  3: "swim",
+  4: "strength",
+  5: "trailRun",
+  6: "indoorClimb",
+  7: "bouldering",
+  8: "xcSki",
+  9: "hyrox"
+};
+
+export function workoutSportFromType(value?: number): WorkoutSport | undefined {
+  return value === undefined ? undefined : SPORT_BY_TYPE[value];
+}
+
+function isoNow(): string {
+  return new Date().toISOString();
+}
+
+function uniqueId(prefix: string): string {
+  const random = globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`;
+  return `${prefix}:${random}`;
+}
+
+export function createTrainingPlan(
+  name = "Untitled plan",
+  source: TrainingPlanDocument["source"] = "local"
+): TrainingPlanDocument {
+  const now = isoNow();
+  return {
+    id: uniqueId(source === "template" ? "template" : "plan"),
+    name,
+    description: "",
+    goal: "",
+    difficulty: "custom",
+    notes: "",
+    source,
+    sportMix: [],
+    weekCount: 4,
+    phases: [],
+    entries: [],
+    tags: [],
+    favorite: false,
+    archived: false,
+    syncState: "local",
+    createdAt: now,
+    updatedAt: now
+  };
+}
+
+function dateFromPlanValue(value: string): Date | undefined {
+  const normalized = value.replace(/-/g, "");
+  if (!/^\d{8}$/.test(normalized)) return undefined;
+  const date = new Date(
+    Number(normalized.slice(0, 4)),
+    Number(normalized.slice(4, 6)) - 1,
+    Number(normalized.slice(6, 8))
+  );
+  return Number.isNaN(date.valueOf()) ? undefined : date;
+}
+
+function formatPlanDate(date: Date, dashed: boolean): string {
+  const value = `${date.getFullYear()}${String(date.getMonth() + 1).padStart(2, "0")}${String(date.getDate()).padStart(2, "0")}`;
+  return dashed ? `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6)}` : value;
+}
+
+export function shiftTrainingPlan(
+  plan: TrainingPlanDocument,
+  nextStartDate: string
+): TrainingPlanDocument {
+  const nextStart = dateFromPlanValue(nextStartDate);
+  if (!nextStart) throw new Error("Plan start date must be YYYY-MM-DD or YYYYMMDD.");
+  const previousStart = plan.startDate ? dateFromPlanValue(plan.startDate) : undefined;
+  const shiftDays = previousStart
+    ? Math.round((nextStart.valueOf() - previousStart.valueOf()) / 86_400_000)
+    : 0;
+  const entries = plan.entries.map((entry) => {
+    const workout = entry.workout;
+    const scheduleDate = workout?.schedule_date;
+    if (!workout || (entry.dayIndex === undefined && !scheduleDate)) return entry;
+    const date = entry.dayIndex !== undefined
+      ? new Date(nextStart)
+      : scheduleDate
+        ? dateFromPlanValue(scheduleDate)
+        : undefined;
+    if (!date) return entry;
+    if (entry.dayIndex !== undefined) {
+      date.setDate(date.getDate() + entry.weekIndex * 7 + entry.dayIndex);
+    } else {
+      date.setDate(date.getDate() + shiftDays);
+    }
+    return {
+      ...entry,
+      workout: {
+        ...workout,
+        schedule_date: formatPlanDate(date, scheduleDate?.includes("-") ?? true)
+      }
+    };
+  });
+  return {
+    ...plan,
+    startDate: formatPlanDate(nextStart, true),
+    entries,
+    syncState: plan.source === "coros" ? "pending" : "local",
+    updatedAt: isoNow()
+  };
+}
+
+export function duplicateTrainingPlanWeek(
+  plan: TrainingPlanDocument,
+  weekIndex: number
+): TrainingPlanDocument {
+  if (weekIndex < 0 || weekIndex >= plan.weekCount) {
+    throw new Error("Week index is outside the plan.");
+  }
+  const shifted = plan.entries.map((entry) =>
+    entry.weekIndex > weekIndex ? { ...entry, weekIndex: entry.weekIndex + 1 } : entry
+  );
+  const copies = plan.entries
+    .filter((entry) => entry.weekIndex === weekIndex)
+    .map((entry) => ({
+      ...structuredClone(entry),
+      id: uniqueId("entry"),
+      weekIndex: weekIndex + 1,
+      remotePlanProgramId: undefined
+    }));
+  return {
+    ...plan,
+    weekCount: plan.weekCount + 1,
+    entries: [...shifted, ...copies],
+    phases: expandPhasesAfterWeek(plan.phases, weekIndex),
+    syncState: plan.source === "coros" ? "pending" : "local",
+    updatedAt: isoNow()
+  };
+}
+
+function expandPhasesAfterWeek(
+  phases: TrainingPlanPhase[],
+  weekIndex: number
+): TrainingPlanPhase[] {
+  const humanWeek = weekIndex + 1;
+  return phases.map((phase) => ({
+    ...phase,
+    startWeek: phase.startWeek > humanWeek ? phase.startWeek + 1 : phase.startWeek,
+    endWeek: phase.endWeek >= humanWeek ? phase.endWeek + 1 : phase.endWeek
+  }));
+}
+
+export function insertRecoveryWeek(
+  plan: TrainingPlanDocument,
+  afterWeekIndex: number
+): TrainingPlanDocument {
+  const next = duplicateTrainingPlanWeek(
+    { ...plan, entries: plan.entries.filter((entry) => entry.weekIndex !== afterWeekIndex) },
+    afterWeekIndex
+  );
+  return {
+    ...next,
+    phases: [
+      ...next.phases,
+      {
+        id: uniqueId("phase"),
+        name: "Recovery",
+        kind: "recovery",
+        startWeek: afterWeekIndex + 2,
+        endWeek: afterWeekIndex + 2
+      }
+    ]
+  };
+}
+
+export function reorderTrainingPlanWeek(
+  plan: TrainingPlanDocument,
+  fromWeekIndex: number,
+  toWeekIndex: number
+): TrainingPlanDocument {
+  if (
+    fromWeekIndex < 0 ||
+    toWeekIndex < 0 ||
+    fromWeekIndex >= plan.weekCount ||
+    toWeekIndex >= plan.weekCount
+  ) {
+    throw new Error("Week index is outside the plan.");
+  }
+  const remap = (week: number) => {
+    if (week === fromWeekIndex) return toWeekIndex;
+    if (fromWeekIndex < toWeekIndex && week > fromWeekIndex && week <= toWeekIndex) {
+      return week - 1;
+    }
+    if (fromWeekIndex > toWeekIndex && week >= toWeekIndex && week < fromWeekIndex) {
+      return week + 1;
+    }
+    return week;
+  };
+  return {
+    ...plan,
+    entries: plan.entries.map((entry) => ({ ...entry, weekIndex: remap(entry.weekIndex) })),
+    phases: plan.phases.map((phase) => {
+      const remapped = Array.from(
+        { length: phase.endWeek - phase.startWeek + 1 },
+        (_, index) => remap(phase.startWeek - 1 + index) + 1
+      );
+      return {
+        ...phase,
+        startWeek: Math.min(...remapped),
+        endWeek: Math.max(...remapped)
+      };
+    }),
+    syncState: plan.source === "coros" ? "pending" : "local",
+    updatedAt: isoNow()
+  };
+}
+
+function isRepeatGroup(step: RunWorkoutStepInput): step is RunWorkoutCreateRepeatGroup {
+  return typeof step === "object" && step !== null && "repeat" in step && "steps" in step;
+}
+
+function workoutMetrics(workout?: PlanWorkoutEntryInput): {
+  durationSeconds: number;
+  distanceMeters: number;
+  trainingLoad: number;
+  strengthSets: number;
+  intensityDistribution: Record<string, number>;
+} {
+  let durationSeconds = 0;
+  let distanceMeters = (workout?.distance_km ?? 0) * 1000;
+  let trainingLoad = 0;
+  let strengthSets = 0;
+  const intensityDistribution: Record<string, number> = {};
+  const count = (step: RunWorkoutCreateStep, multiplier: number) => {
+    durationSeconds += (step.target_duration_seconds ?? 0) * multiplier;
+    if (!workout?.distance_km) {
+      distanceMeters += (step.target_distance_meters ?? 0) * multiplier;
+    }
+    trainingLoad += (step.target_load ?? 0) * multiplier;
+    strengthSets += (step.sets ?? (step.target_reps ? 1 : 0)) * multiplier;
+    const intensity = step.intensity?.type ?? "notSet";
+    intensityDistribution[intensity] = (intensityDistribution[intensity] ?? 0) + multiplier;
+  };
+  for (const node of workout?.steps ?? []) {
+    if (isRepeatGroup(node)) {
+      for (const step of node.steps) count(step, Math.max(1, node.repeat));
+    } else {
+      count(node, 1);
+    }
+  }
+  return { durationSeconds, distanceMeters, trainingLoad, strengthSets, intensityDistribution };
+}
+
+export function validateTrainingPlan(
+  plan: TrainingPlanDocument
+): TrainingPlanValidationIssue[] {
+  const issues: TrainingPlanValidationIssue[] = [];
+  if (!plan.name.trim()) {
+    issues.push({ path: "name", message: "Add a plan name.", severity: "error" });
+  }
+  if (plan.weekCount < 1 || plan.weekCount > 52) {
+    issues.push({ path: "weekCount", message: "Plans must contain 1 to 52 weeks.", severity: "error" });
+  }
+  const occupied = new Map<string, number>();
+  for (const entry of plan.entries) {
+    if (entry.weekIndex < 0 || entry.weekIndex >= plan.weekCount) {
+      issues.push({ path: `entries.${entry.id}`, message: "A workout is outside the plan range.", severity: "error" });
+    }
+    if (entry.dayIndex !== undefined && (entry.dayIndex < 0 || entry.dayIndex > 6)) {
+      issues.push({ path: `entries.${entry.id}.dayIndex`, message: "Day must be Monday through Sunday.", severity: "error" });
+    }
+    if (entry.kind === "workout" && !entry.workout && !entry.programId) {
+      issues.push({ path: `entries.${entry.id}`, message: "Workout entry has no reusable workout definition.", severity: "error" });
+    }
+    if (entry.dayIndex !== undefined) {
+      const key = `${entry.weekIndex}:${entry.dayIndex}`;
+      occupied.set(key, (occupied.get(key) ?? 0) + 1);
+    }
+  }
+  for (const [key, count] of occupied) {
+    if (count > 2) {
+      issues.push({ path: key, message: `${count} items share one day. Review recovery and scheduling conflicts.`, severity: "warning" });
+    }
+  }
+  for (const phase of plan.phases) {
+    if (phase.startWeek < 1 || phase.endWeek > plan.weekCount || phase.startWeek > phase.endWeek) {
+      issues.push({ path: `phases.${phase.id}`, message: `Phase "${phase.name}" is outside the plan range.`, severity: "error" });
+    }
+  }
+  return issues;
+}
+
+export function summarizeTrainingPlan(plan: TrainingPlanDocument): TrainingPlanSummary {
+  const weekly: TrainingPlanWeekSummary[] = Array.from({ length: plan.weekCount }, (_, weekIndex) => ({
+    weekIndex,
+    workouts: 0,
+    durationSeconds: 0,
+    distanceMeters: 0,
+    trainingLoad: 0
+  }));
+  const sportDistribution: Partial<Record<WorkoutSport, number>> = {};
+  const intensityDistribution: Record<string, number> = {};
+  const occupiedDays = new Set<string>();
+  let workouts = 0;
+  let durationSeconds = 0;
+  let distanceMeters = 0;
+  let trainingLoad = 0;
+  let strengthSets = 0;
+  let longestWorkout: TrainingPlanSummary["longestWorkout"];
+  let conflictCount = 0;
+  const occupiedCounts = new Map<string, number>();
+
+  for (const entry of plan.entries) {
+    if (entry.kind !== "workout") continue;
+    workouts += 1;
+    const calculated = workoutMetrics(entry.workout);
+    const metrics = {
+      ...calculated,
+      durationSeconds: calculated.durationSeconds || entry.plannedDurationSeconds || 0,
+      distanceMeters: calculated.distanceMeters || entry.plannedDistanceMeters || 0,
+      trainingLoad: calculated.trainingLoad || entry.plannedTrainingLoad || 0,
+      strengthSets: calculated.strengthSets || entry.plannedStrengthSets || 0
+    };
+    durationSeconds += metrics.durationSeconds;
+    distanceMeters += metrics.distanceMeters;
+    trainingLoad += metrics.trainingLoad;
+    strengthSets += metrics.strengthSets;
+    const week = weekly[entry.weekIndex];
+    if (week) {
+      week.workouts += 1;
+      week.durationSeconds += metrics.durationSeconds;
+      week.distanceMeters += metrics.distanceMeters;
+      week.trainingLoad += metrics.trainingLoad;
+    }
+    const sport = entry.workout?.sport;
+    if (sport) sportDistribution[sport] = (sportDistribution[sport] ?? 0) + 1;
+    for (const [intensity, count] of Object.entries(metrics.intensityDistribution)) {
+      intensityDistribution[intensity] = (intensityDistribution[intensity] ?? 0) + count;
+    }
+    if (!longestWorkout || metrics.durationSeconds > longestWorkout.durationSeconds) {
+      longestWorkout = {
+        name: entry.workout?.name ?? entry.title ?? "Workout",
+        durationSeconds: metrics.durationSeconds,
+        distanceMeters: metrics.distanceMeters
+      };
+    }
+    if (entry.dayIndex !== undefined) {
+      const key = `${entry.weekIndex}:${entry.dayIndex}`;
+      occupiedDays.add(key);
+      occupiedCounts.set(key, (occupiedCounts.get(key) ?? 0) + 1);
+    }
+  }
+  for (const count of occupiedCounts.values()) if (count > 1) conflictCount += count - 1;
+  const peak = weekly.reduce((best, week) =>
+    week.trainingLoad > best.trainingLoad ? week : best, weekly[0] ?? { weekIndex: 0, trainingLoad: 0, workouts: 0, durationSeconds: 0, distanceMeters: 0 });
+  const finalWeek = weekly.at(-1);
+  const taperDetected = Boolean(peak && finalWeek && peak.weekIndex < finalWeek.weekIndex && peak.trainingLoad > 0 && finalWeek.trainingLoad <= peak.trainingLoad * 0.8);
+  return {
+    planId: plan.id,
+    name: plan.name,
+    weekCount: plan.weekCount,
+    workouts,
+    durationSeconds,
+    distanceMeters,
+    trainingLoad,
+    strengthSets,
+    restDays: Math.max(0, plan.weekCount * 7 - occupiedDays.size),
+    sportDistribution,
+    intensityDistribution,
+    weekly,
+    longestWorkout,
+    peakWeek: peak ? peak.weekIndex + 1 : undefined,
+    taperDetected,
+    conflictCount
+  };
+}
+
+export function compareTrainingPlans(plans: TrainingPlanDocument[]): TrainingPlanComparison {
+  const summaries = plans.slice(0, 3).map(summarizeTrainingPlan);
+  const namesByPlan = plans.slice(0, 3).map((plan) =>
+    new Set(plan.entries.filter((entry) => entry.kind === "workout").map((entry) => entry.workout?.name ?? entry.title).filter((name): name is string => Boolean(name)))
+  );
+  const sharedWorkoutNames = namesByPlan.length < 2
+    ? []
+    : [...namesByPlan[0]!].filter((name) => namesByPlan.slice(1).every((set) => set.has(name)));
+  const insights: string[] = [];
+  for (const summary of summaries) {
+    for (let index = 1; index < summary.weekly.length; index += 1) {
+      const prior = summary.weekly[index - 1]!.trainingLoad;
+      const current = summary.weekly[index]!.trainingLoad;
+      if (prior > 0 && current > prior * 1.15) {
+        insights.push(`${summary.name}: week ${index + 1} increases planned load by more than 15%.`);
+      }
+    }
+    if (summary.peakWeek && !summary.taperDetected && summary.peakWeek === summary.weekCount) {
+      insights.push(`${summary.name}: planned load peaks in the final week with no clear taper.`);
+    }
+    if (summary.conflictCount > 0) {
+      insights.push(`${summary.name}: ${summary.conflictCount} same-day scheduling conflict${summary.conflictCount === 1 ? "" : "s"}.`);
+    }
+  }
+  if (summaries.length > 1) {
+    const mostLoad = [...summaries].sort((a, b) => b.trainingLoad - a.trainingLoad)[0]!;
+    const leastLoad = [...summaries].sort((a, b) => a.trainingLoad - b.trainingLoad)[0]!;
+    if (mostLoad.planId !== leastLoad.planId) {
+      insights.push(`${mostLoad.name} carries ${Math.round(mostLoad.trainingLoad - leastLoad.trainingLoad)} more estimated training load than ${leastLoad.name}.`);
+    }
+  }
+  return { summaries, sharedWorkoutNames, insights };
+}
+
+export function planEntryFromWorkout(
+  workout: PlanWorkoutEntryInput,
+  weekIndex: number,
+  dayIndex?: number,
+  programId?: string
+): TrainingPlanEntry {
+  return {
+    id: uniqueId("entry"),
+    kind: "workout",
+    weekIndex,
+    dayIndex,
+    sortOrder: 0,
+    title: workout.name,
+    workout: structuredClone(workout),
+    programId
+  };
+}

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -2500,6 +2500,251 @@ export type ChatStreamInfo =
 
 // ----- Training plan upload (AI coach) -----
 
+export type TrainingLibrarySyncState =
+  | "local"
+  | "synced"
+  | "pending"
+  | "conflicted"
+  | "failed"
+  | "stale";
+
+export type TrainingPlanSource =
+  | "coros"
+  | "local"
+  | "template"
+  | "coach";
+
+export type TrainingPlanDifficulty =
+  | "beginner"
+  | "intermediate"
+  | "advanced"
+  | "custom";
+
+export type TrainingPlanDestination =
+  | "workoutLibrary"
+  | "calendar"
+  | "nativePlan"
+  | "localTemplate"
+  | "nativePlanAndCalendar";
+
+export type TrainingPlanEntryKind = "workout" | "rest" | "note";
+
+export interface TrainingPlanPhase {
+  id: string;
+  name: string;
+  startWeek: number;
+  endWeek: number;
+  kind?: "base" | "build" | "peak" | "taper" | "recovery" | "custom";
+}
+
+export interface TrainingPlanEntry {
+  id: string;
+  kind: TrainingPlanEntryKind;
+  weekIndex: number;
+  /** Undefined dayIndex places the workout in the holding area. */
+  dayIndex?: number;
+  sortOrder: number;
+  title?: string;
+  workout?: PlanWorkoutEntryInput;
+  programId?: string;
+  remotePlanProgramId?: string;
+  plannedDurationSeconds?: number;
+  plannedDistanceMeters?: number;
+  plannedTrainingLoad?: number;
+  plannedStrengthSets?: number;
+  notes?: string;
+}
+
+export interface TrainingPlanDocument {
+  id: string;
+  remoteId?: string;
+  name: string;
+  description: string;
+  goal: string;
+  difficulty: TrainingPlanDifficulty;
+  notes: string;
+  source: TrainingPlanSource;
+  sportMix: WorkoutSport[];
+  weekCount: number;
+  startDate?: string;
+  phases: TrainingPlanPhase[];
+  entries: TrainingPlanEntry[];
+  tags: string[];
+  collectionId?: string;
+  favorite: boolean;
+  archived: boolean;
+  syncState: TrainingLibrarySyncState;
+  remoteVersion?: number;
+  remoteUpdatedAt?: number;
+  lastSyncedAt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TrainingCollection {
+  id: string;
+  name: string;
+  description?: string;
+  color?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TrainingWorkoutMetadata {
+  programId: string;
+  favorite: boolean;
+  tags: string[];
+  collectionId?: string;
+  source: "coros" | "local" | "activity" | "coach";
+  syncState: TrainingLibrarySyncState;
+  lastUsedAt?: string;
+  lastSyncedAt?: string;
+  cachedVersion?: string;
+}
+
+export interface TrainingLibraryWorkout extends TrainingHubLibraryWorkout {
+  favorite: boolean;
+  tags: string[];
+  collectionId?: string;
+  source: TrainingWorkoutMetadata["source"];
+  syncState: TrainingLibrarySyncState;
+  lastUsedAt?: string;
+  lastSyncedAt?: string;
+  usedByPlanIds: string[];
+  scheduledCount: number;
+}
+
+export interface NativeCorosPlanSummary {
+  remoteId: string;
+  name: string;
+  overview: string;
+  totalDay: number;
+  minWeeks?: number;
+  maxWeeks?: number;
+  startDay?: string;
+  endDay?: string;
+  executeStatus?: number;
+  inSchedule?: boolean;
+  workoutCount: number;
+  sportTypes: number[];
+  trainingLoad?: number;
+  durationSeconds?: number;
+  distanceMeters?: number;
+  version?: number;
+  updateTimestamp?: number;
+  syncState: TrainingLibrarySyncState;
+  lastSyncedAt?: string;
+}
+
+export interface NativeCorosPlanEntity {
+  idInPlan: string;
+  planProgramId?: string;
+  happenDay?: string;
+  dayNo?: number;
+  sortNo?: number;
+  sortNoInPlan?: number;
+  sortNoInSchedule?: number;
+  status?: number;
+}
+
+export interface NativeCorosPlanProgram {
+  id?: string;
+  idInPlan?: string;
+  planProgramId?: string;
+  name: string;
+  overview?: string;
+  sportType?: number;
+  planDistance?: number;
+  planDuration?: number;
+  planTrainingLoad?: number;
+  planSets?: number;
+  exercises?: TrainingHubScheduledExercise[];
+}
+
+export interface NativeCorosPlanDetail extends NativeCorosPlanSummary {
+  entities: NativeCorosPlanEntity[];
+  programs: NativeCorosPlanProgram[];
+  weekStages: Array<{
+    weekNo: number;
+    stage?: number | string;
+    planDistance?: number;
+    planDuration?: number;
+    planTrainingLoad?: number;
+  }>;
+  /** Lossless payload retained only at the remote adapter boundary. */
+  rawPayload: Record<string, unknown>;
+}
+
+export interface TrainingPlanWriteCapabilities {
+  create: boolean;
+  update: boolean;
+  duplicate: boolean;
+  delete: boolean;
+  activate: boolean;
+  removeActive: boolean;
+  reason?: string;
+  verifiedAt?: string;
+}
+
+export interface TrainingActivityMatch {
+  id: string;
+  planId?: string;
+  planEntryId?: string;
+  schedulePlanId: string;
+  scheduleIdInPlan: string;
+  activityId?: string;
+  happenDay: string;
+  status:
+    | "completed"
+    | "partial"
+    | "missed"
+    | "skipped"
+    | "rescheduled"
+    | "upcoming";
+  confidence?: number;
+  manual: boolean;
+  plannedDurationSeconds?: number;
+  completedDurationSeconds?: number;
+  plannedDistanceMeters?: number;
+  completedDistanceMeters?: number;
+  plannedTrainingLoad?: number;
+  completedTrainingLoad?: number;
+  updatedAt: string;
+}
+
+export interface TrainingLibrarySnapshot {
+  workouts: TrainingLibraryWorkout[];
+  plans: TrainingPlanDocument[];
+  nativePlans: NativeCorosPlanSummary[];
+  collections: TrainingCollection[];
+  matches: TrainingActivityMatch[];
+  cachedAt: string;
+  stale: boolean;
+  offline: boolean;
+  partialFailures: string[];
+  nativePlanWrites: TrainingPlanWriteCapabilities;
+}
+
+export interface WorkoutMetadataPatch {
+  favorite?: boolean;
+  tags?: string[];
+  collectionId?: string | null;
+  source?: TrainingWorkoutMetadata["source"];
+  lastUsedAt?: string;
+}
+
+export interface TrainingPlanMetadataPatch {
+  favorite?: boolean;
+  tags?: string[];
+  collectionId?: string | null;
+  archived?: boolean;
+}
+
+export interface TrainingLibraryDeleteRequest {
+  programIds: string[];
+  confirmed: boolean;
+}
+
 export interface TrainingTrendPoint {
   date: string;
   label: string;
@@ -2608,6 +2853,9 @@ export interface PlanDraftPreview {
   uploadResult?: {
     workoutsScheduled: number;
     workoutsCreated: number;
+    destination?: TrainingPlanDestination;
+    localPlanId?: string;
+    groupedPlanCreated?: boolean;
   };
 }
 
@@ -2851,6 +3099,10 @@ export interface UploadPlanResult {
   workoutsCreated: number;
   workoutsScheduled: number;
   entries: UploadPlanResultEntry[];
+  destination?: TrainingPlanDestination;
+  localPlanId?: string;
+  groupedPlanCreated?: boolean;
+  remoteWrites?: string[];
 }
 
 export interface TrainingHubScheduledWorkoutEntry {

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -1964,11 +1964,33 @@ export interface StrengthSet {
   workSec: number;
   restSec: number;
   calories: number;
+  /** Original set classification when supplied by an external strength log. */
+  type?: StrengthSetType;
+  /** Rating of perceived exertion, on Hevy's 1–10 scale. */
+  rpe?: number;
+}
+
+export type StrengthSetType = "normal" | "warmup" | "dropset" | "failure";
+
+export type StrengthSource = "coros" | "hevy" | "combined";
+
+export type StrengthDataSource = StrengthSource;
+
+export interface StrengthSourceIds {
+  coros?: string;
+  hevy?: string;
 }
 
 export interface StrengthExercise {
   nameKey: string;   // "T####"/"S####" library code, or a custom name
   rawName?: string;  // payload name, used to resolve custom exercises
+  /** Provider exercise/template identity, when one exists. */
+  externalId?: string;
+  /** Provider exercise classification (for example, `weight_reps`). */
+  exerciseType?: string;
+  /** Hevy muscle metadata, used only when name-based resolution has no match. */
+  primaryMuscleGroup?: string;
+  secondaryMuscleGroups?: string[];
   sets: number;
   totalReps: number;
   entries: StrengthSet[];
@@ -1996,6 +2018,9 @@ export interface StrengthDetail {
 /** One completed strength activity plus its cached set-by-set breakdown. */
 export interface StrengthSession {
   activityId: string;
+  /** Absent on legacy cached rows, which are implicitly COROS sessions. */
+  source?: StrengthSource;
+  sourceIds?: StrengthSourceIds;
   sportType: number;
   name?: string;
   sportName?: string;
@@ -2017,6 +2042,31 @@ export interface StrengthHistory {
   fetched: number;
   /** Window length in days that produced this history. */
   days: number;
+  /** Source selection used to produce this history. */
+  source?: StrengthDataSource;
+  pendingBySource?: Partial<Record<Exclude<StrengthSource, "combined">, number>>;
+  fetchedBySource?: Partial<Record<Exclude<StrengthSource, "combined">, number>>;
+  /** Non-fatal provider errors; cached sessions remain usable. */
+  warnings?: string[];
+}
+
+export interface StrengthHistoryRequest {
+  days?: number;
+  force?: boolean;
+  source?: StrengthDataSource;
+}
+
+export interface HevyStatus {
+  connected: boolean;
+  userId?: string;
+  displayName?: string;
+  profileUrl?: string;
+  lastSyncedAt?: string;
+  includeWarmups: boolean;
+}
+
+export interface HevySettingsInput {
+  includeWarmups: boolean;
 }
 
 export interface TrainingHubActivityDetail {
@@ -2555,6 +2605,51 @@ export interface TrainingPlanEntry {
   notes?: string;
 }
 
+export interface TrainingPlanGenerationRequest {
+  goal: string;
+  sports: WorkoutSport[];
+  difficulty: TrainingPlanDifficulty;
+  weeks: number;
+  sessionsPerWeek: number;
+  /** ISO date for Week 1 Monday. */
+  startDate: string;
+  /** Monday = 0 through Sunday = 6. */
+  availableDayIndexes: number[];
+  maxSessionMinutes?: number;
+  constraints?: string;
+}
+
+export interface TrainingPlanCalendarOccurrence {
+  planEntryId: string;
+  happenDay: string;
+  schedulePlanId: string;
+  scheduleIdInPlan: string;
+  planProgramId: string;
+  pbVersion?: number;
+  createdAt: string;
+  removedAt?: string;
+}
+
+export interface TrainingPlanCalendarFailure {
+  planEntryId: string;
+  happenDay: string;
+  message: string;
+  /** True when COROS may have accepted the write but its identity could not be verified. */
+  writeMayHaveSucceeded?: boolean;
+}
+
+export interface TrainingPlanCalendarInstall {
+  id: string;
+  startDate: string;
+  planRevision: string;
+  state: "active" | "partial" | "removed";
+  lastOperation?: "install" | "remove";
+  occurrences: TrainingPlanCalendarOccurrence[];
+  failures: TrainingPlanCalendarFailure[];
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface TrainingPlanDocument {
   id: string;
   remoteId?: string;
@@ -2569,6 +2664,7 @@ export interface TrainingPlanDocument {
   startDate?: string;
   phases: TrainingPlanPhase[];
   entries: TrainingPlanEntry[];
+  calendarInstalls?: TrainingPlanCalendarInstall[];
   tags: string[];
   collectionId?: string;
   favorite: boolean;
@@ -2579,6 +2675,46 @@ export interface TrainingPlanDocument {
   lastSyncedAt?: string;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface TrainingPlanCalendarPreviewEntry {
+  planEntryId: string;
+  name: string;
+  happenDay: string;
+  sport?: WorkoutSport;
+  schedulePlanId?: string;
+  scheduleIdInPlan?: string;
+  planProgramId?: string;
+  pbVersion?: number;
+}
+
+export interface TrainingPlanCalendarConflict {
+  happenDay: string;
+  existing: Array<{
+    name: string;
+    schedulePlanId: string;
+    scheduleIdInPlan: string;
+  }>;
+}
+
+export interface TrainingPlanCalendarPreview {
+  previewId: string;
+  operation: "install" | "remove";
+  planId: string;
+  planName: string;
+  planRevision: string;
+  startDate: string;
+  entries: TrainingPlanCalendarPreviewEntry[];
+  conflicts: TrainingPlanCalendarConflict[];
+  blockers: string[];
+  expiresAt: string;
+}
+
+export interface TrainingPlanCalendarMutationResult {
+  plan: TrainingPlanDocument;
+  scheduledCount: number;
+  removedCount: number;
+  failures: TrainingPlanCalendarFailure[];
 }
 
 export interface TrainingCollection {

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -2283,6 +2283,27 @@ export interface PersistedChatMessageEntry {
   role: ChatRole;
   content: string;
   source?: PersistedChatSource;
+  /** Display-safe provider reasoning summary, never raw chain-of-thought. */
+  reasoningSummary?: string;
+}
+
+export interface CoachInputChoice {
+  id: string;
+  label: string;
+  description?: string;
+  /** Text sent back to Coach when the athlete selects this choice. */
+  response: string;
+}
+
+export interface CoachInputPrompt {
+  promptId: string;
+  question: string;
+  choices: CoachInputChoice[];
+  allowCustom: boolean;
+  /** Athlete response retained as model context without a separate chat bubble. */
+  answer?: string;
+  selectedChoiceId?: string;
+  answeredAt?: number;
 }
 
 export type ChatProvider = "chatgpt" | "claude-code" | "local";
@@ -2519,7 +2540,7 @@ export type ChatStreamInfo =
   | {
       requestId: string;
       kind: "thinking";
-      /** Incremental extended-thinking text from the model. */
+      /** Incremental display-safe reasoning/thinking summary from the provider. */
       delta: string;
     }
   | {
@@ -2546,6 +2567,11 @@ export type ChatStreamInfo =
       requestId: string;
       kind: "hrZoneSummary";
       preview: HrZonePreview;
+    }
+  | {
+      requestId: string;
+      kind: "coachPrompt";
+      prompt: CoachInputPrompt;
     };
 
 // ----- Training plan upload (AI coach) -----
@@ -3433,6 +3459,7 @@ export interface WorkoutDeletePreview {
 /** Persisted coach timeline entry (messages plus inline action cards). */
 export type PersistedChatEntry =
   | PersistedChatMessageEntry
+  | { kind: "coachPrompt"; prompt: CoachInputPrompt }
   | { kind: "planDraft"; draft: PlanDraftPreview }
   | { kind: "workoutDelete"; preview: WorkoutDeletePreview }
   | { kind: "activityVisual"; preview: ActivityVisualPreview }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coroslink",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coroslink",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.206",
         "@anthropic-ai/sdk": "^0.111.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "test:exercise-names": "node --experimental-strip-types scripts/test-exercise-names.mjs",
     "test:strength-detail": "node --experimental-strip-types scripts/test-strength-detail.mjs",
     "test:strength-analytics": "node --experimental-strip-types --import ./scripts/register-ts-ext.mjs scripts/test-strength-analytics.mjs",
+    "test:hevy-strength": "node --experimental-strip-types --import ./scripts/register-ts-ext.mjs scripts/test-hevy-strength.mjs",
+    "test:hevy-service": "npm run build:electron && cross-env ELECTRON_RUN_AS_NODE=1 electron scripts/test-hevy-service.mjs",
     "test:exercise-explorer": "node --experimental-strip-types --import ./scripts/register-ts-ext.mjs scripts/test-exercise-explorer.mjs",
     "test:strength-body-focus": "node --experimental-strip-types --import ./scripts/register-ts-ext.mjs scripts/test-strength-body-focus.mjs",
     "test:anatomy-assets": "node scripts/test-anatomy-assets.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coroslink",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": true,
   "description": "Unofficial COROS Pace Pro companion — media, watch sync, and training analytics.",
   "author": "CorosLink Contributors",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test:coros-workout-builder": "npm run build:electron && node scripts/test-coros-workout-builder.mjs",
     "test:coros-workout-editor": "npm run build:electron && node scripts/test-coros-workout-editor.mjs",
     "test:workout-intensity-codec": "npm run build:electron && node scripts/test-workout-intensity-codec.mjs",
+    "test:training-library": "npm run build:electron && cross-env ELECTRON_RUN_AS_NODE=1 electron scripts/test-training-library.mjs && node scripts/test-coros-workout-builder.mjs && node scripts/test-workout-intensity-codec.mjs",
     "verify:coach-workout-api": "npm run build:electron && node scripts/verify-coach-workout-api.mjs",
     "test:training-hub-write": "npm run build:electron && node scripts/test-training-hub-write.mjs",
     "test:coros-login": "npm run build:electron && node scripts/test-coros-login.mjs",

--- a/scripts/test-chat-history-store.mjs
+++ b/scripts/test-chat-history-store.mjs
@@ -72,6 +72,7 @@ assert.deepEqual(
         kind: "message",
         role: "assistant",
         content: "Hi",
+        reasoningSummary: "I should greet the athlete briefly.",
         source: {
           snapshotIncluded: true,
           mcpEnabled: false,
@@ -87,6 +88,7 @@ assert.deepEqual(
       kind: "message",
       role: "assistant",
       content: "Hi",
+      reasoningSummary: "I should greet the athlete briefly.",
       source: {
         snapshotIncluded: true,
         mcpEnabled: false,
@@ -95,6 +97,53 @@ assert.deepEqual(
       }
     }
   ]
+);
+
+const waitingPromptEntry = {
+  kind: "coachPrompt",
+  prompt: {
+    promptId: "prompt-1",
+    question: "Which strength option should Coach use?",
+    choices: [
+      {
+        id: "choice-1",
+        label: "Use split squats",
+        description: "Recommended supported alternative.",
+        response: "Use split squats."
+      },
+      {
+        id: "choice-2",
+        label: "I’ll provide the exact name",
+        response: "I’ll provide the exact COROS exercise name."
+      }
+    ],
+    allowCustom: true
+  }
+};
+assert.deepEqual(
+  parseChatTranscriptJson(JSON.stringify([waitingPromptEntry])),
+  [waitingPromptEntry]
+);
+assert.deepEqual(
+  parseChatTranscriptJson(
+    JSON.stringify([
+      {
+        ...waitingPromptEntry,
+        prompt: {
+          ...waitingPromptEntry.prompt,
+          answer: "Use split squats.",
+          selectedChoiceId: "choice-1",
+          answeredAt: 1234
+        }
+      }
+    ])
+  )[0].prompt,
+  {
+    ...waitingPromptEntry.prompt,
+    answer: "Use split squats.",
+    selectedChoiceId: "choice-1",
+    answeredAt: 1234
+  }
 );
 
 assert.equal(

--- a/scripts/test-chat-service.mjs
+++ b/scripts/test-chat-service.mjs
@@ -20,6 +20,20 @@ const { parseFunctionCallArguments } = await import(
   `${distUrl("chatToolArguments.js")}?cacheBust=${Date.now()}`
 );
 const {
+  buildCoachInputPrompt,
+  getChatInteractionTools,
+  handleChatInteractionTool
+} = await import(
+  `${distUrl("chatInteractionTools.js")}?cacheBust=${Date.now()}`
+);
+const {
+  buildResponsesRequest,
+  extractReasoningSummaryDelta,
+  extractResponseTextDelta
+} = await import(
+  `${distUrl("chatResponsesProtocol.js")}?cacheBust=${Date.now()}`
+);
+const {
   buildCoachInstructions,
   buildCoachSportCapabilityGuide,
   formatCoachDashboard,
@@ -34,6 +48,90 @@ assert.match(coachInstructions, /Never add an unfamiliar sport merely for variet
 assert.match(coachInstructions, /Open Water Swim is not Pool Swim/);
 assert.match(coachInstructions, /exercise_resolution_required/);
 assert.match(coachInstructions, /call draft_training_plan again in the same response/);
+assert.match(coachInstructions, /request_coach_input/);
+
+const interactionTool = getChatInteractionTools()[0];
+assert.equal(interactionTool.name, "request_coach_input");
+assert.deepEqual(interactionTool.inputSchema.required, ["question", "choices"]);
+
+const prompt = buildCoachInputPrompt(
+  {
+    question: "Which squat option should I use?",
+    choices: [
+      {
+        label: "Use split squats",
+        description: "Uses a supported unilateral movement.",
+        response: "Use split squats for the heavy gym sessions."
+      },
+      { label: "I’ll provide the COROS name" }
+    ]
+  },
+  "prompt-test"
+);
+assert.equal(prompt.promptId, "prompt-test");
+assert.equal(prompt.allowCustom, true);
+assert.equal(prompt.choices[0].response, "Use split squats for the heavy gym sessions.");
+assert.equal(prompt.choices[1].response, "I’ll provide the COROS name");
+assert.throws(
+  () =>
+    buildCoachInputPrompt({
+      question: "Choose",
+      choices: [{ label: "Only one" }]
+    }),
+  /at least two/
+);
+
+let emittedPrompt;
+const interactionResult = JSON.parse(
+  handleChatInteractionTool(
+    "request_coach_input",
+    {
+      question: "Choose a gym movement",
+      choices: [{ label: "Split squat" }, { label: "Leg press" }],
+      allow_custom: false
+    },
+    (nextPrompt) => {
+      emittedPrompt = nextPrompt;
+    }
+  )
+);
+assert.equal(interactionResult.status, "waiting_for_athlete");
+assert.equal(emittedPrompt.allowCustom, false);
+
+const responsesRequest = buildResponsesRequest(
+  "gpt-test",
+  "Coach instructions",
+  [{ type: "message", role: "user" }],
+  [{ type: "function", name: "get_metrics" }]
+);
+assert.deepEqual(responsesRequest.reasoning, { summary: "auto" });
+assert.equal(responsesRequest.tool_choice, "auto");
+assert.equal(
+  "reasoning" in
+    buildResponsesRequest("gpt-test", "Coach", [], [], false),
+  false
+);
+assert.equal(
+  extractReasoningSummaryDelta({
+    type: "response.reasoning_summary_text.delta",
+    delta: "Reviewing recent training load."
+  }),
+  "Reviewing recent training load."
+);
+assert.equal(
+  extractReasoningSummaryDelta({
+    type: "response.reasoning_text.delta",
+    delta: "raw reasoning"
+  }),
+  ""
+);
+assert.equal(
+  extractResponseTextDelta({
+    type: "response.output_text.delta",
+    delta: "Your plan is ready."
+  }),
+  "Your plan is ready."
+);
 
 const capabilityGuide = buildCoachSportCapabilityGuide();
 for (const sport of [

--- a/scripts/test-hevy-service.mjs
+++ b/scripts/test-hevy-service.mjs
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const distUrl = (file) =>
+  `${pathToFileURL(path.join(repoRoot, "dist-electron", file)).href}?cacheBust=${Date.now()}`;
+const database = await import(distUrl("database.js"));
+const hevy = await import(distUrl("hevyService.js"));
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "coroslink-hevy-test-"));
+database.initializeDatabase(tempRoot);
+
+let encryptionAvailable = true;
+hevy.setHevyCredentialStorageForTests({
+  isEncryptionAvailable: () => encryptionAvailable,
+  encryptString: (value) => Buffer.from(`encrypted:${value}`, "utf8"),
+  decryptString: (value) => value.toString("utf8").replace(/^encrypted:/, "")
+});
+
+const now = Date.now();
+const isoDaysAgo = (days, hour = 12) => {
+  const date = new Date(now - days * 86_400_000);
+  date.setUTCHours(hour, 0, 0, 0);
+  return date.toISOString();
+};
+const workout = (id, title, daysAgo) => ({
+  id,
+  title,
+  start_time: isoDaysAgo(daysAgo),
+  end_time: isoDaysAgo(daysAgo, 13),
+  updated_at: new Date(now).toISOString(),
+  exercises: [
+    {
+      index: 0,
+      title: "Bench Press (Barbell)",
+      exercise_template_id: "bench",
+      sets: [{ index: 0, type: "normal", weight_kg: 80, reps: 8 }]
+    }
+  ]
+});
+
+let phase = "connect";
+let activeUser = { id: "user-1", name: "Ada", url: "https://hevy.com/user/ada" };
+const requests = [];
+globalThis.fetch = async (input, init = {}) => {
+  const url = new URL(String(input));
+  requests.push({ url, headers: init.headers });
+  if (url.pathname.endsWith("/user/info")) {
+    if (phase === "bad-auth") {
+      return new Response(JSON.stringify({ error: "forbidden" }), {
+        status: 403,
+        headers: { "content-type": "application/json" }
+      });
+    }
+    return Response.json({ data: activeUser });
+  }
+  if (url.pathname.endsWith("/exercise_templates")) {
+    return Response.json({
+      page: 1,
+      page_count: 1,
+      exercise_templates: [
+        {
+          id: "bench",
+          title: "Bench Press (Barbell)",
+          type: "weight_reps",
+          primary_muscle_group: "chest",
+          secondary_muscle_groups: ["triceps"]
+        }
+      ]
+    });
+  }
+  if (url.pathname.endsWith("/workouts/events")) {
+    if (phase === "event-failure") throw new Error("offline");
+    return Response.json({
+      page: 1,
+      page_count: 1,
+      events:
+        phase === "events"
+          ? [
+              { type: "updated", workout: workout("a", "Push Updated", 2) },
+              { type: "deleted", id: "b", deleted_at: new Date(now).toISOString() }
+            ]
+          : []
+    });
+  }
+  if (url.pathname.endsWith("/workouts")) {
+    const page = Number(url.searchParams.get("page"));
+    return Response.json(
+      page === 1
+        ? {
+            page: 1,
+            page_count: 2,
+            workouts: [workout("a", "Push", 2), workout("b", "Pull", 5)]
+          }
+        : {
+            page: 2,
+            page_count: 2,
+            workouts: [workout("old", "Old workout", 500)]
+          }
+    );
+  }
+  throw new Error(`Unexpected Hevy request: ${url}`);
+};
+
+const connected = await hevy.connectHevy("secret-key");
+assert.equal(connected.connected, true);
+assert.equal(connected.displayName, "Ada");
+assert.notEqual(database.getSetting("hevy.apiKey"), "secret-key");
+assert.equal(
+  requests.at(-1).headers["api-key"],
+  "secret-key",
+  "the supplied key authenticates the validation request"
+);
+
+phase = "full";
+const firstSync = await hevy.syncHevyStrengthHistory(90, false);
+assert.equal(firstSync.fetched, 2);
+assert.equal(firstSync.sessions.length, 2);
+assert.equal(database.listStoredHevyExerciseTemplates().size, 1);
+assert.ok(database.getSetting("hevy.eventCursor"));
+assert.ok(
+  requests.some(
+    ({ url }) =>
+      url.pathname.endsWith("/exercise_templates") && url.searchParams.get("pageSize") === "100"
+  )
+);
+assert.ok(
+  requests.some(
+    ({ url }) => url.pathname.endsWith("/workouts") && url.searchParams.get("pageSize") === "10"
+  )
+);
+
+phase = "events";
+const incremental = await hevy.syncHevyStrengthHistory(90, false);
+assert.equal(incremental.fetched, 1);
+assert.equal(incremental.sessions.length, 1);
+assert.equal(incremental.sessions[0].name, "Push Updated");
+
+const cursorBeforeFailure = database.getSetting("hevy.eventCursor");
+phase = "event-failure";
+await assert.rejects(() => hevy.syncHevyStrengthHistory(90, false), /offline/);
+assert.equal(
+  database.getSetting("hevy.eventCursor"),
+  cursorBeforeFailure,
+  "a failed page must not advance the event cursor"
+);
+assert.equal(hevy.getStoredHevyStrengthSessions(90).length, 1, "cached data survives errors");
+
+phase = "bad-auth";
+await assert.rejects(() => hevy.connectHevy("bad-key"), /rejected the API key/);
+assert.equal(hevy.getHevyStatus().userId, "user-1", "failed auth keeps the prior account");
+
+phase = "connect";
+activeUser = { id: "user-2", name: "Grace", url: "https://hevy.com/user/grace" };
+const switched = await hevy.connectHevy("second-key");
+assert.equal(switched.userId, "user-2");
+assert.equal(hevy.getStoredHevyStrengthSessions(90).length, 0, "account switching purges workouts");
+assert.equal(database.getSetting("hevy.eventCursor"), undefined);
+
+encryptionAvailable = false;
+await assert.rejects(() => hevy.connectHevy("cannot-save"), /Secure credential storage/);
+encryptionAvailable = true;
+hevy.disconnectHevy();
+assert.equal(hevy.getHevyStatus().connected, false);
+assert.equal(database.listStoredHevyWorkouts(0).length, 0);
+assert.equal(database.listStoredHevyExerciseTemplates().size, 0);
+
+console.log("hevy-service tests passed");

--- a/scripts/test-hevy-strength.mjs
+++ b/scripts/test-hevy-strength.mjs
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const bust = Date.now();
+const load = async (file) =>
+  import(`${pathToFileURL(path.join(repoRoot, "electron", file)).href}?cacheBust=${bust}`);
+
+const {
+  canonicalStrengthExerciseName,
+  normalizeHevyWorkout
+} = await load("hevyModel.ts");
+const {
+  combineStrengthSessions,
+  mergeStrengthSessionPair,
+  selectStrengthSessions
+} = await load("strengthSessionMerge.ts");
+
+const templates = new Map([
+  [
+    "bench",
+    {
+      id: "bench",
+      title: "Bench Press (Barbell)",
+      type: "weight_reps",
+      primary_muscle_group: "chest",
+      secondary_muscle_groups: ["triceps"]
+    }
+  ],
+  [
+    "plank",
+    {
+      id: "plank",
+      title: "Plank",
+      type: "duration",
+      primary_muscle_group: "abdominals",
+      secondary_muscle_groups: []
+    }
+  ],
+  [
+    "assisted",
+    {
+      id: "assisted",
+      title: "Assisted Pull Up",
+      type: "bodyweight_assisted_reps",
+      primary_muscle_group: "lats",
+      secondary_muscle_groups: ["biceps"]
+    }
+  ]
+]);
+
+const rawWorkout = {
+  id: "hevy-1",
+  title: "Push Day",
+  start_time: "2026-07-20T12:00:00Z",
+  end_time: "2026-07-20T13:05:00Z",
+  exercises: [
+    {
+      index: 0,
+      title: "Bench Press (Barbell)",
+      exercise_template_id: "bench",
+      sets: [
+        { index: 0, type: "warmup", weight_kg: 20, reps: 10, rpe: null },
+        { index: 1, type: "normal", weight_kg: 80, reps: 8, rpe: 8.5 },
+        { index: 2, type: "dropset", weight_kg: 60, reps: 10, rpe: 10 },
+        { index: 3, type: "failure", weight_kg: 50, reps: 12, rpe: 12 }
+      ]
+    },
+    {
+      index: 1,
+      title: "Plank",
+      exercise_template_id: "plank",
+      sets: [{ index: 0, type: "normal", duration_seconds: 75, reps: null }]
+    },
+    {
+      index: 2,
+      title: "Assisted Pull Up",
+      exercise_template_id: "assisted",
+      sets: [{ index: 0, type: "normal", weight_kg: 25, reps: 6 }]
+    }
+  ]
+};
+
+const withoutWarmups = normalizeHevyWorkout(rawWorkout, templates, false);
+assert.ok(withoutWarmups);
+assert.equal(withoutWarmups.source, "hevy");
+assert.deepEqual(withoutWarmups.sourceIds, { hevy: "hevy-1" });
+assert.equal(withoutWarmups.duration, 3_900);
+assert.equal(withoutWarmups.detail.summary.sets, 5);
+assert.equal(withoutWarmups.detail.exercises[0].entries[0].rpe, 8.5);
+assert.equal(
+  withoutWarmups.detail.exercises[0].entries[2].rpe,
+  undefined,
+  "out-of-range RPE is discarded"
+);
+assert.equal(withoutWarmups.detail.exercises[1].entries[0].workSec, 75);
+assert.equal(
+  withoutWarmups.detail.exercises[2].entries[0].weightKg,
+  0,
+  "assistance must not be counted as lifted weight"
+);
+assert.equal(withoutWarmups.detail.summary.totalWeightKg, 80 * 8 + 60 * 10 + 50 * 12);
+
+const withWarmups = normalizeHevyWorkout(rawWorkout, templates, true);
+assert.ok(withWarmups);
+assert.equal(withWarmups.detail.summary.sets, 6);
+assert.equal(withWarmups.detail.summary.totalWeightKg, 20 * 10 + 80 * 8 + 60 * 10 + 50 * 12);
+
+assert.equal(canonicalStrengthExerciseName("Bench Press (Barbell)"), "bench press");
+assert.equal(
+  canonicalStrengthExerciseName("Bench Press (Dumbbell)"),
+  "dumbbell bench press"
+);
+
+const coros = {
+  activityId: "coros-1",
+  sportType: 402,
+  name: "Strength",
+  startTime: withoutWarmups.startTime + 120,
+  duration: 3_800,
+  calories: 420,
+  avgHr: 128,
+  maxHr: 171,
+  trainingLoad: 54,
+  detail: {
+    summary: {
+      sets: 3,
+      totalReps: 30,
+      totalWeightKg: 1_000,
+      exercises: 1,
+      calories: 420,
+      durationSec: 3_800
+    },
+    exercises: [
+      {
+        nameKey: "T1041",
+        rawName: "Bench Press",
+        sets: 3,
+        totalReps: 30,
+        entries: [{ reps: 10, weightKg: 70, workSec: 30, restSec: 60, calories: 5 }]
+      }
+    ]
+  }
+};
+
+const merged = mergeStrengthSessionPair(coros, withoutWarmups);
+assert.equal(merged.source, "combined");
+assert.equal(merged.name, "Push Day");
+assert.equal(merged.detail.exercises.length, 3, "Hevy supplies the set detail");
+assert.equal(merged.avgHr, 128);
+assert.equal(merged.detail.summary.trainingLoad, 54);
+
+const combined = combineStrengthSessions([coros], [withoutWarmups]);
+assert.equal(combined.length, 1);
+assert.equal(combined[0].source, "combined");
+assert.equal(selectStrengthSessions("hevy", [coros], [withoutWarmups]).length, 1);
+assert.equal(selectStrengthSessions("coros", [coros], [withoutWarmups])[0].source, "coros");
+
+const laterHevy = {
+  ...withoutWarmups,
+  activityId: "hevy:later",
+  sourceIds: { hevy: "later" },
+  startTime: withoutWarmups.startTime + 8 * 3_600
+};
+assert.equal(
+  combineStrengthSessions([coros], [withoutWarmups, laterHevy]).length,
+  2,
+  "a second same-day workout must remain separate"
+);
+
+const codeOnlyCoros = {
+  ...coros,
+  activityId: "coros-code",
+  startTime: withoutWarmups.startTime + 30,
+  duration: withoutWarmups.duration,
+  detail: {
+    ...coros.detail,
+    exercises: [{ ...coros.detail.exercises[0], rawName: undefined }]
+  }
+};
+assert.equal(
+  combineStrengthSessions([codeOnlyCoros], [withoutWarmups]).length,
+  1,
+  "very close time and duration provide a safe fallback for coded COROS exercises"
+);
+
+assert.equal(normalizeHevyWorkout({ ...rawWorkout, id: undefined }, templates, false), undefined);
+assert.equal(
+  normalizeHevyWorkout({ ...rawWorkout, start_time: "not-a-date" }, templates, false),
+  undefined
+);
+
+console.log("hevy-strength tests passed");

--- a/scripts/test-strength-analytics.mjs
+++ b/scripts/test-strength-analytics.mjs
@@ -142,6 +142,22 @@ assert.ok(chest.sets > 0 && quads.sets > 0);
 assert.equal(analytics.muscleById.neck.sets, 0);
 assert.equal(analytics.muscleById.neck.lastTrained, undefined);
 
+// Unknown custom names fall back to Hevy's exercise-template muscle metadata.
+const providerFallback = buildStrengthAnalytics(
+  [
+    session("hevy-custom", now, [
+      {
+        ...exercise("Uncatalogued Lever Movement", [{ reps: 10, weightKg: 40 }]),
+        primaryMuscleGroup: "quadriceps",
+        secondaryMuscleGroups: ["glutes"]
+      }
+    ])
+  ],
+  30
+);
+assert.ok(providerFallback.muscleById.quads.sets > 0);
+assert.ok(providerFallback.muscleById.glutes.sets > 0);
+
 // Credited sets never exceed the sets actually performed.
 const creditedSets = analytics.muscles.reduce((sum, stat) => sum + stat.sets, 0);
 assert.ok(creditedSets <= analytics.summary.sets + 1e-9);

--- a/scripts/test-strength-analytics.mjs
+++ b/scripts/test-strength-analytics.mjs
@@ -64,7 +64,7 @@ assert.equal(estimateOneRepMax(0, 10), 0, "bodyweight sets have no 1RM estimate"
 assert.equal(estimateOneRepMax(100, 40), 0, "rep counts outside the usable range are ignored");
 assert.equal(formatWeightKg(10, "metric"), "10 kg");
 assert.equal(formatWeightKg(10, "imperial"), "22.0 lb");
-assert.equal(formatVolumeKg(1_000, "metric"), "1.0t");
+assert.equal(formatVolumeKg(1_000, "metric"), "1.0 tonnes");
 assert.equal(formatVolumeKg(1_000, "imperial"), "2,205 lb");
 
 // ---- Aggregation ----

--- a/scripts/test-training-hub-write.mjs
+++ b/scripts/test-training-hub-write.mjs
@@ -6,8 +6,32 @@ const repoRoot = path.resolve(import.meta.dirname, "..");
 const distUrl = (file) =>
   pathToFileURL(path.join(repoRoot, "dist-electron", file)).href;
 
-const { parseTrainingHubApiResponse } = await import(
+const {
+  buildTrainingHubActivityPagePlan,
+  parseTrainingHubApiResponse
+} = await import(
   `${distUrl("trainingHubService.js")}?cacheBust=${Date.now()}`
+);
+
+assert.deepEqual(buildTrainingHubActivityPagePlan(1, 50), {
+  requests: [{ page: 1, size: 50 }],
+  sliceStart: 0
+});
+assert.deepEqual(buildTrainingHubActivityPagePlan(1, 500), {
+  requests: [1, 2, 3, 4, 5].map((page) => ({ page, size: 100 })),
+  sliceStart: 0
+});
+assert.deepEqual(buildTrainingHubActivityPagePlan(2, 150), {
+  requests: [2, 3].map((page) => ({ page, size: 100 })),
+  sliceStart: 50
+});
+assert.throws(
+  () => buildTrainingHubActivityPagePlan(0, 50),
+  /page must be a positive integer/
+);
+assert.throws(
+  () => buildTrainingHubActivityPagePlan(1, Number.NaN),
+  /page size must be a positive integer/
 );
 
 assert.equal(

--- a/scripts/test-training-library.mjs
+++ b/scripts/test-training-library.mjs
@@ -13,6 +13,7 @@ const domain = await import(distUrl("trainingPlanDomain.js"));
 const adapter = await import(distUrl("corosTrainingPlanAdapter.js"));
 const databaseModule = await import(distUrl("database.js"));
 const library = await import(distUrl("trainingLibraryService.js"));
+const planWorkoutEditor = await import(distUrl("planWorkoutEditor.js"));
 
 const makeWorkout = (name, load, seconds = 1_800) => ({
   key: name.toLowerCase().replaceAll(" ", "-"),
@@ -75,6 +76,177 @@ const comparison = domain.compareTrainingPlans([first, second]);
 assert.deepEqual(comparison.sharedWorkoutNames, ["Easy"]);
 assert.equal(comparison.summaries.length, 2);
 assert.equal(comparison.insights.some((insight) => insight.includes("more estimated training load")), true);
+
+const generationRequest = {
+  goal: "Build durable mountain endurance",
+  sports: ["run", "strength", "swim"],
+  difficulty: "advanced",
+  weeks: 2,
+  sessionsPerWeek: 2,
+  startDate: "2026-08-03",
+  availableDayIndexes: [0, 2],
+  maxSessionMinutes: 90,
+  constraints: "Keep Wednesday joint-friendly."
+};
+const generatedDraft = {
+  draftId: "typed-draft",
+  name: "Mountain durability",
+  summary: "Two focused weeks built from current recovery context.",
+  conflicts: [],
+  warnings: ["Review loads before saving."],
+  entries: [
+    {
+      key: "w1-run",
+      name: "Uphill repeats",
+      scheduleDate: "20260803",
+      saveToLibrary: false,
+      workoutType: "run",
+      source: {
+        key: "w1-run",
+        name: "Uphill repeats",
+        sport: "run",
+        schedule_date: "20260803",
+        save_to_library: false,
+        steps: [{
+          repeat: 4,
+          name: "Climbing set",
+          steps: [{ kind: "training", name: "Uphill", target_type: "time", target_duration_seconds: 240, intensity: { type: "heartRatePercent", basis: "lthr", lowPercent: 92, highPercent: 98 } }, { kind: "rest", name: "Float down", target_type: "time", target_duration_seconds: 120, intensity: { type: "none" } }]
+        }]
+      }
+    },
+    {
+      key: "w1-strength",
+      name: "Trail strength",
+      scheduleDate: "20260805",
+      saveToLibrary: false,
+      workoutType: "strength",
+      source: {
+        key: "w1-strength", name: "Trail strength", sport: "strength", schedule_date: "20260805",
+        steps: [{ kind: "training", name: "Goblet squat", target_type: "reps", target_reps: 10, exercise_id: "squat-1", exercise_name: "Goblet Squat", exercise_kind: 3, intensity: { type: "weight", mode: "weight", value: 24, unit: "kg" } }]
+      }
+    },
+    {
+      key: "w2-run", name: "Steady trail", scheduleDate: "20260810", saveToLibrary: false, workoutType: "run",
+      source: { key: "w2-run", name: "Steady trail", sport: "run", schedule_date: "20260810", steps: [{ kind: "training", target_type: "distance", target_distance_meters: 12_000, intensity: { type: "effortPace", lowSecondsPerKm: 330, highSecondsPerKm: 360, displayUnit: "km" } }] }
+    },
+    {
+      key: "w2-swim", name: "Pool recovery", scheduleDate: "20260812", saveToLibrary: false, workoutType: "swim",
+      source: { key: "w2-swim", name: "Pool recovery", sport: "swim", sport_options: { poolLength: { value: 25, unit: "m" } }, schedule_date: "20260812", steps: [{ kind: "sendOff", target_type: "distance", target_distance_meters: 100, send_off_seconds: 120, intensity: { type: "swimStroke", stroke: "freestyle" } }] }
+    }
+  ]
+};
+const generated = domain.trainingPlanFromDraftPreview(generatedDraft, generationRequest);
+assert.equal(generated.source, "coach");
+assert.equal(generated.weekCount, 2);
+assert.equal(generated.entries.length, 4);
+assert.equal(generated.entries[0].workout.steps[0].repeat, 4);
+assert.deepEqual(generated.entries[1].workout.steps[0].intensity, { type: "weight", mode: "weight", value: 24, unit: "kg" });
+assert.deepEqual(generated.entries[3].workout.sport_options, { poolLength: { value: 25, unit: "m" } });
+assert.match(generated.notes, /Review loads/);
+const coachLibraryPlan = domain.trainingPlanFromCoachDraftPreview(generatedDraft);
+assert.equal(coachLibraryPlan.source, "coach");
+assert.equal(coachLibraryPlan.startDate, "2026-08-03");
+assert.equal(coachLibraryPlan.entries[3].weekIndex, 1);
+assert.deepEqual(coachLibraryPlan.entries[0].workout.steps, generatedDraft.entries[0].source.steps);
+const undatedCoachPlan = domain.trainingPlanFromCoachDraftPreview({
+  ...generatedDraft,
+  draftId: "undated-coach",
+  entries: [{ key: "holding", name: "Decide later", sport: "run", saveToLibrary: false, workoutType: "run", conflicts: [], warnings: [] }]
+});
+assert.equal(undatedCoachPlan.startDate, undefined);
+assert.equal(undatedCoachPlan.entries[0].dayIndex, undefined);
+assert.equal(undatedCoachPlan.entries[0].workout.name, "Decide later");
+assert.throws(
+  () => domain.trainingPlanFromDraftPreview({ ...generatedDraft, entries: generatedDraft.entries.slice(0, 3) }, generationRequest),
+  /week 2 has 1 workouts/i
+);
+
+const intensityFamilies = [
+  { type: "none" },
+  { type: "heartRate", lowBpm: 130, highBpm: 145 },
+  { type: "heartRatePercent", basis: "reserve", preset: "aerobicEndurance", zoneId: 2 },
+  { type: "heartRatePercent", basis: "maxHr", lowPercent: 70, highPercent: 80 },
+  { type: "pace", lowSecondsPerKm: 270, highSecondsPerKm: 300, displayUnit: "km" },
+  { type: "effortPace", lowSecondsPerKm: 285, highSecondsPerKm: 315, displayUnit: "mi" },
+  { type: "thresholdPacePercent", preset: "threshold", zoneId: 4 },
+  { type: "effortPacePercent", lowPercent: 88, highPercent: 96 },
+  { type: "ftpPercent", preset: "aerobicPower", zoneId: 3 },
+  { type: "power", lowWatts: 220, highWatts: 260 },
+  { type: "power", preset: "interval", zoneId: 4 },
+  { type: "speed", low: 10, high: 13, unit: "km/h" },
+  { type: "cadence", low: 82, high: 92, unit: "rpm" },
+  { type: "swimStroke", stroke: "individualMedley" },
+  { type: "weight", mode: "bodyweight" },
+  { type: "weight", mode: "weight", value: 50, unit: "lb" },
+  { type: "rpe", value: 8 },
+  { type: "climbGrade", system: "yds", relativeToOnsight: -1 },
+  { type: "climbGrade", system: "font", absoluteGrade: "7A" },
+  { type: "lthrPercent", lowPercent: 90, highPercent: 95, zoneId: 4 }
+];
+const targetSteps = [
+  { kind: "training", name: "Time", target_type: "time", target_duration_seconds: 300 },
+  { kind: "training", name: "Distance", target_type: "distance", target_distance_meters: 1_200 },
+  { kind: "training", name: "Load", target_type: "load", target_load: 50 },
+  { kind: "rest", name: "HR recovery", target_type: "hrRecovery", target_hr_recovery_bpm: 110 },
+  { kind: "training", name: "Open", target_type: "open" },
+  { kind: "training", name: "Reps", target_type: "reps", target_reps: 12, exercise_id: "exercise-1", exercise_name: "Squat", exercise_kind: 2 },
+  { kind: "training", name: "Vert", target_type: "elevationGain", target_elevation_gain_meters: 400 },
+  { kind: "training", name: "Routes", target_type: "routes", target_routes: 5 }
+].map((step, index) => ({ ...step, intensity: intensityFamilies[index] }));
+const remainingIntensitySteps = intensityFamilies.slice(targetSteps.length).map((intensity, index) => ({ kind: "training", name: `Intensity ${index}`, target_type: "time", target_duration_seconds: 60, intensity }));
+const roundTripSource = {
+  key: "typed-round-trip",
+  name: "All typed controls",
+  description: "Keep every target and intensity family.",
+  sport: "swim",
+  sport_options: { poolLength: { value: 25, unit: "yd" }, gradingSystem: "font" },
+  schedule_date: "20260803",
+  sort_no: 4,
+  steps: [...targetSteps, { repeat: 3, name: "Typed repeat", steps: remainingIntensitySteps }]
+};
+const editorDraft = planWorkoutEditor.planWorkoutInputToEditorDraft(roundTripSource);
+const roundTripped = planWorkoutEditor.editorDraftToPlanWorkoutInput(editorDraft, roundTripSource);
+assert.equal(roundTripped.name, roundTripSource.name);
+assert.deepEqual(roundTripped.sport_options, roundTripSource.sport_options);
+assert.deepEqual(roundTripped.steps, roundTripSource.steps);
+assert.equal(roundTripped.schedule_date, "20260803");
+assert.equal(roundTripped.save_to_library, false);
+const linkedEntry = { ...domain.planEntryFromWorkout({ key: "linked", name: "Linked source", sport: "strength" }, 0, 0, "remote-program"), plannedTrainingLoad: 80 };
+const detachedEntry = planWorkoutEditor.replaceTrainingPlanEntryWorkout(linkedEntry, {
+  key: "linked",
+  name: "Edited plan copy",
+  sport: "strength",
+  steps: [{ kind: "training", name: "Deadlift", target_type: "reps", target_reps: 5, exercise_id: "deadlift-1", exercise_name: "Deadlift", exercise_kind: 4, intensity: { type: "weight", mode: "weight", value: 100, unit: "kg" } }]
+});
+assert.equal(detachedEntry.programId, undefined, "editing a linked workout detaches only the plan copy");
+assert.equal(detachedEntry.plannedTrainingLoad, undefined);
+assert.equal(linkedEntry.programId, "remote-program", "the linked source entry remains unchanged");
+assert.equal(detachedEntry.workout.steps[0].exercise_id, "deadlift-1");
+for (const specialistInput of [
+  { key: "pool", name: "Pool", sport: "swim", sport_options: { poolLength: { value: 50, unit: "m" } }, steps: [{ kind: "sendOff", name: "100s", target_type: "distance", target_distance_meters: 100, send_off_seconds: 105, intensity: { type: "swimStroke", stroke: "butterfly" } }] },
+  { key: "climb", name: "Boulders", sport: "bouldering", sport_options: { gradingSystem: "font" }, steps: [{ kind: "training", name: "Limit route", target_type: "routes", target_routes: 4, intensity: { type: "climbGrade", system: "font", absoluteGrade: "7B" } }] }
+]) {
+  const specialistDraft = planWorkoutEditor.planWorkoutInputToEditorDraft(specialistInput);
+  assert.deepEqual(planWorkoutEditor.editorDraftToPlanWorkoutInput(specialistDraft, specialistInput).steps, specialistInput.steps);
+  assert.deepEqual(planWorkoutEditor.editorDraftToPlanWorkoutInput(specialistDraft, specialistInput).sport_options, specialistInput.sport_options);
+}
+
+const calendarPlan = structuredClone(generated);
+calendarPlan.startDate = "2099-08-03";
+calendarPlan.entries = calendarPlan.entries.slice(0, 2).map((entry, index) => ({ ...entry, weekIndex: 0, dayIndex: index * 2 }));
+const projection = library.buildTrainingPlanCalendarProjection(calendarPlan, "2099-08-03", [
+  { planId: "other", idInPlan: "existing", planProgramId: "other-program", happenDay: "20990803", name: "Existing run" }
+], "20990101");
+assert.equal(projection.entries.length, 2);
+assert.equal(projection.entries[1].happenDay, "20990805");
+assert.equal(projection.conflicts[0].existing[0].name, "Existing run");
+const holdingPlan = structuredClone(calendarPlan);
+holdingPlan.entries[0].dayIndex = undefined;
+assert.match(library.buildTrainingPlanCalendarProjection(holdingPlan, "2099-08-03", [], "20990101").blockers[0], /holding area/i);
+assert.throws(() => library.buildTrainingPlanCalendarProjection(calendarPlan, "2099-08-04", [], "20990101"), /Monday/i);
+const revisionBefore = domain.trainingPlanCalendarRevision(calendarPlan);
+calendarPlan.entries[0].title = "Edited after install";
+assert.notEqual(domain.trainingPlanCalendarRevision(calendarPlan), revisionBefore);
 
 const rawNative = {
   id: "remote-1",
@@ -158,6 +330,141 @@ databaseModule.saveTrainingPlanDocument(first, rawNative);
 assert.equal(databaseModule.getTrainingPlanDocument(first.id).name, "Build");
 assert.equal(databaseModule.getNativePlanRawPayload(first.id).unknownFutureField.keep, true);
 assert.equal(db.prepare("SELECT COUNT(*) AS count FROM training_plan_workout_links WHERE plan_id = ?").get(first.id).count, 3);
+
+const installedPlan = structuredClone(calendarPlan);
+installedPlan.id = "plan:installed-test";
+installedPlan.calendarInstalls = [{
+  id: "install-1",
+  startDate: "2099-08-03",
+  planRevision: domain.trainingPlanCalendarRevision(installedPlan),
+  state: "active",
+  lastOperation: "install",
+  occurrences: [{
+    planEntryId: installedPlan.entries[0].id,
+    happenDay: "20990803",
+    schedulePlanId: "owned-schedule",
+    scheduleIdInPlan: "owned-occurrence",
+    planProgramId: "owned-program",
+    createdAt: "2099-08-03T12:00:00.000Z"
+  }],
+  failures: [],
+  createdAt: "2099-08-03T12:00:00.000Z",
+  updatedAt: "2099-08-03T12:00:00.000Z"
+}];
+databaseModule.saveTrainingPlanDocument(installedPlan);
+assert.equal(domain.activeTrainingPlanCalendarInstall(installedPlan, "20990101").id, "install-1");
+assert.match(library.buildTrainingPlanCalendarProjection(installedPlan, "2099-08-03", [], "20990101").blockers[0], /already has an active/i);
+assert.throws(() => library.deleteLocalTrainingPlan(installedPlan.id, true), /future calendar workouts/i);
+
+let mockCalendar = [];
+let mockIdentity = 0;
+const writeOrder = [];
+const appendMockOccurrence = (name, happenDay) => {
+  mockIdentity += 1;
+  mockCalendar.push({
+    planId: `owned-plan-${mockIdentity}`,
+    idInPlan: `owned-id-${mockIdentity}`,
+    planProgramId: `owned-program-${mockIdentity}`,
+    happenDay,
+    name
+  });
+};
+library.setTrainingPlanCalendarAdapterForTests({
+  listScheduled: async (startDay, endDay) => mockCalendar.filter((entry) => entry.happenDay >= startDay && entry.happenDay <= endDay),
+  scheduleLibrary: async (_programId, happenDay) => {
+    writeOrder.push(`library:${happenDay}`);
+    appendMockOccurrence("Uphill repeats", happenDay);
+  },
+  createAndSchedule: async (entry, happenDay) => {
+    writeOrder.push(`embedded:${happenDay}`);
+    appendMockOccurrence(entry.name, happenDay);
+    return {};
+  },
+  removeScheduled: async (entry) => {
+    writeOrder.push(`remove:${entry.planId}:${entry.idInPlan}`);
+    mockCalendar = mockCalendar.filter((candidate) => !(candidate.planId === entry.planId && candidate.idInPlan === entry.idInPlan));
+  }
+});
+const mutationPlan = structuredClone(generated);
+mutationPlan.id = "plan:mutation-test";
+mutationPlan.startDate = "2099-08-03";
+mutationPlan.weekCount = 1;
+mutationPlan.entries = mutationPlan.entries.slice(0, 2).map((entry, index) => ({ ...entry, weekIndex: 0, dayIndex: index * 2 }));
+mutationPlan.entries[0].programId = "linked-library-program";
+mutationPlan.entries[0].workout = { key: "linked", name: "Uphill repeats", sport: "run", save_to_library: false };
+mutationPlan.calendarInstalls = [];
+databaseModule.saveTrainingPlanDocument(mutationPlan);
+mockCalendar.push({ planId: "preexisting", idInPlan: "morning", planProgramId: "morning-program", happenDay: "20990803", name: "Morning recovery" });
+const installPreview = await library.previewTrainingPlanCalendar(mutationPlan.id, "2099-08-03");
+assert.equal(installPreview.conflicts[0].existing[0].name, "Morning recovery");
+const installResult = await library.addTrainingPlanToCalendar(installPreview.previewId, true);
+assert.deepEqual(writeOrder.slice(0, 2), ["library:20990803", "embedded:20990805"], "calendar writes remain serialized in plan order");
+assert.equal(installResult.scheduledCount, 2);
+assert.equal(installResult.failures.length, 0);
+assert.equal(installResult.plan.calendarInstalls[0].occurrences.length, 2);
+assert.equal(installResult.plan.calendarInstalls[0].occurrences[0].scheduleIdInPlan, "owned-id-1");
+assert.equal(mockCalendar.some((entry) => entry.planId === "preexisting"), true, "confirmed conflicts are kept alongside the plan");
+const duplicatePreview = await library.previewTrainingPlanCalendar(mutationPlan.id, "2099-08-03");
+assert.match(duplicatePreview.blockers[0], /already has an active/i);
+
+const installedMutationPlan = databaseModule.getTrainingPlanDocument(mutationPlan.id);
+installedMutationPlan.calendarInstalls[0].occurrences.push({ planEntryId: installedMutationPlan.entries[0].id, happenDay: "20200101", schedulePlanId: "past-owned", scheduleIdInPlan: "past-id", planProgramId: "past-program", createdAt: "2020-01-01T12:00:00.000Z" });
+databaseModule.saveTrainingPlanDocument(installedMutationPlan);
+mockCalendar.push({ planId: "past-owned", idInPlan: "past-id", planProgramId: "past-program", happenDay: "20200101", name: "Past completed workout" });
+mockCalendar = mockCalendar.filter((entry) => !(entry.planId === "owned-plan-1" && entry.idInPlan === "owned-id-1"));
+mockCalendar.push({ planId: "unrelated", idInPlan: "same-name", planProgramId: "unrelated-program", happenDay: "20990803", name: "Uphill repeats" });
+const removalPreview = await library.previewTrainingPlanCalendarRemoval(mutationPlan.id);
+const removalResult = await library.removeTrainingPlanFromCalendar(removalPreview.previewId, true);
+assert.equal(removalResult.removedCount, 1, "already-absent owned occurrences are handled idempotently");
+assert.equal(mockCalendar.some((entry) => entry.planId === "unrelated" && entry.idInPlan === "same-name"), true, "same-name unrelated workouts are preserved");
+assert.equal(mockCalendar.some((entry) => entry.planId === "past-owned"), true, "past owned workouts are preserved");
+assert.equal(databaseModule.getTrainingPlanDocument(mutationPlan.id).calendarInstalls[0].state, "removed");
+
+const stalePlan = structuredClone(mutationPlan);
+stalePlan.id = "plan:stale-preview";
+stalePlan.calendarInstalls = [];
+databaseModule.saveTrainingPlanDocument(stalePlan);
+const stalePreview = await library.previewTrainingPlanCalendar(stalePlan.id, "2099-08-03");
+mockCalendar.push({ planId: "calendar-change", idInPlan: "new", planProgramId: "new-program", happenDay: "20990805", name: "Changed elsewhere" });
+await assert.rejects(library.addTrainingPlanToCalendar(stalePreview.previewId, true), /calendar changed/i);
+const revisionStalePlan = structuredClone(stalePlan);
+revisionStalePlan.id = "plan:revision-stale-preview";
+databaseModule.saveTrainingPlanDocument(revisionStalePlan);
+const revisionStalePreview = await library.previewTrainingPlanCalendar(revisionStalePlan.id, "2099-08-03");
+revisionStalePlan.entries[0].title = "Changed after preview";
+databaseModule.saveTrainingPlanDocument(revisionStalePlan);
+await assert.rejects(library.addTrainingPlanToCalendar(revisionStalePreview.previewId, true), /plan changed/i);
+
+mockCalendar = [];
+const partialPlan = structuredClone(generated);
+partialPlan.id = "plan:partial-install";
+partialPlan.startDate = "2099-08-03";
+partialPlan.weekCount = 1;
+partialPlan.entries = partialPlan.entries.slice(0, 2).map((entry, index) => ({ ...entry, weekIndex: 0, dayIndex: index * 2, programId: undefined }));
+partialPlan.calendarInstalls = [];
+databaseModule.saveTrainingPlanDocument(partialPlan);
+library.setTrainingPlanCalendarAdapterForTests({
+  listScheduled: async (startDay, endDay) => mockCalendar.filter((entry) => entry.happenDay >= startDay && entry.happenDay <= endDay),
+  createAndSchedule: async (entry, happenDay) => {
+    if (entry.name === "Trail strength") throw new Error("mock write failure");
+    appendMockOccurrence(entry.name, happenDay);
+    return {};
+  },
+  removeScheduled: async (entry) => {
+    mockCalendar = mockCalendar.filter((candidate) => !(candidate.planId === entry.planId && candidate.idInPlan === entry.idInPlan));
+  }
+});
+const partialPreview = await library.previewTrainingPlanCalendar(partialPlan.id, "2099-08-03");
+const partialResult = await library.addTrainingPlanToCalendar(partialPreview.previewId, true);
+assert.equal(partialResult.scheduledCount, 1);
+assert.equal(partialResult.failures.length, 1);
+assert.equal(partialResult.plan.calendarInstalls[0].state, "partial");
+assert.equal(partialResult.plan.calendarInstalls[0].occurrences.length, 1, "successful writes persist during a partial install");
+const partialRemovalPreview = await library.previewTrainingPlanCalendarRemoval(partialPlan.id);
+const partialRemoval = await library.removeTrainingPlanFromCalendar(partialRemovalPreview.previewId, true);
+assert.equal(partialRemoval.removedCount, 1, "known occurrences remain removable after a partial install");
+assert.equal(partialRemoval.failures.some((failure) => failure.writeMayHaveSucceeded), true, "unverified writes remain recorded instead of being retried by name");
+library.setTrainingPlanCalendarAdapterForTests();
 
 assert.throws(() => library.deleteLocalTrainingPlan(first.id, false), /confirmation/i);
 assert.throws(() => library.removeTrainingCollection("collection", false), /confirmation/i);

--- a/scripts/test-training-library.mjs
+++ b/scripts/test-training-library.mjs
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import Database from "better-sqlite3";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const distUrl = (file) =>
+  `${pathToFileURL(path.join(repoRoot, "dist-electron", file)).href}?cacheBust=${Date.now()}`;
+
+const domain = await import(distUrl("trainingPlanDomain.js"));
+const adapter = await import(distUrl("corosTrainingPlanAdapter.js"));
+const databaseModule = await import(distUrl("database.js"));
+const library = await import(distUrl("trainingLibraryService.js"));
+
+const makeWorkout = (name, load, seconds = 1_800) => ({
+  key: name.toLowerCase().replaceAll(" ", "-"),
+  name,
+  sport: "run",
+  steps: [
+    {
+      kind: "training",
+      target_type: "time",
+      target_duration_seconds: seconds,
+      target_load: load,
+      intensity: { type: "heartRate", lowBpm: 135, highBpm: 145 }
+    }
+  ]
+});
+
+const first = domain.createTrainingPlan("Build", "local");
+first.weekCount = 2;
+first.startDate = "2026-08-03";
+first.phases = [{ id: "base", name: "Base", kind: "base", startWeek: 1, endWeek: 2 }];
+first.entries = [
+  domain.planEntryFromWorkout(makeWorkout("Easy", 40), 0, 0),
+  domain.planEntryFromWorkout(makeWorkout("Threshold", 80, 2_700), 1, 2),
+  domain.planEntryFromWorkout(makeWorkout("Double", 20), 1, 2)
+];
+
+const shifted = domain.shiftTrainingPlan(first, "2026-08-10");
+assert.equal(shifted.startDate, "2026-08-10");
+assert.equal(shifted.entries[0].workout.schedule_date, "2026-08-10");
+assert.equal(shifted.entries[1].workout.schedule_date, "2026-08-19");
+
+const duplicated = domain.duplicateTrainingPlanWeek(first, 0);
+assert.equal(duplicated.weekCount, 3);
+assert.equal(duplicated.entries.filter((entry) => entry.weekIndex === 1).length, 1);
+assert.notEqual(duplicated.entries[0].id, duplicated.entries.at(-1).id);
+
+const recovery = domain.insertRecoveryWeek(first, 0);
+assert.equal(recovery.weekCount, 3);
+assert.equal(recovery.entries.filter((entry) => entry.weekIndex === 1).length, 0);
+assert.equal(recovery.phases.some((phase) => phase.kind === "recovery"), true);
+
+const reordered = domain.reorderTrainingPlanWeek(first, 0, 1);
+assert.equal(reordered.entries[0].weekIndex, 1);
+assert.equal(reordered.phases.length, 1, "week reordering preserves phase metadata");
+
+const summary = domain.summarizeTrainingPlan(first);
+assert.equal(summary.workouts, 3);
+assert.equal(summary.trainingLoad, 140);
+assert.equal(summary.conflictCount, 1);
+assert.equal(
+  domain.validateTrainingPlan({ ...first, name: "" }).some((issue) => issue.path === "name"),
+  true
+);
+
+const second = structuredClone(first);
+second.id = "plan:second";
+second.name = "Lower load";
+second.entries = [domain.planEntryFromWorkout(makeWorkout("Easy", 20), 0, 0)];
+const comparison = domain.compareTrainingPlans([first, second]);
+assert.deepEqual(comparison.sharedWorkoutNames, ["Easy"]);
+assert.equal(comparison.summaries.length, 2);
+assert.equal(comparison.insights.some((insight) => insight.includes("more estimated training load")), true);
+
+const rawNative = {
+  id: "remote-1",
+  name: "Native Build",
+  overview: "Preserve this plan",
+  totalDay: 14,
+  version: 7,
+  unknownFutureField: { keep: true },
+  entities: [
+    { idInPlan: "entry-1", planProgramId: "pp-1", dayNo: 0, happenDay: "20260803" }
+  ],
+  programs: [
+    {
+      id: "program-1",
+      idInPlan: "entry-1",
+      planProgramId: "pp-1",
+      name: "Native Run",
+      sportType: 1,
+      duration: 2_400,
+      distance: 6_000,
+      trainingLoad: 55,
+      totalSets: 3,
+      opaqueProgramField: "round-trip"
+    }
+  ],
+  weekStages: [{ weekNo: 1, stage: "Base", planTrainingLoad: 55 }]
+};
+const native = adapter.parseNativeCorosPlan(rawNative, "2026-07-29T00:00:00.000Z");
+assert.equal(native.remoteId, "remote-1");
+assert.equal(native.programs[0].planTrainingLoad, 55);
+assert.equal(native.programs[0].planDuration, 2_400);
+assert.equal(native.programs[0].planDistance, 6_000);
+assert.equal(native.programs[0].planSets, 3);
+assert.equal(native.rawPayload.unknownFutureField.keep, true);
+assert.equal(native.sportTypes[0], 1);
+
+const day = new Date(2099, 11, 1, 12, 0, 0).valueOf();
+const scheduled = [
+  { planId: "schedule", idInPlan: "one", planProgramId: "pp", happenDay: "20991201", name: "Easy", sportType: 1, trainingLoad: 40 },
+  { planId: "schedule", idInPlan: "two", planProgramId: "pp2", happenDay: "20991202", name: "Restored", sportType: 1, trainingLoad: 30 }
+];
+const activities = [
+  { activityId: "activity-1", name: "Easy", sportType: 1, startTime: day, duration: 1_800, distance: 5_000, trainingLoad: 38 }
+];
+const matches = library.buildTrainingActivityMatches(scheduled, activities, [], "20991202");
+assert.equal(matches[0].status, "completed");
+assert.equal(matches[0].activityId, "activity-1");
+assert.equal(matches[0].confidence >= 0.9, true);
+assert.equal(matches[1].status, "upcoming");
+const manual = library.buildTrainingActivityMatches(
+  scheduled,
+  activities,
+  [{ ...matches[1], status: "skipped", manual: true }],
+  "21000101"
+);
+assert.equal(manual[1].status, "skipped");
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "coroslink-training-library-"));
+const legacyPath = path.join(tempRoot, "coros-desktop.sqlite");
+const legacy = new Database(legacyPath);
+legacy.exec("CREATE TABLE app_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+legacy.prepare("INSERT INTO app_settings (key, value) VALUES (?, ?)").run("preserved", "yes");
+legacy.close();
+
+const db = databaseModule.initializeDatabase(tempRoot);
+assert.equal(fs.existsSync(path.join(tempRoot, "coroslink.sqlite")), true);
+assert.equal(db.prepare("SELECT value FROM app_settings WHERE key = ?").get("preserved").value, "yes");
+const expectedTables = [
+  "training_plans",
+  "training_workout_metadata",
+  "training_collections",
+  "training_plan_workout_links",
+  "training_activity_matches"
+];
+const tableNames = new Set(
+  db.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all().map((row) => row.name)
+);
+for (const table of expectedTables) assert.equal(tableNames.has(table), true, `${table} was migrated`);
+
+databaseModule.saveTrainingPlanDocument(first, rawNative);
+assert.equal(databaseModule.getTrainingPlanDocument(first.id).name, "Build");
+assert.equal(databaseModule.getNativePlanRawPayload(first.id).unknownFutureField.keep, true);
+assert.equal(db.prepare("SELECT COUNT(*) AS count FROM training_plan_workout_links WHERE plan_id = ?").get(first.id).count, 3);
+
+assert.throws(() => library.deleteLocalTrainingPlan(first.id, false), /confirmation/i);
+assert.throws(() => library.removeTrainingCollection("collection", false), /confirmation/i);
+await assert.rejects(
+  library.deleteTrainingLibraryWorkouts({ programIds: ["remote"], confirmed: false }),
+  /confirmation/i
+);
+assert.equal(library.getNativePlanWriteCapabilities().create, false);
+
+db.close();
+fs.rmSync(tempRoot, { recursive: true, force: true });
+
+console.log("test-training-library: ok");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,8 @@ import {
   X,
 } from "lucide-react";
 import {
+  Component,
+  type ErrorInfo,
   type FormEvent,
   type ReactNode,
   lazy,
@@ -148,6 +150,11 @@ const LazyTrainingHubView = lazy(() =>
     default: TrainingHubView,
   })),
 );
+const LazyTrainingLibraryView = lazy(() =>
+  import("./training-library/TrainingLibraryView").then(({ TrainingLibraryView }) => ({
+    default: TrainingLibraryView,
+  })),
+);
 const LazyStrengthView = lazy(() =>
   import("./strength/StrengthView").then(({ StrengthView }) => ({
     default: StrengthView,
@@ -174,6 +181,41 @@ function DeferredSurfaceFallback({ label }: { label: string }) {
       <span>Loading {label}…</span>
     </div>
   );
+}
+
+class TrainingLibraryErrorBoundary extends Component<
+  { children: ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null as Error | null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Training Library render failed", error, info);
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children;
+    // Uses the global .empty-state: the library's own stylesheet ships with the
+    // lazy chunk, which may be exactly what failed to load.
+    return (
+      <section className="empty-state" role="alert">
+        <AlertCircle size={28} aria-hidden="true" />
+        <strong>Training Library could not render</strong>
+        <span>{this.state.error.message}</span>
+        <button
+          type="button"
+          className="primary-button"
+          onClick={() => this.setState({ error: null })}
+        >
+          Try again
+        </button>
+      </section>
+    );
+  }
 }
 
 function getLatestReleasePreview(changelog: string): {
@@ -2183,7 +2225,7 @@ export default function App() {
           className={[
             "content",
             isOverviewDashboard && "content-overview",
-            (activeView === "media" || activeView === "coach") && "content-fill",
+            (activeView === "media" || activeView === "coach" || activeView === "library") && "content-fill",
           ]
             .filter(Boolean)
             .join(" ")}
@@ -2366,6 +2408,19 @@ export default function App() {
                   onExportFile={handleTrainingHubExport}
                 />
               </Suspense>
+            ) : null}
+            {activeView === "library" ? (
+              <TrainingLibraryErrorBoundary>
+                <Suspense fallback={<DeferredSurfaceFallback label="Training Library" />}>
+                  <LazyTrainingLibraryView
+                    api={api}
+                    status={trainingHubStatus}
+                    onOpenTraining={() => setActiveView("training")}
+                    onMessage={setMessage}
+                    onError={setError}
+                  />
+                </Suspense>
+              </TrainingLibraryErrorBoundary>
             ) : null}
             {activeView === "strength" ? (
               <Suspense fallback={<DeferredSurfaceFallback label="strength" />}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,7 @@ import type {
   TrainingHubSportType,
   TrainingHubStatus,
   TrainingHubUpcomingWorkout,
+  TrainingPlanDocument,
   WatchStatus,
   WatchTrack,
   WatchTransferProgress,
@@ -311,6 +312,7 @@ export default function App() {
     activeView === "watchfaces",
   );
   const [coachPrefill, setCoachPrefill] = useState<string | null>(null);
+  const [pendingCoachPlan, setPendingCoachPlan] = useState<TrainingPlanDocument | null>(null);
   const [calendarRefreshToken, setCalendarRefreshToken] = useState(0);
   const [activeMediaTab, setActiveMediaTab] = useState<MediaTab>("library");
   const [watchStatus, setWatchStatus] = useState<WatchStatus | null>(null);
@@ -2416,6 +2418,12 @@ export default function App() {
                     api={api}
                     status={trainingHubStatus}
                     onOpenTraining={() => setActiveView("training")}
+                    onOpenCoach={(prompt) => {
+                      setCoachPrefill(prompt ?? null);
+                      setActiveView("coach");
+                    }}
+                    pendingPlan={pendingCoachPlan}
+                    onPendingPlanConsumed={() => setPendingCoachPlan(null)}
                     onMessage={setMessage}
                     onError={setError}
                   />
@@ -2486,6 +2494,10 @@ export default function App() {
                     onPlanUploaded={() => {
                       void loadTrainingHubData();
                       setCalendarRefreshToken((token) => token + 1);
+                    }}
+                    onReviewPlan={(plan) => {
+                      setPendingCoachPlan(plan);
+                      setActiveView("library");
                     }}
                     onActivityChange={setCoachBusy}
                     pendingPrompt={coachPrefill}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,7 @@ import { recentTrainingHubDateList } from "./training/formatters";
 import type { TrainingHubSnapshot } from "./training/types";
 import type { CorosLinkApi } from "./coroslink-api";
 import { AppUpdateControls } from "./components/AppUpdateControls";
+import { DonateButton } from "./components/DonateButton";
 import { UpdateAvailablePrompt } from "./components/UpdateAvailablePrompt";
 import {
   AppSidebar,
@@ -2136,6 +2137,7 @@ export default function App() {
     <div className="app">
       <header className="app-header app-header--slim">
         <div className="app-header-end">
+          <DonateButton />
           <ThemeToggle />
           <StartupViewMenu
             value={startupView}

--- a/src/calendar/AddWorkoutModal.tsx
+++ b/src/calendar/AddWorkoutModal.tsx
@@ -62,6 +62,7 @@ import {
 import { formatHappenDayLabel, getLocalHappenDayKey } from "../training/formatters";
 import { dateFromKey } from "./dateUtils";
 import { ExerciseCombobox, type ExerciseComboboxSelection } from "./ExerciseCombobox";
+import { ExercisePreview } from "./ExercisePreview";
 import {
   CLIMB_GRADES,
   CLIMB_SYSTEM_IDS,
@@ -526,6 +527,13 @@ function builderRowValidationMessage(
     if (!Number.isFinite(Number(row.restSeconds)) || Number(row.restSeconds) < 0 || Number(row.restSeconds) > 3600) {
       return "Enter rest between 0 and 3600 seconds.";
     }
+  }
+  // An empty added-weight field reads as 0 and would upload a 0 kg step, so
+  // the load has to be stated once "added weight" is the chosen mode.
+  if (row.intensityType === "weight"
+    && row.intensityPreset === "weight"
+    && !(Number(row.intensityLow) > 0)) {
+    return `Enter the added weight in ${unitSystem === "imperial" ? "lb" : "kg"}.`;
   }
   if (sport === "hyrox" && row.exerciseName.trim() && !row.exerciseId) {
     return exerciseOptions.length === 0
@@ -997,6 +1005,287 @@ function BuilderIntensityFields({ row, sport, context, exerciseOptions, exercise
   </div>;
 }
 
+/** Rest lengths lifters actually reach for; anything else goes in the field. */
+const STRENGTH_REST_PRESETS = [30, 45, 60, 90, 120] as const;
+
+/** Rest chips read as one clock format so they scan as a single scale. */
+function formatRestChip(seconds: number): string {
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
+}
+
+function formatStrengthClock(totalSeconds: number): string {
+  const seconds = Math.max(0, Math.round(totalSeconds));
+  if (seconds < 60) return `${seconds} sec`;
+  const minutes = Math.floor(seconds / 60);
+  const remainder = seconds % 60;
+  return remainder === 0 ? `${minutes} min` : `${minutes}:${String(remainder).padStart(2, "0")}`;
+}
+
+/** How the load slot is set, folding the intensity type and its mode into one. */
+type StrengthLoadMode = "bodyweight" | "added" | "unspecified";
+
+function strengthLoadMode(row: BuilderRow): StrengthLoadMode {
+  if (row.intensityType === "none") return "unspecified";
+  return row.intensityPreset === "weight" ? "added" : "bodyweight";
+}
+
+/**
+ * A strength set is written the way lifters write it — sets × work @ load,
+ * then rest — so the editor is that line rather than a column of look-alike
+ * fields. Everything COROS accepts for a Strength training step (reps or
+ * seconds or a manual end, bodyweight or added load, sets, rest) lives here.
+ */
+function BuilderStrengthStepFields({
+  row,
+  exerciseOptions,
+  exercisesLoading,
+  allowedKinds,
+  kindLabel,
+  validationMessage,
+  onChange,
+  onKindChange
+}: {
+  row: BuilderRow;
+  exerciseOptions: WorkoutExerciseOption[];
+  exercisesLoading: boolean;
+  allowedKinds: readonly BuilderKind[];
+  kindLabel: string;
+  validationMessage?: string;
+  onChange: (update: Partial<BuilderRow>) => void;
+  onKindChange: (kind: BuilderKind) => void;
+}) {
+  const { unitSystem } = useUnitSystem();
+  const targetTypes = workoutTargetsForStep("strength", "training", row.exerciseKind);
+  const selectedExercise = row.exerciseId
+    ? exerciseOptions.find((option) => option.id === row.exerciseId)
+    : undefined;
+  const loadMode = strengthLoadMode(row);
+  const weightUnit = unitSystem === "imperial" ? "lb" : "kg";
+  const restSeconds = Number(row.restSeconds);
+  const sets = Number(row.sets);
+  const perSet = row.targetType === "time" ? Number(row.timeMin) : Number(row.distanceKm);
+
+  const measureLabels: Partial<Record<BuilderRow["targetType"], string>> = {
+    reps: "reps",
+    time: "seconds",
+    open: "to lap button"
+  };
+
+  // Only worth saying once the sets multiply into something you can't read
+  // straight off the line above.
+  const restTotal = Number.isFinite(restSeconds) && sets > 1
+    ? Math.max(0, restSeconds) * (sets - 1)
+    : 0;
+  const readout = !(sets > 1)
+    ? undefined
+    : row.targetType === "reps" && perSet > 0
+      ? `${sets * perSet} reps in total${restTotal > 0 ? `, ${formatStrengthClock(restTotal)} resting` : ""}`
+      : row.targetType === "time" && perSet > 0
+        ? `About ${formatStrengthClock(sets * perSet + restTotal)} in total`
+        : row.targetType === "open" && restTotal > 0
+          ? `${formatStrengthClock(restTotal)} resting in total`
+          : undefined;
+
+  const changeMeasure = (targetType: BuilderRow["targetType"]) => {
+    if (targetType === row.targetType) return;
+    const update: Partial<BuilderRow> = { targetType };
+    // Seed the field the new measure reads from so the step stays valid.
+    if (targetType === "reps" && !(Number(row.distanceKm) > 0)) update.distanceKm = "10";
+    if (targetType === "time" && !(Number(row.timeMin) > 0)) update.timeMin = "30";
+    onChange(update);
+  };
+
+  const changeLoadMode = (mode: StrengthLoadMode) => {
+    if (mode === "unspecified") {
+      onChange({ intensityType: "none", intensityPreset: "" });
+      return;
+    }
+    if (mode === "bodyweight") {
+      onChange({ intensityType: "weight", intensityPreset: "bodyweight" });
+      return;
+    }
+    onChange({
+      intensityType: "weight",
+      intensityPreset: "weight",
+      intensityUnit: weightUnit,
+      intensityLow: Number(row.intensityLow) > 0 ? row.intensityLow : ""
+    });
+  };
+
+  return (
+    <div className="calendar-builder-row-content strength-step">
+      <div className="strength-step-form">
+        <label className="calendar-builder-control strength-step-kind">
+          <span>{kindLabel}</span>
+          <select value={row.kind} onChange={(event) => onKindChange(event.target.value as BuilderKind)}>
+            {allowedKinds.map((kind) => (
+              <option key={kind} value={kind}>{BUILDER_KIND_META[kind].label}</option>
+            ))}
+          </select>
+        </label>
+
+        <section className="strength-block">
+          <h4>Movement</h4>
+          <ExerciseCombobox
+            value={row.exerciseName}
+            selectedId={row.exerciseId}
+            options={exerciseOptions}
+            placeholder="Search the COROS exercise library"
+            label="Exercise"
+            loading={exercisesLoading}
+            hidePreview
+            onChange={(selection) => onChange({
+              exerciseName: selection.name,
+              exerciseId: selection.id ?? "",
+              exerciseKind: selection.exerciseKind
+            })}
+          />
+          {exercisesLoading ? (
+            <p className="strength-block-note">Loading the COROS exercise library.</p>
+          ) : exerciseOptions.length === 0 ? (
+            <p className="strength-block-note">No exercises loaded. Reconnect COROS to get the library.</p>
+          ) : !row.exerciseId ? (
+            <p className="strength-block-note">Pick one exercise from the list. The watch needs an exact match.</p>
+          ) : null}
+        </section>
+
+        <section className="strength-block">
+          <h4>Prescription</h4>
+          <div className="set-line">
+            <label className="set-line-cell">
+              <span>Sets</span>
+              <input
+                type="number"
+                min="1"
+                max="99"
+                value={row.sets}
+                onChange={(event) => onChange({ sets: event.target.value })}
+              />
+            </label>
+
+            <span className="set-line-operator" aria-hidden="true">×</span>
+
+            <div className="set-line-cell">
+              <span>Per set</span>
+              <div className="set-line-compound">
+                {row.targetType === "open" ? (
+                  <span className="set-line-open">Ends on the lap button</span>
+                ) : (
+                  <input
+                    type="number"
+                    min="1"
+                    max={row.targetType === "reps" ? 500 : undefined}
+                    aria-label={row.targetType === "reps" ? "Repetitions per set" : "Seconds per set"}
+                    value={row.targetType === "time" ? row.timeMin : row.distanceKm}
+                    placeholder={row.targetType === "time" ? "30" : "10"}
+                    onChange={(event) => onChange(
+                      row.targetType === "time"
+                        ? { timeMin: event.target.value }
+                        : { distanceKm: event.target.value }
+                    )}
+                  />
+                )}
+                <select
+                  aria-label="Measure each set by"
+                  value={row.targetType}
+                  onChange={(event) => changeMeasure(event.target.value as BuilderRow["targetType"])}
+                >
+                  {targetTypes.map((target) => (
+                    <option key={target} value={target}>
+                      {measureLabels[target] ?? builderTargetTypeLabel(target)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <span className="set-line-operator" aria-hidden="true">@</span>
+
+            <div className="set-line-cell is-load">
+              <span>Load</span>
+              <div className="set-line-compound">
+                <select
+                  aria-label="Load"
+                  value={loadMode}
+                  onChange={(event) => changeLoadMode(event.target.value as StrengthLoadMode)}
+                >
+                  <option value="bodyweight">Bodyweight</option>
+                  <option value="added">Added weight</option>
+                  <option value="unspecified">Not set</option>
+                </select>
+                {loadMode === "added" ? (
+                  <span className="set-line-weight">
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.5"
+                      aria-label={`Weight in ${weightUnit}`}
+                      placeholder="20"
+                      value={row.intensityLow}
+                      onChange={(event) => onChange({
+                        intensityLow: event.target.value,
+                        intensityUnit: weightUnit
+                      })}
+                    />
+                    <em>{weightUnit}</em>
+                  </span>
+                ) : null}
+              </div>
+            </div>
+          </div>
+          {readout ? <p className="set-line-readout">{readout}</p> : null}
+        </section>
+
+        <section className="strength-block">
+          <h4>Rest between sets</h4>
+          <div className="rest-picker">
+            {STRENGTH_REST_PRESETS.map((preset) => (
+              <button
+                key={preset}
+                type="button"
+                className={restSeconds === preset ? "is-selected" : ""}
+                aria-pressed={restSeconds === preset}
+                onClick={() => onChange({ restSeconds: String(preset) })}
+              >
+                {formatRestChip(preset)}
+              </button>
+            ))}
+            <label className="rest-picker-custom">
+              <input
+                type="number"
+                min="0"
+                max="3600"
+                step="5"
+                aria-label="Rest between sets in seconds"
+                value={row.restSeconds}
+                onChange={(event) => onChange({ restSeconds: event.target.value })}
+              />
+              <em>sec</em>
+            </label>
+          </div>
+        </section>
+
+        {validationMessage ? (
+          <p className="calendar-builder-error" role="alert">
+            <AlertCircle size={13} aria-hidden="true" />
+            <span>{validationMessage}</span>
+          </p>
+        ) : null}
+      </div>
+
+      {selectedExercise ? (
+        <aside className="strength-step-aside">
+          <ExercisePreview
+            option={selectedExercise}
+            name={row.exerciseName}
+            showTargets
+          />
+        </aside>
+      ) : null}
+    </div>
+  );
+}
+
 function BuilderStepFields({
   row,
   sport,
@@ -1031,6 +1320,21 @@ function BuilderStepFields({
     exercisesLoading,
     unitSystem
   );
+
+  if (sport === "strength" && row.kind === "training") {
+    return (
+      <BuilderStrengthStepFields
+        row={row}
+        exerciseOptions={exerciseOptions}
+        exercisesLoading={exercisesLoading}
+        allowedKinds={allowedKinds}
+        kindLabel={kindLabel}
+        validationMessage={validationMessage}
+        onChange={onChange}
+        onKindChange={onKindChange}
+      />
+    );
+  }
 
   return (
     <div className={`calendar-builder-row-content ${usesExerciseWorkspace ? "has-exercise-workspace" : ""}`}>
@@ -1467,6 +1771,7 @@ export function AddWorkoutModal({
   // Log activity
   const [activitySportId, setActivitySportId] = useState(DEFAULT_LOG_SPORT_OPTION.id);
   const [activitySportSearch, setActivitySportSearch] = useState("");
+  const [activitySportSearchOpen, setActivitySportSearchOpen] = useState(false);
   const [activityTime, setActivityTime] = useState(() =>
     dateKey === todayKey
       ? new Date(Date.now() - 3_600_000).toTimeString().slice(0, 5)
@@ -1616,12 +1921,10 @@ export function AddWorkoutModal({
   }, [activitySportSearch, combinedSportOptions, selectedActivitySport]);
 
   const showActivityDistance = selectedActivitySport.distanceUnit !== "none";
-  const activityDistanceLabel =
+  const activityDistanceUnit =
     selectedActivitySport.distanceUnit === "m"
-      ? `Distance (${swimDistanceUnit(unitSystem)})`
-      : `Distance (${distanceUnit(unitSystem)})`;
-  const activityDistancePlaceholder =
-    selectedActivitySport.distanceUnit === "m" ? "1500" : "0";
+      ? swimDistanceUnit(unitSystem)
+      : distanceUnit(unitSystem);
 
   const run = async (action: () => Promise<void>, successMessage: string) => {
     setSubmitting(true);
@@ -2483,24 +2786,44 @@ export function AddWorkoutModal({
 
           {tab === "activity" ? (
             <div className="calendar-modal-body calendar-activity-body">
-              <div
-                className="calendar-activity-sport-picker"
+              <section
+                className="calendar-activity-section calendar-activity-sport-picker"
                 role="group"
                 aria-label="Activity type"
               >
-                <label className="calendar-field calendar-sport-search">
-                  <span>Activity type</span>
+                <div className="calendar-activity-section-head">
+                  <h4>Activity type</h4>
+                  <button
+                    type="button"
+                    className="calendar-activity-search-toggle"
+                    aria-expanded={activitySportSearchOpen}
+                    disabled={submitting}
+                    onClick={() => {
+                      setActivitySportSearchOpen((open) => {
+                        if (open) setActivitySportSearch("");
+                        return !open;
+                      });
+                    }}
+                  >
+                    <Search size={12} aria-hidden="true" />
+                    {activitySportSearchOpen ? "Hide search" : "Search all types"}
+                  </button>
+                </div>
+
+                {activitySportSearchOpen ? (
                   <span className="calendar-sport-search-control">
                     <Search size={14} aria-hidden="true" />
                     <input
                       type="text"
+                      aria-label="Search activity types"
                       value={activitySportSearch}
                       onChange={(event) => setActivitySportSearch(event.target.value)}
-                      placeholder="Search activity types"
+                      placeholder="Rowing, pilates, indoor bike…"
                       disabled={submitting}
+                      autoFocus
                     />
                   </span>
-                </label>
+                ) : null}
 
                 {visibleSportOptions.length === 0 ? (
                   <p className="calendar-activity-hint">
@@ -2527,85 +2850,113 @@ export function AddWorkoutModal({
                     })}
                   </div>
                 )}
-              </div>
+              </section>
 
-              <div className="calendar-field-row">
-                <label className="calendar-field">
-                  <span>Start time</span>
-                  <input
-                    type="time"
-                    value={activityTime}
-                    onChange={(event) => setActivityTime(event.target.value)}
-                    disabled={submitting}
-                  />
-                </label>
-                <label className="calendar-field">
-                  <span>Hours</span>
-                  <input
-                    type="number"
-                    min="0"
-                    value={activityHours}
-                    onChange={(event) => setActivityHours(event.target.value)}
-                    placeholder="0"
-                    disabled={submitting}
-                  />
-                </label>
-                <label className="calendar-field">
-                  <span>Minutes</span>
-                  <input
-                    type="number"
-                    min="0"
-                    max="59"
-                    value={activityMinutes}
-                    onChange={(event) => setActivityMinutes(event.target.value)}
-                    placeholder="45"
-                    disabled={submitting}
-                  />
-                </label>
-              </div>
-              <div className="calendar-field-row">
-                {showActivityDistance ? (
+              <section className="calendar-activity-section">
+                <h4>When and how long</h4>
+                <div className="calendar-field-row">
                   <label className="calendar-field">
-                    <span>{activityDistanceLabel}</span>
+                    <span>Started at</span>
                     <input
-                      type="number"
-                      min="0"
-                      step={selectedActivitySport.distanceUnit === "m" ? "1" : "0.01"}
-                      value={activityDistance}
-                      onChange={(event) => setActivityDistance(event.target.value)}
-                      placeholder={activityDistancePlaceholder}
+                      type="time"
+                      value={activityTime}
+                      onChange={(event) => setActivityTime(event.target.value)}
                       disabled={submitting}
                     />
                   </label>
-                ) : null}
-                <label className="calendar-field">
-                  <span>Calories (optional)</span>
-                  <input
-                    type="number"
-                    min="0"
-                    value={activityCalories}
-                    onChange={(event) => setActivityCalories(event.target.value)}
-                    placeholder="450"
-                    disabled={submitting}
-                  />
-                </label>
-                <label className="calendar-field">
-                  <span>Avg HR (optional)</span>
-                  <input
-                    type="number"
-                    min="0"
-                    value={activityAvgHr}
-                    onChange={(event) => setActivityAvgHr(event.target.value)}
-                    placeholder="145"
-                    disabled={submitting}
-                  />
-                </label>
-              </div>
-              <p className="calendar-activity-hint">
-                Logs an activity that wasn&apos;t recorded by a device straight to
-                your COROS account.
-              </p>
-              <footer className="calendar-modal-footer">
+                  <div className="calendar-field">
+                    <span>Duration</span>
+                    <div className="calendar-duration-control">
+                      <span className="calendar-duration-part">
+                        <input
+                          type="number"
+                          min="0"
+                          max="23"
+                          aria-label="Duration, hours"
+                          value={activityHours}
+                          onChange={(event) => setActivityHours(event.target.value)}
+                          placeholder="0"
+                          disabled={submitting}
+                        />
+                        <em>h</em>
+                      </span>
+                      <span className="calendar-duration-part">
+                        <input
+                          type="number"
+                          min="0"
+                          max="59"
+                          aria-label="Duration, minutes"
+                          value={activityMinutes}
+                          onChange={(event) => setActivityMinutes(event.target.value)}
+                          placeholder="0"
+                          disabled={submitting}
+                        />
+                        <em>m</em>
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </section>
+
+              {/* Everything below is recalled rather than measured, so the
+                  heading says so once instead of tagging each field. */}
+              <section className="calendar-activity-section">
+                <h4>If you know them</h4>
+                <div className="calendar-field-row">
+                  {showActivityDistance ? (
+                    <label className="calendar-field">
+                      <span>Distance</span>
+                      <span className="calendar-unit-control">
+                        <input
+                          type="number"
+                          min="0"
+                          step={selectedActivitySport.distanceUnit === "m" ? "1" : "0.01"}
+                          value={activityDistance}
+                          onChange={(event) => setActivityDistance(event.target.value)}
+                          placeholder="—"
+                          disabled={submitting}
+                        />
+                        <em>{activityDistanceUnit}</em>
+                      </span>
+                    </label>
+                  ) : null}
+                  <label className="calendar-field">
+                    <span>Calories</span>
+                    <span className="calendar-unit-control">
+                      <input
+                        type="number"
+                        min="0"
+                        value={activityCalories}
+                        onChange={(event) => setActivityCalories(event.target.value)}
+                        placeholder="—"
+                        disabled={submitting}
+                      />
+                      <em>kcal</em>
+                    </span>
+                  </label>
+                  <label className="calendar-field">
+                    <span>Average heart rate</span>
+                    <span className="calendar-unit-control">
+                      <input
+                        type="number"
+                        min="0"
+                        value={activityAvgHr}
+                        onChange={(event) => setActivityAvgHr(event.target.value)}
+                        placeholder="—"
+                        disabled={submitting}
+                      />
+                      <em>bpm</em>
+                    </span>
+                  </label>
+                </div>
+              </section>
+
+              <footer className="calendar-modal-footer calendar-activity-footer">
+                <p className="calendar-activity-hint">
+                  {activityValid
+                    ? "Goes straight to your COROS account."
+                    : "Add a duration to log this activity."}
+                </p>
                 <button
                   type="button"
                   className="primary-button"

--- a/src/calendar/AddWorkoutModal.tsx
+++ b/src/calendar/AddWorkoutModal.tsx
@@ -339,6 +339,7 @@ interface AddWorkoutModalProps {
   onScheduled: (message: string) => void;
   onError: (message: string | null) => void;
   onEditLibrary: (programId: string) => void;
+  libraryOnly?: boolean;
 }
 
 let builderRowId = 0;
@@ -1744,7 +1745,8 @@ export function AddWorkoutModal({
   onClose,
   onScheduled,
   onError,
-  onEditLibrary
+  onEditLibrary,
+  libraryOnly = false
 }: AddWorkoutModalProps) {
   const { unitSystem } = useUnitSystem();
   const reducedMotion = useReducedMotion();
@@ -1752,9 +1754,9 @@ export function AddWorkoutModal({
   // Logging makes no sense for a day that hasn't happened yet, and COROS
   // rejects scheduling in the past — so each side of "today" gets the
   // tab set (and default tab) that can actually succeed.
-  const canLogActivity = dateKey <= todayKey;
+  const canLogActivity = !libraryOnly && dateKey <= todayKey;
   const canSchedule = dateKey >= todayKey;
-  const [tab, setTab] = useState<AddTab>(canSchedule ? "quick" : "activity");
+  const [tab, setTab] = useState<AddTab>(libraryOnly ? "builder" : canSchedule ? "quick" : "activity");
   const [submitting, setSubmitting] = useState(false);
 
   // Quick training
@@ -1985,8 +1987,14 @@ export function AddWorkoutModal({
             : {}),
         steps: rows.flatMap((row) => rowToSteps(row, builderSport, unitSystem))
       };
-      await api.createAndScheduleWorkout(entry, dateKey, unitSystem, builderSave);
-    }, `Scheduled "${builderName.trim() || "Structured Workout"}" on ${formatHappenDayLabel(dateKey)}.`);
+      if (libraryOnly) {
+        await api.createLibraryWorkout(entry, unitSystem);
+      } else {
+        await api.createAndScheduleWorkout(entry, dateKey, unitSystem, builderSave);
+      }
+    }, libraryOnly
+      ? `Saved "${builderName.trim() || "Structured Workout"}" to the Workout Library.`
+      : `Scheduled "${builderName.trim() || "Structured Workout"}" on ${formatHappenDayLabel(dateKey)}.`);
 
   const submitActivity = () =>
     run(async () => {
@@ -2052,7 +2060,7 @@ export function AddWorkoutModal({
   const quickDuration = quickPaceValid
     ? quickWorkoutDuration(quickDistance, quickPace, unitSystem)
     : null;
-  const availableTabs: AddTab[] = [
+  const availableTabs: AddTab[] = libraryOnly ? ["builder"] : [
     ...(canSchedule ? (["quick", "library", "builder"] as AddTab[]) : []),
     ...(canLogActivity ? (["activity"] as AddTab[]) : [])
   ];
@@ -2120,9 +2128,9 @@ export function AddWorkoutModal({
             <div>
               <p className="calendar-modal-date">
                 <CalendarDays size={13} aria-hidden="true" />
-                {formatHappenDayLabel(dateKey)}
+                {libraryOnly ? "Reusable workout" : formatHappenDayLabel(dateKey)}
               </p>
-              <h3 id="add-calendar-title">Add to calendar</h3>
+              <h3 id="add-calendar-title">{libraryOnly ? "Create library workout" : "Add to calendar"}</h3>
             </div>
             <button
               type="button"
@@ -2134,7 +2142,7 @@ export function AddWorkoutModal({
             </button>
           </header>
 
-          <div className="calendar-modal-tabs" role="tablist" aria-label="Add to calendar method">
+          <div className="calendar-modal-tabs" role="tablist" aria-label={libraryOnly ? "Workout creation method" : "Add to calendar method"}>
             {availableTabs.map((id) => {
               const { label, Icon } = ADD_TAB_ITEMS[id];
               return (
@@ -2443,7 +2451,7 @@ export function AddWorkoutModal({
                       placeholder="Add coaching notes or the goal of this workout"
                     />
                   </label>
-                  <label className={`calendar-builder-save-card ${builderSave ? "is-checked" : ""}`}>
+                  {!libraryOnly ? <label className={`calendar-builder-save-card ${builderSave ? "is-checked" : ""}`}>
                     <input
                       type="checkbox"
                       role="switch"
@@ -2461,7 +2469,7 @@ export function AddWorkoutModal({
                     <span className="calendar-builder-save-switch" aria-hidden="true">
                       <span />
                     </span>
-                  </label>
+                  </label> : null}
                 </aside>
 
                 <section className="calendar-builder-canvas" aria-labelledby="calendar-builder-steps-title">
@@ -2734,14 +2742,14 @@ export function AddWorkoutModal({
                 </section>
               </div>
               <footer className="calendar-modal-footer calendar-builder-footer">
-                <label className="calendar-check calendar-builder-footer-save">
+                {!libraryOnly ? <label className="calendar-check calendar-builder-footer-save">
                   <input
                     type="checkbox"
                     checked={builderSave}
                     onChange={(event) => setBuilderSave(event.target.checked)}
                   />
                   Also save to workout library
-                </label>
+                </label> : null}
                 <span className="calendar-builder-totals">
                   <span className="calendar-builder-total">
                     <ListTree size={11} aria-hidden="true" />
@@ -2777,8 +2785,8 @@ export function AddWorkoutModal({
                   disabled={!builderValid || submitting}
                   onClick={() => void submitBuilder()}
                 >
-                  <CalendarPlus size={16} aria-hidden="true" />
-                  {submitting ? "Scheduling…" : "Schedule workout"}
+                  {libraryOnly ? <BookmarkPlus size={16} aria-hidden="true" /> : <CalendarPlus size={16} aria-hidden="true" />}
+                  {submitting ? (libraryOnly ? "Saving…" : "Scheduling…") : (libraryOnly ? "Save workout" : "Schedule workout")}
                 </button>
               </footer>
             </div>

--- a/src/calendar/ExerciseCombobox.tsx
+++ b/src/calendar/ExerciseCombobox.tsx
@@ -1,12 +1,4 @@
-import {
-  AlertCircle,
-  Check,
-  ChevronDown,
-  ChevronLeft,
-  ChevronRight,
-  Search
-} from "lucide-react";
-import { useReducedMotion } from "motion/react";
+import { Check, ChevronDown, Search } from "lucide-react";
 import {
   type KeyboardEvent,
   type ReactNode,
@@ -19,6 +11,7 @@ import {
 import { createPortal } from "react-dom";
 import type { WorkoutExerciseOption } from "../../electron/types";
 import { resolveExerciseName } from "../training/exerciseNames";
+import { ExercisePreview } from "./ExercisePreview";
 
 export interface ExerciseComboboxSelection {
   name: string;
@@ -35,6 +28,8 @@ interface ExerciseComboboxProps {
   loading?: boolean;
   disabled?: boolean;
   details?: ReactNode;
+  /** Suppress the built-in demonstration plate when the host renders its own. */
+  hidePreview?: boolean;
   onChange: (selection: ExerciseComboboxSelection) => void;
 }
 
@@ -69,6 +64,7 @@ export function ExerciseCombobox({
   loading = false,
   disabled = false,
   details,
+  hidePreview = false,
   onChange
 }: ExerciseComboboxProps) {
   const id = useId();
@@ -76,10 +72,7 @@ export function ExerciseCombobox({
   const inputShellRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const reducedMotion = useReducedMotion();
   const [isOpen, setIsOpen] = useState(false);
-  const [previewMediaIndex, setPreviewMediaIndex] = useState(0);
-  const [previewStatus, setPreviewStatus] = useState<"loading" | "ready" | "error">("loading");
   const [query, setQuery] = useState(value);
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [menuPosition, setMenuPosition] = useState<ExerciseMenuPosition>();
@@ -92,11 +85,8 @@ export function ExerciseCombobox({
     () => labeledOptions.find((option) => option.id === selectedId),
     [labeledOptions, selectedId]
   );
-  const previewMedia = useMemo(
-    () => selectedOption?.media?.filter((entry) => entry.videoUrl) ?? [],
-    [selectedOption]
-  );
-  const activePreviewMedia = previewMedia[previewMediaIndex] ?? previewMedia[0];
+  const hasPreview = !hidePreview
+    && Boolean(selectedOption?.media?.some((entry) => entry.videoUrl));
 
   const filteredOptions = useMemo(() => {
     const term = normalizeSearch(query);
@@ -119,15 +109,6 @@ export function ExerciseCombobox({
     const selectedIndex = filteredOptions.findIndex((option) => option.id === selectedId);
     setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
   }, [filteredOptions, isOpen, selectedId]);
-
-  useEffect(() => {
-    setPreviewMediaIndex(0);
-    setPreviewStatus("loading");
-  }, [selectedId]);
-
-  useEffect(() => {
-    setPreviewStatus("loading");
-  }, [activePreviewMedia?.videoUrl]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -224,7 +205,7 @@ export function ExerciseCombobox({
 
   return (
     <div
-      className={`exercise-combobox ${activePreviewMedia?.videoUrl ? "has-inline-video" : ""}`}
+      className={`exercise-combobox ${hasPreview ? "has-inline-video" : ""}`}
       ref={rootRef}
     >
       <div className="exercise-combobox-picker">
@@ -332,64 +313,11 @@ export function ExerciseCombobox({
         {details ? <div className="exercise-combobox-details">{details}</div> : null}
       </div>
 
-      {activePreviewMedia?.videoUrl ? (
-        <section className="exercise-inline-video" aria-label={`${selectedOption?.label ?? "Exercise"} movement demonstration`}>
-          <header className="exercise-inline-video-header">
-            <div>
-              <strong>{selectedOption?.label}</strong>
-              <span>Movement demonstration</span>
-            </div>
-            {previewMedia.length > 1 ? (
-              <div className="exercise-inline-video-actions">
-                <button
-                  type="button"
-                  aria-label="Previous movement angle"
-                  onClick={() => setPreviewMediaIndex((current) => (current - 1 + previewMedia.length) % previewMedia.length)}
-                >
-                  <ChevronLeft size={15} aria-hidden="true" />
-                </button>
-                <span>{previewMediaIndex + 1} / {previewMedia.length}</span>
-                <button
-                  type="button"
-                  aria-label="Next movement angle"
-                  onClick={() => setPreviewMediaIndex((current) => (current + 1) % previewMedia.length)}
-                >
-                  <ChevronRight size={15} aria-hidden="true" />
-                </button>
-              </div>
-            ) : null}
-          </header>
-          <div className="exercise-inline-video-stage">
-            {previewStatus === "loading" ? (
-              <div className="exercise-inline-video-loading" role="status">
-                <span aria-hidden="true" />
-                <strong>Loading movement</strong>
-              </div>
-            ) : null}
-            {previewStatus === "error" ? (
-              <div className="exercise-inline-video-error" role="alert">
-                <AlertCircle size={21} aria-hidden="true" />
-                <strong>Video unavailable</strong>
-                <span>Try another angle.</span>
-              </div>
-            ) : null}
-            <video
-              key={activePreviewMedia.videoUrl}
-              className={previewStatus === "ready" ? "is-ready" : ""}
-              src={activePreviewMedia.videoUrl}
-              poster={activePreviewMedia.coverUrl ?? selectedOption?.thumbnailUrl}
-              controls
-              autoPlay={!reducedMotion}
-              muted
-              loop={!reducedMotion}
-              playsInline
-              preload="metadata"
-              onLoadedData={() => setPreviewStatus("ready")}
-              onError={() => setPreviewStatus("error")}
-              aria-label={`${selectedOption?.label ?? "Exercise"} demonstration`}
-            />
-          </div>
-        </section>
+      {hasPreview ? (
+        <ExercisePreview
+          option={selectedOption}
+          name={selectedOption?.label ?? ""}
+        />
       ) : null}
     </div>
   );

--- a/src/calendar/ExercisePreview.tsx
+++ b/src/calendar/ExercisePreview.tsx
@@ -1,0 +1,143 @@
+import { AlertCircle, ChevronLeft, ChevronRight } from "lucide-react";
+import { useReducedMotion } from "motion/react";
+import { useEffect, useMemo, useState } from "react";
+import type { WorkoutExerciseOption } from "../../electron/types";
+import { MUSCLE_BY_ID, resolveExerciseTargets } from "../strength/muscles";
+
+interface ExercisePreviewProps {
+  option?: WorkoutExerciseOption;
+  /** Resolved display name; drives both the heading and the muscle lookup. */
+  name: string;
+  /** Show which muscles the movement trains, from the anatomy rule set. */
+  showTargets?: boolean;
+  className?: string;
+}
+
+/** Muscles within this much of the top share are the movement's prime movers. */
+const PRIMARY_SHARE_TOLERANCE = 0.02;
+const MAX_LISTED_MUSCLES = 6;
+
+/**
+ * The movement plate: a demonstration clip, one angle at a time, plus what the
+ * movement trains. COROS ships the clips on a white cyclorama, so the stage is
+ * a light plate rather than a dark well — the video meets its own background
+ * instead of a letterbox.
+ */
+export function ExercisePreview({
+  option,
+  name,
+  showTargets = false,
+  className = ""
+}: ExercisePreviewProps) {
+  const reducedMotion = useReducedMotion();
+  const [angleIndex, setAngleIndex] = useState(0);
+  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+
+  const angles = useMemo(
+    () => option?.media?.filter((entry) => entry.videoUrl) ?? [],
+    [option]
+  );
+  const angle = angles[angleIndex] ?? angles[0];
+
+  const targets = useMemo(
+    () => (showTargets ? resolveExerciseTargets(name) : undefined),
+    [name, showTargets]
+  );
+  const muscles = useMemo(() => {
+    const activations = targets?.activations ?? [];
+    if (activations.length === 0) return [];
+    const top = Math.max(...activations.map((entry) => entry.share));
+    return activations.slice(0, MAX_LISTED_MUSCLES).map((entry) => ({
+      id: entry.muscle,
+      label: MUSCLE_BY_ID[entry.muscle].label,
+      anatomy: MUSCLE_BY_ID[entry.muscle].anatomy,
+      isPrime: entry.share >= top - PRIMARY_SHARE_TOLERANCE
+    }));
+  }, [targets]);
+
+  useEffect(() => {
+    setAngleIndex(0);
+    setStatus("loading");
+  }, [option?.id]);
+
+  useEffect(() => {
+    setStatus("loading");
+  }, [angle?.videoUrl]);
+
+  if (!angle?.videoUrl) return null;
+
+  return (
+    <section
+      className={`exercise-preview ${className}`.trim()}
+      aria-label={`${name || "Exercise"} demonstration`}
+    >
+      <div className="exercise-preview-stage">
+        {status === "loading" ? (
+          <div className="exercise-preview-status" role="status">
+            <span className="exercise-preview-spinner" aria-hidden="true" />
+            <strong>Loading demonstration</strong>
+          </div>
+        ) : null}
+        {status === "error" ? (
+          <div className="exercise-preview-status is-error" role="alert">
+            <AlertCircle size={20} aria-hidden="true" />
+            <strong>Demonstration unavailable</strong>
+            {angles.length > 1 ? <span>Try another angle.</span> : null}
+          </div>
+        ) : null}
+        <video
+          key={angle.videoUrl}
+          className={status === "ready" ? "is-ready" : ""}
+          src={angle.videoUrl}
+          poster={angle.coverUrl ?? option?.thumbnailUrl}
+          controls
+          autoPlay={!reducedMotion}
+          muted
+          loop={!reducedMotion}
+          playsInline
+          preload="metadata"
+          onLoadedData={() => setStatus("ready")}
+          onError={() => setStatus("error")}
+          aria-label={`${name || "Exercise"} demonstration, angle ${angleIndex + 1} of ${angles.length}`}
+        />
+      </div>
+
+      {angles.length > 1 ? (
+        <div className="exercise-preview-angles">
+          <button
+            type="button"
+            aria-label="Show previous angle"
+            onClick={() => setAngleIndex((current) => (current - 1 + angles.length) % angles.length)}
+          >
+            <ChevronLeft size={15} aria-hidden="true" />
+          </button>
+          <span aria-live="polite">Angle {angleIndex + 1} of {angles.length}</span>
+          <button
+            type="button"
+            aria-label="Show next angle"
+            onClick={() => setAngleIndex((current) => (current + 1) % angles.length)}
+          >
+            <ChevronRight size={15} aria-hidden="true" />
+          </button>
+        </div>
+      ) : null}
+
+      {showTargets && targets?.mobility ? (
+        <p className="exercise-preview-note">Mobility work. It carries no training load.</p>
+      ) : null}
+
+      {showTargets && muscles.length > 0 ? (
+        <div className="exercise-preview-targets">
+          <h5>Trains</h5>
+          <ul>
+            {muscles.map((muscle) => (
+              <li key={muscle.id} className={muscle.isPrime ? "is-prime" : ""} title={muscle.anatomy}>
+                {muscle.label}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/calendar/WorkoutEditorModal.tsx
+++ b/src/calendar/WorkoutEditorModal.tsx
@@ -22,9 +22,12 @@ import type {
   RunWorkoutEditorStep,
   RunWorkoutEditorStepKind,
   RunWorkoutEditorTarget,
+  PlanWorkoutEntryInput,
+  TrainingPlanEntry,
   WorkoutEditPreview,
   WorkoutEditRef,
   WorkoutEditSaveResult,
+  WorkoutEditorDocument,
   WorkoutEditorContext,
   WorkoutExerciseOption,
   WorkoutHeartRateBasis,
@@ -32,6 +35,10 @@ import type {
   WorkoutSport
 } from "../../electron/types";
 import type { CorosLinkApi } from "../coroslink-api";
+import {
+  editorDraftToPlanWorkoutInput,
+  planWorkoutInputToEditorDraft
+} from "../../electron/planWorkoutEditor";
 import { useUnitSystem } from "../units/UnitSystemProvider";
 import {
   elevationToMeters,
@@ -58,9 +65,11 @@ import {
 
 interface WorkoutEditorModalProps {
   api: CorosLinkApi;
-  editRef: WorkoutEditRef;
+  editRef?: WorkoutEditRef;
+  planEntry?: TrainingPlanEntry;
   onClose: () => void;
-  onSaved: (result: WorkoutEditSaveResult) => void;
+  onSaved?: (result: WorkoutEditSaveResult) => void;
+  onSavedToPlan?: (workout: PlanWorkoutEntryInput) => void;
   onError: (message: string | null) => void;
 }
 
@@ -206,13 +215,15 @@ function moveItem<T>(items: T[], from: number, to: number): T[] {
 export function WorkoutEditorModal({
   api,
   editRef,
+  planEntry,
   onClose,
   onSaved,
+  onSavedToPlan,
   onError
 }: WorkoutEditorModalProps) {
   const { unitSystem } = useUnitSystem();
   const reducedMotion = useReducedMotion();
-  const [document, setDocument] = useState<Awaited<ReturnType<CorosLinkApi["getWorkoutForEdit"]>> | null>(null);
+  const [document, setDocument] = useState<WorkoutEditorDocument | null>(null);
   const [draft, setDraft] = useState<RunWorkoutEditorDraft | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [preview, setPreview] = useState<WorkoutEditPreview | null>(null);
@@ -223,13 +234,51 @@ export function WorkoutEditorModal({
   const [exerciseOptionsLoading, setExerciseOptionsLoading] = useState(false);
   const [confirmClose, setConfirmClose] = useState(false);
   const previewSequence = useRef(0);
+  const planMode = Boolean(planEntry);
+  const planWorkout = useMemo<PlanWorkoutEntryInput | undefined>(() => {
+    if (!planEntry) return undefined;
+    return planEntry.workout ?? {
+      key: `plan:${planEntry.id}`,
+      name: planEntry.title ?? "Workout",
+      sport: "run",
+      save_to_library: false
+    };
+  }, [planEntry]);
 
   useEffect(() => {
     let cancelled = false;
     setDocument(null);
     setDraft(null);
     setLoadError(null);
-    void api.getWorkoutForEdit(editRef, unitSystem).then((loaded) => {
+    const load = async (): Promise<WorkoutEditorDocument> => {
+      if (!planEntry) {
+        if (!editRef) throw new Error("No workout was selected.");
+        return api.getWorkoutForEdit(editRef, unitSystem);
+      }
+      if (planEntry.programId) {
+        const linked = await api.getWorkoutForEdit(
+          { kind: "library", programId: planEntry.programId },
+          unitSystem
+        );
+        return {
+          ...linked,
+          ref: { kind: "library", programId: planEntry.programId },
+          revision: `plan:${planEntry.id}`,
+          canEdit: true,
+          unsupportedReason: undefined
+        };
+      }
+      if (!planWorkout) throw new Error("This plan entry has no editable workout definition.");
+      const context = await api.getWorkoutEditorContext(unitSystem);
+      return {
+        ref: { kind: "library", programId: `plan:${planEntry.id}` },
+        revision: `plan:${planEntry.id}`,
+        draft: planWorkoutInputToEditorDraft(planWorkout),
+        context,
+        canEdit: true
+      };
+    };
+    void load().then((loaded) => {
       if (!cancelled) {
         setDocument(loaded);
         setDraft(structuredClone(loaded.draft));
@@ -238,7 +287,7 @@ export function WorkoutEditorModal({
       if (!cancelled) setLoadError(cause instanceof Error ? cause.message : String(cause));
     });
     return () => { cancelled = true; };
-  }, [api, editRef, unitSystem]);
+  }, [api, editRef, planEntry, planWorkout, unitSystem]);
 
   useEffect(() => {
     const sport = draft?.sport;
@@ -264,7 +313,7 @@ export function WorkoutEditorModal({
 
   useEffect(() => {
     const sequence = ++previewSequence.current;
-    if (!document || !draft || !document.canEdit || !validation.valid) {
+    if (!document || !draft || !document.canEdit || !validation.valid || planMode || !editRef) {
       setPreview(null);
       setPreviewing(false);
       return;
@@ -291,7 +340,7 @@ export function WorkoutEditorModal({
         });
     }, 500);
     return () => window.clearTimeout(timer);
-  }, [api, document, draft, editRef, unitSystem, validation.valid]);
+  }, [api, document, draft, editRef, planMode, unitSystem, validation.valid]);
 
   const requestClose = useCallback(() => {
     if (dirty && !saving) setConfirmClose(true);
@@ -430,6 +479,12 @@ export function WorkoutEditorModal({
     if (!document || !draft || !validation.valid) return;
     setSaving(true);
     try {
+      if (planMode) {
+        if (!planWorkout || !onSavedToPlan) throw new Error("The plan workout cannot be updated.");
+        onSavedToPlan(editorDraftToPlanWorkoutInput(draft, planWorkout));
+        return;
+      }
+      if (!editRef || !onSaved) throw new Error("The workout editor is missing its save target.");
       const result = await api.saveWorkoutEdit(
         editRef,
         document.revision,
@@ -459,7 +514,7 @@ export function WorkoutEditorModal({
         >
           <header className="workout-editor-header">
             <div>
-              <p className="eyebrow">{editRef.kind === "scheduled" ? "Scheduled occurrence" : "Workout library"}</p>
+              <p className="eyebrow">{planMode ? "Training plan copy" : editRef?.kind === "scheduled" ? "Scheduled occurrence" : "Workout library"}</p>
               <h2 id="workout-editor-title">Edit {draft ? formatWorkoutSport(draft.sport) : "workout"}</h2>
             </div>
             <button type="button" className="icon-button" aria-label="Close workout editor" onClick={requestClose} disabled={saving}>
@@ -597,7 +652,7 @@ export function WorkoutEditorModal({
                   <button type="button" className="ghost-button" onClick={requestClose} disabled={saving}>Cancel</button>
                   <button type="button" className="primary-button" disabled={!document.canEdit || !dirty || !validation.valid || saving} onClick={() => void save()}>
                     {saving ? <LoaderCircle className="is-spinning" size={15} aria-hidden="true" /> : <Save size={15} aria-hidden="true" />}
-                    {saving ? "Saving and verifying..." : "Save"}
+                    {saving ? (planMode ? "Applying..." : "Saving and verifying...") : (planMode ? "Apply to plan" : "Save")}
                   </button>
                 </div>
               </footer>
@@ -606,7 +661,7 @@ export function WorkoutEditorModal({
 
           {confirmClose ? (
             <div className="workout-editor-confirm" role="alertdialog" aria-label="Discard workout changes">
-              <div><strong>Discard unsaved changes?</strong><span>Your edits have not been sent to COROS.</span></div>
+              <div><strong>Discard unsaved changes?</strong><span>{planMode ? "Your edits have not been applied to the plan." : "Your edits have not been sent to COROS."}</span></div>
               <button type="button" className="ghost-button" onClick={() => setConfirmClose(false)}>Keep editing</button>
               <button type="button" className="danger-button" onClick={onClose}>Discard</button>
             </div>

--- a/src/calendar/WorkoutEditorModal.tsx
+++ b/src/calendar/WorkoutEditorModal.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { DragEvent, ReactElement } from "react";
+import { createPortal } from "react-dom";
 import type {
   RunWorkoutEditorDraft,
   RunWorkoutEditorIntensity,
@@ -499,7 +500,7 @@ export function WorkoutEditorModal({
     }
   };
 
-  return (
+  return createPortal(
     <AnimatePresence>
       <motion.div className="workout-editor-backdrop" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
         <motion.section
@@ -668,7 +669,8 @@ export function WorkoutEditorModal({
           ) : null}
         </motion.section>
       </motion.div>
-    </AnimatePresence>
+    </AnimatePresence>,
+    window.document.body
   );
 }
 

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -39,6 +39,8 @@ import type {
   ChatSessionSummary,
   ChatSettings,
   ClaudeCodeStatus,
+  CoachInputChoice,
+  CoachInputPrompt,
   LocalChatConnectionTest,
   LocalChatDiscovery,
   CorosMcpStatus,
@@ -66,6 +68,7 @@ import {
   toPersistedEntries,
   toWireMessages,
   upsertActivityVisualEntry,
+  upsertCoachPromptEntry,
   upsertFitnessTrendEntry,
   upsertHrZoneEntry,
   upsertPlanDraftEntry,
@@ -119,6 +122,84 @@ function AssistantMarkdown({
         {content}
       </ReactMarkdown>
     </div>
+  );
+}
+
+function ThinkingDisclosure({
+  content,
+  live = false
+}: {
+  content: string;
+  live?: boolean;
+}) {
+  return (
+    <details className={`chat-thinking${live ? " chat-thinking-live" : ""}`}>
+      <summary>
+        <span>Thinking</span>
+        {live ? <small><i aria-hidden="true" />Live</small> : null}
+      </summary>
+      <div className="chat-thinking-text">
+        <AssistantMarkdown content={content} />
+      </div>
+    </details>
+  );
+}
+
+function CoachInputCard({
+  prompt,
+  disabled,
+  onChoose,
+  onCustom
+}: {
+  prompt: CoachInputPrompt;
+  disabled: boolean;
+  onChoose: (choice: CoachInputChoice) => void;
+  onCustom: () => void;
+}) {
+  const answered = prompt.answeredAt !== undefined;
+  return (
+    <section
+      className={`chat-coach-prompt${answered ? " is-answered" : ""}`}
+      aria-labelledby={`coach-prompt-${prompt.promptId}`}
+    >
+      <header className="chat-coach-prompt-header">
+        <span className="chat-coach-prompt-status">
+          <MessageCircle size={14} aria-hidden="true" />
+          {answered ? "Answered" : "Waiting for your answer"}
+        </span>
+        <h4 id={`coach-prompt-${prompt.promptId}`}>{prompt.question}</h4>
+      </header>
+      <div className="chat-coach-prompt-choices" role="group" aria-label="Answer choices">
+        {prompt.choices.map((choice, index) => {
+          const selected = prompt.selectedChoiceId === choice.id;
+          return (
+            <button
+              key={choice.id}
+              type="button"
+              className={`chat-coach-prompt-choice${selected ? " is-selected" : ""}`}
+              onClick={() => onChoose(choice)}
+              disabled={disabled || answered}
+            >
+              <span>
+                {choice.label}
+                {!answered && index === 0 ? <em>Recommended</em> : null}
+              </span>
+              {choice.description ? <small>{choice.description}</small> : null}
+            </button>
+          );
+        })}
+      </div>
+      {!answered && prompt.allowCustom ? (
+        <button
+          type="button"
+          className="chat-coach-prompt-custom"
+          onClick={onCustom}
+          disabled={disabled}
+        >
+          Type another answer
+        </button>
+      ) : null}
+    </section>
   );
 }
 
@@ -628,6 +709,13 @@ export function ChatView({
   const activeSessionIdRef = useRef<string | null>(null);
   // Accumulates source info across the current stream's info events.
   const sourceRef = useRef<SourceInfo | null>(null);
+  const thinkingRef = useRef("");
+  // Interaction cards are appended after the assistant's final text so the
+  // question and its choices stay in a natural reading order.
+  const pendingCoachPromptsRef = useRef<CoachInputPrompt[]>([]);
+  // Kept only while a paused Coach turn is resuming, so a failed/cancelled
+  // request can restore the question instead of silently losing it.
+  const resumedCoachPromptRef = useRef<CoachInputPrompt | null>(null);
   const autoDetectLocalRef = useRef(false);
   const claudePollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -649,6 +737,8 @@ export function ChatView({
   const resetEphemeralChatState = () => {
     setUploadedPlans({});
     setDeletedWorkouts({});
+    pendingCoachPromptsRef.current = [];
+    resumedCoachPromptRef.current = null;
   };
 
   const persistHistory = (
@@ -837,27 +927,57 @@ export function ChatView({
   // Subscribe once to the streaming push channels.
   useEffect(() => {
     if (!api) return;
-    const finishStreaming = (finalText: string) => {
+    const restoreResumedCoachPrompt = () => {
+      const originalPrompt = resumedCoachPromptRef.current;
+      resumedCoachPromptRef.current = null;
+      if (!originalPrompt) return;
+      setTimeline((prev) => {
+        const next = prev.map((entry): ChatEntry =>
+          entry.kind === "coachPrompt" &&
+          entry.prompt.promptId === originalPrompt.promptId
+            ? { kind: "coachPrompt", prompt: originalPrompt }
+            : entry
+        );
+        persistHistory(activeSessionIdRef.current, next, true);
+        return next;
+      });
+    };
+    const finishStreaming = (finalText: string, finishReason?: string) => {
       activeRequestIdRef.current = null;
       setStreaming(false);
       setStreamingText("");
       setThinkingText("");
       setActiveTool(null);
       const source = sourceRef.current ?? undefined;
+      const reasoningSummary = thinkingRef.current.trim() || undefined;
+      thinkingRef.current = "";
+      const coachPrompts = pendingCoachPromptsRef.current;
+      pendingCoachPromptsRef.current = [];
       setCurrentSource(null);
       sourceRef.current = null;
-      if (finalText) {
+      if (finishReason === "cancelled") {
+        restoreResumedCoachPrompt();
+        return;
+      }
+      resumedCoachPromptRef.current = null;
+      if (finalText || coachPrompts.length > 0) {
         setTimeline((prev) => {
-          const next: ChatEntry[] = [...prev];
+          let next: ChatEntry[] = [...prev];
           if (source?.mcpError) {
             next.push({ kind: "toolNotice", message: source.mcpError });
           }
-          next.push({
-            kind: "message",
-            role: "assistant",
-            content: finalText,
-            source
-          });
+          if (finalText) {
+            next.push({
+              kind: "message",
+              role: "assistant",
+              content: finalText,
+              source,
+              reasoningSummary
+            });
+          }
+          for (const prompt of coachPrompts) {
+            next = upsertCoachPromptEntry(next, prompt);
+          }
           persistHistory(activeSessionIdRef.current, next, true);
           return next;
         });
@@ -869,7 +989,9 @@ export function ChatView({
         if (payload.requestId !== activeRequestIdRef.current) return;
         setStreamingText("");
         setThinkingText("");
+        thinkingRef.current = "";
         setActiveTool(null);
+        pendingCoachPromptsRef.current = [];
       }),
       api.onChatStreamToken((payload) => {
         if (payload.requestId !== activeRequestIdRef.current) return;
@@ -904,8 +1026,16 @@ export function ChatView({
           if (chatSettings.visualizationsEnabled) {
             setTimeline((prev) => upsertHrZoneEntry(prev, payload.preview));
           }
+        } else if (payload.kind === "coachPrompt") {
+          pendingCoachPromptsRef.current = [
+            ...pendingCoachPromptsRef.current.filter(
+              (prompt) => prompt.promptId !== payload.prompt.promptId
+            ),
+            payload.prompt
+          ];
         } else if (payload.kind === "thinking") {
-          setThinkingText((prev) => prev + payload.delta);
+          thinkingRef.current += payload.delta;
+          setThinkingText(thinkingRef.current);
         } else if (payload.kind === "mcp") {
           setActiveTool(payload.status === "call" ? payload.tool ?? null : null);
           const base: SourceInfo = sourceRef.current ?? {
@@ -930,7 +1060,7 @@ export function ChatView({
       }),
       api.onChatStreamDone((payload) => {
         if (payload.requestId !== activeRequestIdRef.current) return;
-        finishStreaming(payload.fullText);
+        finishStreaming(payload.fullText, payload.finishReason);
       }),
       api.onChatStreamError((payload) => {
         if (payload.requestId !== activeRequestIdRef.current) return;
@@ -938,9 +1068,12 @@ export function ChatView({
         setStreaming(false);
         setStreamingText("");
         setThinkingText("");
+        thinkingRef.current = "";
         setActiveTool(null);
         setCurrentSource(null);
         sourceRef.current = null;
+        pendingCoachPromptsRef.current = [];
+        restoreResumedCoachPrompt();
         onError(payload.message);
         if (payload.authError) {
           setAuthStatus({ signedIn: false });
@@ -1370,8 +1503,10 @@ export function ChatView({
     }
   };
 
-  const handleSend = async () => {
-    const trimmed = input.trim();
+  const sendMessage = async (
+    trimmed: string,
+    answeredPrompt?: { promptId: string; choiceId: string }
+  ) => {
     if (!api || !trimmed || streaming || exportingLatestActivity) return;
     if (isLatestActivityFileRequest(trimmed)) {
       await handleLatestActivityFileRequest(trimmed);
@@ -1398,17 +1533,62 @@ export function ChatView({
         return;
       }
     }
-    const nextEntries: ChatEntry[] = [
-      ...timeline,
-      { kind: "message", role: "user", content: trimmed }
-    ];
+    let answeredPromptIndex = answeredPrompt
+      ? timeline.findIndex(
+          (entry) =>
+            entry.kind === "coachPrompt" &&
+            entry.prompt.promptId === answeredPrompt.promptId &&
+            entry.prompt.answeredAt === undefined
+        )
+      : -1;
+    if (answeredPromptIndex < 0) {
+      for (let index = timeline.length - 1; index >= 0; index -= 1) {
+        const entry = timeline[index];
+        if (entry.kind === "coachPrompt" && entry.prompt.answeredAt === undefined) {
+          answeredPromptIndex = index;
+          break;
+        }
+      }
+    }
+    const promptEntry =
+      answeredPromptIndex >= 0 ? timeline[answeredPromptIndex] : undefined;
+    const originalPrompt =
+      promptEntry?.kind === "coachPrompt" ? promptEntry.prompt : null;
+    const answeredTimeline = timeline.map((entry, index): ChatEntry =>
+      index === answeredPromptIndex && entry.kind === "coachPrompt"
+        ? {
+            kind: "coachPrompt",
+            prompt: {
+              ...entry.prompt,
+              answer: trimmed,
+              answeredAt: Date.now(),
+              selectedChoiceId:
+                answeredPrompt?.promptId === entry.prompt.promptId
+                  ? answeredPrompt.choiceId
+                  : undefined
+            }
+          }
+        : entry
+    );
+    const nextEntries: ChatEntry[] = originalPrompt
+      ? answeredTimeline
+      : [
+          ...answeredTimeline,
+          { kind: "message", role: "user", content: trimmed }
+        ];
     const requestId = crypto.randomUUID();
 
     activeRequestIdRef.current = requestId;
+    resumedCoachPromptRef.current = originalPrompt;
     sourceRef.current = null;
     setCurrentSource(null);
     setTimeline(nextEntries);
-    persistHistory(activeSessionIdRef.current, nextEntries, true);
+    // Keep the unanswered card durable until the resumed turn completes. If
+    // the app closes mid-request, reloading the session can safely offer it
+    // again instead of leaving an answered-but-incomplete invisible entry.
+    if (!originalPrompt) {
+      persistHistory(activeSessionIdRef.current, nextEntries, true);
+    }
     setInput("");
     setStreaming(true);
     setStreamingText("");
@@ -1420,8 +1600,37 @@ export function ChatView({
     } catch (caught) {
       activeRequestIdRef.current = null;
       setStreaming(false);
+      if (originalPrompt) {
+        resumedCoachPromptRef.current = null;
+        const restoredEntries = timeline.map((entry): ChatEntry =>
+          entry.kind === "coachPrompt" &&
+          entry.prompt.promptId === originalPrompt.promptId
+            ? { kind: "coachPrompt", prompt: originalPrompt }
+            : entry
+        );
+        setTimeline(restoredEntries);
+        persistHistory(activeSessionIdRef.current, restoredEntries, true);
+      }
       onError(caught instanceof Error ? caught.message : "Chat request failed.");
     }
+  };
+
+  const handleSend = async () => {
+    await sendMessage(input.trim());
+  };
+
+  const handleCoachPromptChoice = async (
+    prompt: CoachInputPrompt,
+    choice: CoachInputChoice
+  ) => {
+    await sendMessage(choice.response, {
+      promptId: prompt.promptId,
+      choiceId: choice.id
+    });
+  };
+
+  const handleCustomCoachAnswer = () => {
+    inputRef.current?.focus();
   };
 
   const handleStop = () => {
@@ -1564,6 +1773,12 @@ export function ChatView({
   const isChatGptProvider = chatSettings.provider === "chatgpt";
   const localModelConfigured = chatSettings.local.model.trim().length > 0;
   const isBusy = streaming || exportingLatestActivity;
+  const waitingForCoachAnswer = [...timeline]
+    .reverse()
+    .some(
+      (entry) =>
+        entry.kind === "coachPrompt" && entry.prompt.answeredAt === undefined
+    );
   const showLoginGate = isChatGptProvider && !authStatus?.signedIn;
   const showClaudeGate =
     isClaudeProvider && claudeStatus?.state !== "connected";
@@ -1943,6 +2158,32 @@ export function ChatView({
               );
             }
 
+            if (entry.kind === "coachPrompt") {
+              if (entry.prompt.answeredAt !== undefined) {
+                return null;
+              }
+              return (
+                <div
+                  key={entry.prompt.promptId}
+                  className="chat-row chat-row-assistant"
+                >
+                  <div className="chat-avatar chat-avatar-assistant">
+                    <MessageCircle size={16} aria-hidden="true" />
+                  </div>
+                  <div className="chat-bubble chat-bubble-coach-prompt">
+                    <CoachInputCard
+                      prompt={entry.prompt}
+                      disabled={streaming || exportingLatestActivity}
+                      onChoose={(choice) =>
+                        void handleCoachPromptChoice(entry.prompt, choice)
+                      }
+                      onCustom={handleCustomCoachAnswer}
+                    />
+                  </div>
+                </div>
+              );
+            }
+
             if (entry.kind === "planDraft") {
               return (
                 <div
@@ -2053,6 +2294,9 @@ export function ChatView({
                 <div className="chat-bubble">
                   {entry.role === "assistant" ? (
                     <>
+                      {entry.reasoningSummary ? (
+                        <ThinkingDisclosure content={entry.reasoningSummary} />
+                      ) : null}
                       <AssistantMarkdown content={entry.content} />
                       {entry.source ? (
                         <SourceBadge source={entry.source} />
@@ -2071,30 +2315,27 @@ export function ChatView({
               <div className="chat-avatar chat-avatar-assistant">
                 <Sparkles size={16} aria-hidden="true" />
               </div>
-              <div className="chat-bubble">
-                {streamingText && thinkingText ? (
-                  <details className="chat-thinking">
-                    <summary>Thought process</summary>
-                    <p className="chat-thinking-text">{thinkingText}</p>
-                  </details>
-                ) : null}
+              <div className="chat-bubble chat-bubble-streaming">
                 {streamingText ? (
-                  <AssistantMarkdown content={streamingText} streaming />
+                  <>
+                    {thinkingText ? (
+                      <ThinkingDisclosure content={thinkingText} live />
+                    ) : null}
+                    <AssistantMarkdown content={streamingText} streaming />
+                  </>
                 ) : (
                   <div className="chat-stream-pending">
-                    <span className="chat-stream-status">
-                      {activeTool
-                        ? `Using ${activeTool.replace(/_/g, " ")}…`
-                        : thinkingText
-                          ? "Thinking…"
-                          : "Working on it…"}
-                    </span>
+                    {activeTool || !thinkingText ? (
+                      <span className="chat-stream-status">
+                        {activeTool
+                          ? `Using ${activeTool.replace(/_/g, " ")}…`
+                          : resumedCoachPromptRef.current
+                            ? "Resuming plan…"
+                            : "Working on it…"}
+                      </span>
+                    ) : null}
                     {thinkingText ? (
-                      <p className="chat-thinking-preview">
-                        {thinkingText.length > 280
-                          ? `…${thinkingText.slice(-280)}`
-                          : thinkingText}
-                      </p>
+                      <ThinkingDisclosure content={thinkingText} live />
                     ) : null}
                   </div>
                 )}
@@ -2123,7 +2364,11 @@ export function ChatView({
                 value={input}
                 onChange={(event) => setInput(event.target.value)}
                 onKeyDown={handleInputKeyDown}
-                placeholder="Ask your coach…"
+                placeholder={
+                  waitingForCoachAnswer
+                    ? "Type another answer…"
+                    : "Ask your coach…"
+                }
                 rows={1}
                 disabled={exportingLatestActivity}
               />

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -44,6 +44,7 @@ import type {
   McpServerStatus,
   PlanDraftPreview,
   PlanWorkoutEntryInput,
+  TrainingPlanDestination,
   TrainingHubExportResult,
   UploadPlanResult,
   WorkoutIntensityInput,
@@ -262,9 +263,12 @@ function PlanPreviewCard({
   draft: PlanDraftPreview;
   uploading: boolean;
   uploaded?: UploadPlanResult;
-  onUpload: () => void;
+  onUpload: (destination: TrainingPlanDestination) => void;
 }) {
   const { unitSystem } = useUnitSystem();
+  const [destination, setDestination] = useState<TrainingPlanDestination>(
+    "workoutLibrary"
+  );
   const uploadedResult =
     uploaded ??
     (draft.uploadResult
@@ -276,6 +280,44 @@ function PlanPreviewCard({
         }
       : undefined);
   const isUploaded = Boolean(uploadedResult || draft.uploadedAt);
+  const rawDates = draft.entries
+    .map((entry) => entry.source?.schedule_date?.replace(/-/g, ""))
+    .filter((date): date is string => Boolean(date && /^\d{8}$/.test(date)))
+    .sort();
+  const firstDate = rawDates[0];
+  const lastDate = rawDates[rawDates.length - 1];
+  const planWeeks = firstDate && lastDate
+    ? Math.max(
+        1,
+        Math.ceil(
+          (new Date(`${lastDate.slice(0, 4)}-${lastDate.slice(4, 6)}-${lastDate.slice(6, 8)}T12:00:00`).valueOf() -
+            new Date(`${firstDate.slice(0, 4)}-${firstDate.slice(4, 6)}-${firstDate.slice(6, 8)}T12:00:00`).valueOf()) /
+            604_800_000 +
+            1 / 7
+        )
+      )
+    : Math.max(1, Math.ceil(draft.entries.length / 7));
+  const sports = [
+    ...new Set(draft.entries.map((entry) => formatWorkoutSport(entry.sport ?? "run")))
+  ];
+  const unavailableNative =
+    destination === "nativePlan" || destination === "nativePlanAndCalendar";
+  const remoteWrites = destination === "localTemplate"
+    ? []
+    : destination === "workoutLibrary"
+      ? draft.entries.map((entry) => `Create workout “${entry.name}” in COROS`)
+      : destination === "calendar"
+        ? draft.entries
+            .filter((entry) => entry.scheduleDate)
+            .map((entry) => `Schedule “${entry.name}” on ${entry.scheduleDate}`)
+        : [];
+  const destinationLabel: Record<TrainingPlanDestination, string> = {
+    workoutLibrary: "COROS Workout Library",
+    calendar: "COROS Calendar",
+    nativePlan: "COROS Plan Library",
+    localTemplate: "Local CorosLink template",
+    nativePlanAndCalendar: "COROS plan + Calendar"
+  };
 
   return (
     <div className="chat-plan-card">
@@ -331,9 +373,50 @@ function PlanPreviewCard({
           ))}
         </ul>
       ) : null}
+      {!isUploaded ? (
+        <div className="chat-plan-confirmation">
+          <label>
+            <span>Destination</span>
+            <select
+              value={destination}
+              onChange={(event) =>
+                setDestination(event.target.value as TrainingPlanDestination)
+              }
+              disabled={uploading}
+            >
+              <option value="workoutLibrary">Workout Library</option>
+              <option value="calendar">Calendar</option>
+              <option value="nativePlan">Plan Library — unavailable</option>
+              <option value="localTemplate">Local template</option>
+              <option value="nativePlanAndCalendar">Plan + Calendar — unavailable</option>
+            </select>
+          </label>
+          <dl className="chat-plan-facts">
+            <div><dt>Weeks</dt><dd>{planWeeks}</dd></div>
+            <div><dt>Workouts</dt><dd>{draft.entries.length}</dd></div>
+            <div><dt>Sports</dt><dd>{sports.join(", ")}</dd></div>
+            <div><dt>Start</dt><dd>{draft.entries.find((entry) => entry.scheduleDate)?.scheduleDate ?? "Not set"}</dd></div>
+            <div><dt>Conflicts</dt><dd>{draft.conflicts.length}</dd></div>
+            <div><dt>Reused</dt><dd>0</dd></div>
+            <div><dt>Grouped COROS plan</dt><dd>{unavailableNative ? "Unavailable" : "No"}</dd></div>
+          </dl>
+          <div className="chat-plan-write-preview">
+            <strong>Writes after confirmation</strong>
+            {unavailableNative ? (
+              <p>Native plan writes remain gated until COROS create/update payloads can be live-verified safely.</p>
+            ) : remoteWrites.length > 0 ? (
+              <ul>
+                {remoteWrites.map((write, index) => <li key={`${write}-${index}`}>{write}</li>)}
+              </ul>
+            ) : (
+              <p>Local database only. No COROS write.</p>
+            )}
+          </div>
+        </div>
+      ) : null}
       {uploadedResult || isUploaded ? (
         <p className="chat-plan-success">
-          Uploaded —{" "}
+          Saved to {destinationLabel[uploadedResult?.destination ?? draft.uploadResult?.destination ?? destination]} —{" "}
           {uploadedResult?.workoutsScheduled ??
             draft.uploadResult?.workoutsScheduled ??
             0}{" "}
@@ -348,15 +431,15 @@ function PlanPreviewCard({
           <button
             type="button"
             className="chat-plan-upload"
-            onClick={onUpload}
-            disabled={uploading}
+            onClick={() => onUpload(destination)}
+            disabled={uploading || unavailableNative}
           >
             {uploading ? (
               <Loader2 className="chat-spinner" size={14} aria-hidden="true" />
             ) : (
               <Upload size={14} aria-hidden="true" />
             )}
-            Upload to COROS
+            Confirm {destinationLabel[destination]}
           </button>
         </div>
       )}
@@ -1338,12 +1421,15 @@ export function ChatView({
     void api.cancelChat(activeRequestIdRef.current);
   };
 
-  const handleUploadPlanDraft = async (draftId: string) => {
+  const handleUploadPlanDraft = async (
+    draftId: string,
+    destination: TrainingPlanDestination
+  ) => {
     if (!api || uploadingDraftId) return;
     setUploadingDraftId(draftId);
     onError(null);
     try {
-      const result = await api.uploadTrainingPlanDraft(draftId, unitSystem);
+      const result = await api.uploadTrainingPlanDraft(draftId, unitSystem, destination);
       setUploadedPlans((prev) => ({ ...prev, [draftId]: result }));
       setTimeline((prev) => {
         const next = prev.map((entry) =>
@@ -1355,7 +1441,10 @@ export function ChatView({
                   uploadedAt: Date.now(),
                   uploadResult: {
                     workoutsScheduled: result.workoutsScheduled,
-                    workoutsCreated: result.workoutsCreated
+                    workoutsCreated: result.workoutsCreated,
+                    destination: result.destination,
+                    localPlanId: result.localPlanId,
+                    groupedPlanCreated: result.groupedPlanCreated
                   }
                 }
               }
@@ -1850,8 +1939,8 @@ export function ChatView({
                       draft={entry.draft}
                       uploading={uploadingDraftId === entry.draft.draftId}
                       uploaded={uploadedPlans[entry.draft.draftId]}
-                      onUpload={() =>
-                        void handleUploadPlanDraft(entry.draft.draftId)
+                      onUpload={(destination) =>
+                        void handleUploadPlanDraft(entry.draft.draftId, destination)
                       }
                     />
                   </div>

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  BookOpen,
   Database,
   ExternalLink,
   FileDown,
@@ -44,6 +45,7 @@ import type {
   McpServerStatus,
   PlanDraftPreview,
   PlanWorkoutEntryInput,
+  TrainingPlanDocument,
   TrainingPlanDestination,
   TrainingHubExportResult,
   UploadPlanResult,
@@ -52,6 +54,7 @@ import type {
   DeleteWorkoutResult
 } from "../../electron/types";
 import { formatWorkoutSport } from "../../electron/workoutCapabilities";
+import { trainingPlanFromCoachDraftPreview } from "../../electron/trainingPlanDomain";
 import { ActivityVisualCard } from "./ActivityVisualCard";
 import { FitnessTrendCard } from "./FitnessTrendCard";
 import { HrZoneCard } from "./HrZoneCard";
@@ -123,6 +126,7 @@ interface ChatViewProps {
   api: CorosLinkApi | undefined;
   onError: (message: string | null) => void;
   onPlanUploaded?: () => void;
+  onReviewPlan?: (plan: TrainingPlanDocument) => void;
   /** Fires when a coach request is in progress (streaming or exporting). */
   onActivityChange?: (active: boolean) => void;
   /** Text preloaded into the composer (e.g. "Ask Coach" from the calendar). */
@@ -258,12 +262,14 @@ function PlanPreviewCard({
   draft,
   uploading,
   uploaded,
-  onUpload
+  onUpload,
+  onReview
 }: {
   draft: PlanDraftPreview;
   uploading: boolean;
   uploaded?: UploadPlanResult;
   onUpload: (destination: TrainingPlanDestination) => void;
+  onReview?: () => void;
 }) {
   const { unitSystem } = useUnitSystem();
   const [destination, setDestination] = useState<TrainingPlanDestination>(
@@ -428,6 +434,7 @@ function PlanPreviewCard({
         </p>
       ) : (
         <div className="chat-plan-actions">
+          {onReview ? <button type="button" className="chat-plan-review" onClick={onReview} disabled={uploading}><BookOpen size={14} aria-hidden="true" /> Review &amp; save in Training Library</button> : null}
           <button
             type="button"
             className="chat-plan-upload"
@@ -565,6 +572,7 @@ export function ChatView({
   api,
   onError,
   onPlanUploaded,
+  onReviewPlan,
   onActivityChange,
   pendingPrompt,
   onPendingPromptConsumed
@@ -1465,6 +1473,16 @@ export function ChatView({
     }
   };
 
+  const handleReviewPlanDraft = (draft: PlanDraftPreview) => {
+    if (!onReviewPlan) return;
+    try {
+      onError(null);
+      onReviewPlan(trainingPlanFromCoachDraftPreview(draft));
+    } catch (caught) {
+      onError(caught instanceof Error ? caught.message : "The Coach plan could not be opened in the Training Library.");
+    }
+  };
+
   const handleConfirmWorkoutDelete = async (requestId: string) => {
     if (!api || deletingRequestId) return;
     setDeletingRequestId(requestId);
@@ -1942,6 +1960,7 @@ export function ChatView({
                       onUpload={(destination) =>
                         void handleUploadPlanDraft(entry.draft.draftId, destination)
                       }
+                      onReview={onReviewPlan ? () => handleReviewPlanDraft(entry.draft) : undefined}
                     />
                   </div>
                 </div>

--- a/src/chat/chatTypes.ts
+++ b/src/chat/chatTypes.ts
@@ -1,6 +1,7 @@
 import type {
   ActivityVisualPreview,
   ChatMessage,
+  CoachInputPrompt,
   FitnessTrendPreview,
   HrZonePreview,
   PersistedChatEntry,
@@ -22,11 +23,17 @@ export interface ChatMessageEntry {
   role: ChatMessage["role"];
   content: string;
   source?: SourceInfo;
+  reasoningSummary?: string;
 }
 
 export interface ChatPlanDraftEntry {
   kind: "planDraft";
   draft: PlanDraftPreview;
+}
+
+export interface ChatCoachPromptEntry {
+  kind: "coachPrompt";
+  prompt: CoachInputPrompt;
 }
 
 export interface ChatWorkoutDeleteEntry {
@@ -56,6 +63,7 @@ export interface ChatToolNoticeEntry {
 
 export type ChatEntry =
   | ChatMessageEntry
+  | ChatCoachPromptEntry
   | ChatPlanDraftEntry
   | ChatWorkoutDeleteEntry
   | ChatActivityVisualEntry
@@ -87,6 +95,22 @@ export function upsertPlanDraftEntry(
     return next;
   }
   return [...entries, { kind: "planDraft", draft }];
+}
+
+export function upsertCoachPromptEntry(
+  entries: ChatEntry[],
+  prompt: CoachInputPrompt
+): ChatEntry[] {
+  const index = entries.findIndex(
+    (entry) =>
+      entry.kind === "coachPrompt" && entry.prompt.promptId === prompt.promptId
+  );
+  if (index >= 0) {
+    const next = [...entries];
+    next[index] = { kind: "coachPrompt", prompt };
+    return next;
+  }
+  return [...entries, { kind: "coachPrompt", prompt }];
 }
 
 export function upsertWorkoutDeleteEntry(
@@ -158,12 +182,34 @@ export function upsertHrZoneEntry(
 }
 
 export function toWireMessages(entries: ChatEntry[]): ChatMessage[] {
-  return entries
-    .filter((entry): entry is ChatMessageEntry => entry.kind === "message")
-    .map(({ role, content }) => ({ role, content }));
+  return entries.flatMap((entry): ChatMessage[] => {
+    if (entry.kind === "message") {
+      return [{ role: entry.role, content: entry.content }];
+    }
+    if (entry.kind === "coachPrompt") {
+      const choices = entry.prompt.choices
+        .map((choice) => `- ${choice.label}`)
+        .join("\n");
+      const promptMessage: ChatMessage =
+        {
+          role: "assistant",
+          content: `I need the athlete's answer before continuing:\n${entry.prompt.question}\n${choices}`
+        };
+      return entry.prompt.answer
+        ? [
+            promptMessage,
+            { role: "user", content: entry.prompt.answer }
+          ]
+        : [promptMessage];
+    }
+    return [];
+  });
 }
 
 function persistVisualEntry(entry: ChatEntry): PersistedChatEntry | null {
+  if (entry.kind === "coachPrompt") {
+    return { kind: "coachPrompt", prompt: entry.prompt };
+  }
   if (entry.kind === "planDraft") {
     return { kind: "planDraft", draft: entry.draft };
   }
@@ -187,14 +233,15 @@ function persistVisualEntry(entry: ChatEntry): PersistedChatEntry | null {
     };
   }
   if (entry.kind === "message") {
-    return entry.source
-      ? {
-          kind: "message",
-          role: entry.role,
-          content: entry.content,
-          source: entry.source
-        }
-      : { kind: "message", role: entry.role, content: entry.content };
+    return {
+      kind: "message",
+      role: entry.role,
+      content: entry.content,
+      ...(entry.source ? { source: entry.source } : {}),
+      ...(entry.reasoningSummary
+        ? { reasoningSummary: entry.reasoningSummary }
+        : {})
+    };
   }
   return null;
 }
@@ -209,6 +256,10 @@ export function fromPersistedEntries(entries: PersistedChatEntry[]): ChatEntry[]
   const result: ChatEntry[] = [];
 
   for (const entry of entries) {
+    if (entry.kind === "coachPrompt") {
+      result.push({ kind: "coachPrompt", prompt: entry.prompt });
+      continue;
+    }
     if (entry.kind === "planDraft") {
       result.push({ kind: "planDraft", draft: entry.draft });
       continue;
@@ -250,20 +301,15 @@ export function fromPersistedEntries(entries: PersistedChatEntry[]): ChatEntry[]
       result.push({ kind: "hrZoneSummary", preview: entry.preview });
       continue;
     }
-    result.push(
-      entry.source
-        ? {
-            kind: "message",
-            role: entry.role,
-            content: entry.content,
-            source: entry.source
-          }
-        : {
-            kind: "message",
-            role: entry.role,
-            content: entry.content
-          }
-    );
+    result.push({
+      kind: "message",
+      role: entry.role,
+      content: entry.content,
+      ...(entry.source ? { source: entry.source } : {}),
+      ...(entry.reasoningSummary
+        ? { reasoningSummary: entry.reasoningSummary }
+        : {})
+    });
   }
 
   return result;

--- a/src/components/DonateButton.tsx
+++ b/src/components/DonateButton.tsx
@@ -1,0 +1,22 @@
+import { Coffee, Sparkles } from "lucide-react";
+
+const DONATE_URL = "https://www.buymeacoffee.com/addridoa";
+
+export function DonateButton() {
+  return (
+    <a
+      className="donate-button"
+      href={DONATE_URL}
+      target="_blank"
+      rel="noreferrer"
+      aria-label="Donate to support CorosLink"
+      title="Buy me a coffee"
+    >
+      <span className="donate-button-art" aria-hidden="true">
+        <Coffee className="donate-button-cup" size={17} strokeWidth={2.6} />
+        <Sparkles className="donate-button-spark" size={10} strokeWidth={2.8} />
+      </span>
+      <span className="donate-button-label">Donate</span>
+    </a>
+  );
+}

--- a/src/coroslink-api.ts
+++ b/src/coroslink-api.ts
@@ -32,7 +32,10 @@ import type {
   SpotifySyncResult,
   SpotifySyncTrack,
   SpotifySyncUpdate,
+  HevySettingsInput,
+  HevyStatus,
   StrengthHistory,
+  StrengthHistoryRequest,
   TrainingHubActivity,
   TrainingHubActivityDetail,
   TrainingHubActivityFileType,
@@ -54,6 +57,8 @@ import type {
   TrainingLibraryDeleteRequest,
   TrainingLibrarySnapshot,
   TrainingPlanDocument,
+  TrainingPlanCalendarMutationResult,
+  TrainingPlanCalendarPreview,
   TrainingPlanDestination,
   TrainingPlanMetadataPatch,
   WorkoutMetadataPatch,
@@ -369,6 +374,10 @@ export interface CorosLinkApi {
     patch: TrainingPlanMetadataPatch
   ) => Promise<TrainingPlanDocument>;
   deleteLocalTrainingPlan: (id: string, confirmed: boolean) => Promise<void>;
+  previewTrainingPlanCalendar: (planId: string, startDate: string) => Promise<TrainingPlanCalendarPreview>;
+  addTrainingPlanToCalendar: (previewId: string, confirmed: boolean) => Promise<TrainingPlanCalendarMutationResult>;
+  previewTrainingPlanCalendarRemoval: (planId: string) => Promise<TrainingPlanCalendarPreview>;
+  removeTrainingPlanFromCalendar: (previewId: string, confirmed: boolean) => Promise<TrainingPlanCalendarMutationResult>;
   updateWorkoutMetadata: (
     programIds: string[],
     patch: WorkoutMetadataPatch
@@ -463,7 +472,11 @@ export interface CorosLinkApi {
   getRacePredictor: () => Promise<TrainingHubRacePredictor>;
   getTrainingDashboard: () => Promise<TrainingHubDashboard>;
   getDailyMetrics: (dateList: string[]) => Promise<TrainingHubDailyMetrics>;
-  syncStrengthHistory: (days?: number, force?: boolean) => Promise<StrengthHistory>;
+  syncStrengthHistory: (request?: StrengthHistoryRequest) => Promise<StrengthHistory>;
+  getHevyStatus: () => Promise<HevyStatus>;
+  connectHevy: (apiKey: string) => Promise<HevyStatus>;
+  updateHevySettings: (input: HevySettingsInput) => Promise<HevyStatus>;
+  disconnectHevy: () => Promise<void>;
   startRpeBackfill: () => Promise<void>;
   getRpeBackfillStatus: () => Promise<{ pending: number; running: boolean }>;
   getRpeLoadByDay: () => Promise<Record<string, number>>;

--- a/src/coroslink-api.ts
+++ b/src/coroslink-api.ts
@@ -49,6 +49,14 @@ import type {
   TrainingHubUpcomingWorkout,
   TrainingHubScheduledWorkoutEntry,
   TrainingHubLibraryWorkout,
+  TrainingActivityMatch,
+  TrainingCollection,
+  TrainingLibraryDeleteRequest,
+  TrainingLibrarySnapshot,
+  TrainingPlanDocument,
+  TrainingPlanDestination,
+  TrainingPlanMetadataPatch,
+  WorkoutMetadataPatch,
   UnitSystem,
   PlanWorkoutEntryInput,
   RunWorkoutEditorDraft,
@@ -348,6 +356,38 @@ export interface CorosLinkApi {
     endDay: string
   ) => Promise<TrainingHubScheduledWorkoutEntry[]>;
   listLibraryWorkouts: () => Promise<TrainingHubLibraryWorkout[]>;
+  duplicateLibraryWorkout: (
+    programId: string,
+    name: string,
+    targetSportType?: number
+  ) => Promise<TrainingHubLibraryWorkout>;
+  getTrainingLibrarySnapshot: () => Promise<TrainingLibrarySnapshot>;
+  getNativeTrainingPlan: (remoteId: string) => Promise<TrainingPlanDocument>;
+  saveLocalTrainingPlan: (plan: TrainingPlanDocument) => Promise<TrainingPlanDocument>;
+  updateTrainingPlanMetadata: (
+    id: string,
+    patch: TrainingPlanMetadataPatch
+  ) => Promise<TrainingPlanDocument>;
+  deleteLocalTrainingPlan: (id: string, confirmed: boolean) => Promise<void>;
+  updateWorkoutMetadata: (
+    programIds: string[],
+    patch: WorkoutMetadataPatch
+  ) => Promise<void>;
+  saveTrainingCollection: (
+    collection: Pick<TrainingCollection, "id" | "name"> &
+      Partial<Pick<TrainingCollection, "description" | "color">>
+  ) => Promise<TrainingCollection>;
+  deleteTrainingCollection: (id: string, confirmed: boolean) => Promise<void>;
+  deleteTrainingLibraryWorkouts: (
+    request: TrainingLibraryDeleteRequest
+  ) => Promise<string[]>;
+  refreshTrainingActivityMatches: (
+    startDay: string,
+    endDay: string
+  ) => Promise<TrainingActivityMatch[]>;
+  saveManualActivityMatch: (
+    match: TrainingActivityMatch
+  ) => Promise<TrainingActivityMatch>;
   listWorkoutExercises: (sport: WorkoutSport) => Promise<WorkoutExerciseOption[]>;
   getWorkoutEditorContext: (unitSystem: UnitSystem) => Promise<WorkoutEditorContext>;
   getWorkoutForEdit: (
@@ -375,6 +415,10 @@ export interface CorosLinkApi {
     happenDay: string,
     unitSystem: UnitSystem,
     saveToLibrary?: boolean
+  ) => Promise<{ programId?: string }>;
+  createLibraryWorkout: (
+    entry: PlanWorkoutEntryInput,
+    unitSystem: UnitSystem
   ) => Promise<{ programId?: string }>;
   rescheduleWorkout: (
     entry: {
@@ -559,7 +603,8 @@ export interface CorosLinkApi {
   setMcpBearer: (id: string, token: string) => Promise<void>;
   uploadTrainingPlanDraft: (
     draftId: string,
-    unitSystem: UnitSystem
+    unitSystem: UnitSystem,
+    destination?: TrainingPlanDestination
   ) => Promise<UploadPlanResult>;
   confirmWorkoutDelete: (requestId: string) => Promise<DeleteWorkoutResult>;
   setWindowBackground: (color: string) => Promise<void>;

--- a/src/navigation/primaryNav.ts
+++ b/src/navigation/primaryNav.ts
@@ -1,5 +1,6 @@
 import {
   Activity,
+  BookOpen,
   CalendarDays,
   Database,
   Dumbbell,
@@ -16,6 +17,7 @@ export type PrimaryView =
   | "overview"
   | "media"
   | "training"
+  | "library"
   | "strength"
   | "data"
   | "calendar"
@@ -40,6 +42,7 @@ export const PRIMARY_NAV_ITEMS: PrimaryNavItem[] = [
   { id: "maps", label: "Maps", icon: MapIcon, beta: true },
   { id: "watchfaces", label: "Watch Faces", icon: Watch, beta: true },
   { id: "training", label: "Training Hub", icon: Activity },
+  { id: "library", label: "Training Library", icon: BookOpen },
   { id: "strength", label: "Strength", icon: Dumbbell, beta: true },
   { id: "calendar", label: "Calendar", icon: CalendarDays },
   {

--- a/src/strength/ExerciseExplorer.tsx
+++ b/src/strength/ExerciseExplorer.tsx
@@ -139,7 +139,7 @@ function formatVolume(kg: number, unitSystem: UnitSystem, empty = "—"): string
   if (kg <= 0) return empty;
   const display = kilogramsToDisplayWeight(kg, unitSystem);
   if (unitSystem === "metric" && display >= 1000) {
-    return `${(display / 1000).toFixed(display >= 10_000 ? 0 : 1)}t`;
+    return `${(display / 1000).toFixed(display >= 10_000 ? 0 : 1)} tonnes`;
   }
   return `${Math.round(display).toLocaleString()} ${weightUnit(unitSystem)}`;
 }

--- a/src/strength/StrengthView.tsx
+++ b/src/strength/StrengthView.tsx
@@ -8,8 +8,9 @@ import {
 } from "react";
 import {
   Bar,
-  BarChart,
   CartesianGrid,
+  ComposedChart,
+  Line,
   ReferenceLine,
   ResponsiveContainer,
   Tooltip,
@@ -113,6 +114,7 @@ const EMBER = {
     hot: "#f6b04a",
     mid: "#e8813c",
     base: "#d9434b",
+    sets: "#f3dfc4",
     /* The hover column reads as the bar's own warmth turned up, not as the
        shared white wash — which on this chart outshone the bar it marked. */
     cursor: "rgba(232, 129, 60, 0.12)"
@@ -121,6 +123,7 @@ const EMBER = {
     hot: "#d9901c",
     mid: "#cf6a2a",
     base: "#bd3238",
+    sets: "#614b3a",
     cursor: "rgba(207, 106, 42, 0.1)"
   }
 };
@@ -178,7 +181,7 @@ function totalWeightParts(kg: number, unitSystem: UnitSystem): FigurePart[] {
     return [
       {
         value: tonnes >= 10 ? Math.round(tonnes).toLocaleString() : tonnes.toFixed(1),
-        unit: "t"
+        unit: "tonnes"
       }
     ];
   }
@@ -824,7 +827,9 @@ export function StrengthView({
       return String(value);
     }
     return value >= 1000
-      ? `${Math.round(value / 1000)}${unitSystem === "metric" ? "t" : "k"}`
+      ? unitSystem === "metric"
+        ? `${Math.round(value / 1000)} tonnes`
+        : `${Math.round(value / 1000)}k`
       : String(value);
   };
 
@@ -1278,10 +1283,10 @@ export function StrengthView({
           <section className="panel strength-card strength-week-card">
             <div className="strength-card-head">
               <div>
-                <h3>{usesWeights ? "Weight lifted each week" : "Sets each week"}</h3>
+                <h3>{usesWeights ? "Weight lifted and sets each week" : "Sets each week"}</h3>
                 <p>
                   {usesWeights
-                    ? "Every bar is everything you lifted that week."
+                    ? "Bars show total weight lifted; the line tracks your sets."
                     : "Every bar is every set you did that week."}
                 </p>
               </div>
@@ -1314,9 +1319,9 @@ export function StrengthView({
 
             <div className="strength-chart">
               <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
-                <BarChart
+                <ComposedChart
                   data={chartData}
-                  margin={{ top: 6, right: 2, left: -10, bottom: 0 }}
+                  margin={{ top: 6, right: 2, left: 0, bottom: 0 }}
                 >
                   <defs>
                     {/*
@@ -1349,14 +1354,28 @@ export function StrengthView({
                     minTickGap={28}
                   />
                   <YAxis
+                    yAxisId="weight"
                     stroke={colors.text}
                     tickLine={false}
                     axisLine={false}
                     fontSize={11.5}
                     tickMargin={6}
-                    width={52}
+                    width={usesWeights && unitSystem === "metric" ? 82 : 52}
                     tickFormatter={axisFormatter}
                   />
+                  {usesWeights ? (
+                    <YAxis
+                      yAxisId="sets"
+                      orientation="right"
+                      stroke={ember.sets}
+                      tickLine={false}
+                      axisLine={false}
+                      fontSize={11.5}
+                      tickMargin={6}
+                      width={32}
+                      allowDecimals={false}
+                    />
+                  ) : null}
                   <Tooltip
                     content={(props: TooltipContentProps) => {
                       if (!props.active || !props.payload?.length) {
@@ -1388,6 +1407,7 @@ export function StrengthView({
                   />
                   {averageValue > 0 ? (
                     <ReferenceLine
+                      yAxisId="weight"
                       y={averageValue}
                       stroke={colors.text}
                       strokeOpacity={0.45}
@@ -1395,13 +1415,32 @@ export function StrengthView({
                     />
                   ) : null}
                   <Bar
+                    yAxisId="weight"
                     dataKey="value"
                     name={usesWeights ? "Weight lifted" : "Sets"}
                     fill="url(#strengthWeekFill)"
                     radius={[5, 5, 2, 2]}
                     maxBarSize={30}
                   />
-                </BarChart>
+                  {usesWeights ? (
+                    <Line
+                      yAxisId="sets"
+                      type="monotone"
+                      dataKey="sets"
+                      name="Sets"
+                      stroke={ember.sets}
+                      strokeWidth={2}
+                      dot={false}
+                      activeDot={{
+                        r: 4,
+                        fill: ember.sets,
+                        stroke: colors.dotStroke,
+                        strokeWidth: 2
+                      }}
+                      isAnimationActive={false}
+                    />
+                  ) : null}
+                </ComposedChart>
               </ResponsiveContainer>
             </div>
 

--- a/src/strength/StrengthView.tsx
+++ b/src/strength/StrengthView.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent
+} from "react";
 import {
   Bar,
   BarChart,
@@ -14,15 +21,21 @@ import {
   ArrowDownRight,
   ArrowUpRight,
   ChevronRight,
+  ExternalLink,
   FlaskConical,
+  Link2,
   Loader2,
   LockKeyhole,
   Minus,
   RefreshCw,
   RotateCw,
-  Search
+  Search,
+  Settings2,
+  X
 } from "lucide-react";
 import type {
+  HevyStatus,
+  StrengthDataSource,
   StrengthSession,
   TrainingHubStatus,
   UnitSystem
@@ -128,6 +141,26 @@ function formatSessionDate(startTime?: number): string {
     day: "numeric",
     ...(sameYear ? {} : { year: "numeric" })
   });
+}
+
+function formatSyncTime(value?: string): string {
+  if (!value) return "Not synced yet";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? "Not synced yet"
+    : `Last synced ${date.toLocaleString(undefined, {
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit"
+      })}`;
+}
+
+function sessionSourceLabel(session: StrengthSession): string | undefined {
+  if (session.source === "combined") return "Hevy + COROS";
+  if (session.source === "hevy") return "Hevy";
+  if (session.source === "coros") return "COROS";
+  return undefined;
 }
 
 interface FigurePart {
@@ -365,17 +398,25 @@ export function StrengthView({
   showDevelopmentTools = false
 }: StrengthViewProps) {
   const { unitSystem } = useUnitSystem();
-  const connected = Boolean(status?.authenticated);
+  const corosConnected = Boolean(status?.authenticated);
   const { colors } = useChartColors();
   const { theme } = useTheme();
   const ember = theme === "paper" ? EMBER.paper : EMBER.dark;
 
   const [days, setDays] = useState(90);
+  const [source, setSource] = useState<StrengthDataSource>("combined");
+  const [hevyStatus, setHevyStatus] = useState<HevyStatus | null>(null);
+  const [hevyStatusLoading, setHevyStatusLoading] = useState(true);
+  const [hevyDialogOpen, setHevyDialogOpen] = useState(false);
+  const [hevyApiKey, setHevyApiKey] = useState("");
+  const [hevyBusy, setHevyBusy] = useState(false);
+  const [hevyDialogError, setHevyDialogError] = useState<string | null>(null);
   const [loadedSessions, setLoadedSessions] = useState<StrengthSession[]>([]);
   const [sampleMode, setSampleMode] = useState(false);
   const [pending, setPending] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [warnings, setWarnings] = useState<string[]>([]);
   const [view, setView] = useState<BodyView>("front");
   const [viewRequest, setViewRequest] = useState(0);
   const [metric, setMetric] = useState<HeatMetric>("sets");
@@ -387,6 +428,72 @@ export function StrengthView({
   const [figureHover, setFigureHover] = useState<MuscleId | null>(null);
   const [listHover, setListHover] = useState<MuscleId | null>(null);
   const syncSequenceRef = useRef(0);
+  const sourceInitializedRef = useRef(false);
+  const hevyConnected = Boolean(hevyStatus?.connected);
+  const anyConnected = corosConnected || hevyConnected;
+
+  useEffect(() => {
+    let active = true;
+    setHevyStatusLoading(true);
+    api
+      .getHevyStatus()
+      .then((next) => {
+        if (!active) return;
+        setHevyStatus(next);
+        if (!sourceInitializedRef.current) {
+          sourceInitializedRef.current = true;
+          setSource(
+            corosConnected && next.connected
+              ? "combined"
+              : next.connected
+                ? "hevy"
+                : "coros"
+          );
+        }
+      })
+      .catch((caught) => {
+        if (!active) return;
+        setHevyStatus({ connected: false, includeWarmups: false });
+        sourceInitializedRef.current = true;
+        setSource("coros");
+        setError(toErrorMessage(caught));
+      })
+      .finally(() => {
+        if (active) setHevyStatusLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [api, corosConnected]);
+
+  useEffect(() => {
+    if (hevyStatus === null) return;
+    setSource((current) => {
+      if (current === "combined" && corosConnected && hevyConnected) return current;
+      if (current === "coros" && corosConnected) return current;
+      if (current === "hevy" && hevyConnected) return current;
+      return corosConnected && hevyConnected
+        ? "combined"
+        : hevyConnected
+          ? "hevy"
+          : "coros";
+    });
+  }, [corosConnected, hevyConnected, hevyStatus]);
+
+  useEffect(() => {
+    if (source !== "coros" && metric === "time") {
+      setMetric("sets");
+    }
+  }, [metric, source]);
+
+  useEffect(() => {
+    if (!hevyDialogOpen) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !hevyBusy) setHevyDialogOpen(false);
+    };
+    document.addEventListener("keydown", closeOnEscape);
+    return () => document.removeEventListener("keydown", closeOnEscape);
+  }, [hevyBusy, hevyDialogOpen]);
 
   const requestView = useCallback((next: BodyView) => {
     setSelectedMuscle(null);
@@ -418,21 +525,23 @@ export function StrengthView({
 
   const runSync = useCallback(
     async (force: boolean) => {
-      if (!connected) {
+      if (hevyStatusLoading || !anyConnected) {
         return;
       }
 
       const sequence = ++syncSequenceRef.current;
       setLoading(true);
       setError(null);
+      setWarnings([]);
 
       try {
-        let result = await api.syncStrengthHistory(days, force);
+        let result = await api.syncStrengthHistory({ days, force, source });
         if (syncSequenceRef.current !== sequence) {
           return;
         }
         setLoadedSessions(result.sessions);
         setPending(result.pending);
+        setWarnings(result.warnings ?? []);
 
         // Keep draining while COROS still owes us breakdowns; each round
         // repaints the body map so it fills in as the history arrives.
@@ -440,12 +549,17 @@ export function StrengthView({
           if (result.pending <= 0) {
             break;
           }
-          const next = await api.syncStrengthHistory(days, false);
+          const next = await api.syncStrengthHistory({
+            days,
+            force: false,
+            source
+          });
           if (syncSequenceRef.current !== sequence) {
             return;
           }
           setLoadedSessions(next.sessions);
           setPending(next.pending);
+          setWarnings(next.warnings ?? []);
           // A round that fetched nothing means the API is refusing; stop
           // instead of spinning against it.
           if (next.fetched === 0) {
@@ -460,10 +574,13 @@ export function StrengthView({
       } finally {
         if (syncSequenceRef.current === sequence) {
           setLoading(false);
+          if (source !== "coros") {
+            void api.getHevyStatus().then(setHevyStatus).catch(() => undefined);
+          }
         }
       }
     },
-    [api, connected, days]
+    [api, anyConnected, days, hevyStatusLoading, source]
   );
 
   useEffect(() => {
@@ -480,6 +597,68 @@ export function StrengthView({
       setSampleMode(false);
     }
   }, [showDevelopmentTools]);
+
+  const connectHevyAccount = useCallback(
+    async (event: FormEvent) => {
+      event.preventDefault();
+      setHevyBusy(true);
+      setHevyDialogError(null);
+      try {
+        const next = await api.connectHevy(hevyApiKey);
+        setHevyStatus(next);
+        setHevyApiKey("");
+        setSource(corosConnected ? "combined" : "hevy");
+      } catch (caught) {
+        setHevyDialogError(toErrorMessage(caught));
+      } finally {
+        setHevyBusy(false);
+      }
+    },
+    [api, corosConnected, hevyApiKey]
+  );
+
+  const changeWarmupSetting = useCallback(
+    async (includeWarmups: boolean) => {
+      setHevyBusy(true);
+      setHevyDialogError(null);
+      try {
+        const next = await api.updateHevySettings({ includeWarmups });
+        setHevyStatus(next);
+        await runSync(false);
+      } catch (caught) {
+        setHevyDialogError(toErrorMessage(caught));
+      } finally {
+        setHevyBusy(false);
+      }
+    },
+    [api, runSync]
+  );
+
+  const disconnectHevyAccount = useCallback(async () => {
+    if (
+      !window.confirm(
+        "Disconnect Hevy and erase its cached workouts from this device?"
+      )
+    ) {
+      return;
+    }
+    setHevyBusy(true);
+    setHevyDialogError(null);
+    try {
+      syncSequenceRef.current += 1;
+      await api.disconnectHevy();
+      setHevyStatus({ connected: false, includeWarmups: false });
+      setLoadedSessions([]);
+      setWarnings([]);
+      setPending(0);
+      setSource(corosConnected ? "coros" : "hevy");
+      if (!corosConnected) setHevyDialogOpen(false);
+    } catch (caught) {
+      setHevyDialogError(toErrorMessage(caught));
+    } finally {
+      setHevyBusy(false);
+    }
+  }, [api, corosConnected]);
 
   // Sample mode swaps in a generated history so the page can be worked on
   // without a populated account; nothing about it touches the API or the cache.
@@ -664,6 +843,138 @@ export function StrengthView({
     </button>
   ) : null;
 
+  const hevyDialog = hevyDialogOpen ? (
+    <div
+      className="strength-hevy-backdrop"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget && !hevyBusy) {
+          setHevyDialogOpen(false);
+        }
+      }}
+    >
+      <section
+        className="strength-hevy-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="strength-hevy-title"
+      >
+        <header>
+          <div>
+            <p className="eyebrow">Strength source</p>
+            <h2 id="strength-hevy-title">
+              {hevyConnected ? "Hevy connected" : "Connect Hevy"}
+            </h2>
+          </div>
+          <button
+            type="button"
+            className="strength-hevy-close"
+            aria-label="Close Hevy settings"
+            disabled={hevyBusy}
+            onClick={() => setHevyDialogOpen(false)}
+          >
+            <X size={18} aria-hidden="true" />
+          </button>
+        </header>
+
+        {hevyConnected ? (
+          <>
+            <div className="strength-hevy-account">
+              <span className="strength-hevy-mark" aria-hidden="true">H</span>
+              <div>
+                <strong>{hevyStatus?.displayName || "Hevy account"}</strong>
+                <span>{formatSyncTime(hevyStatus?.lastSyncedAt)}</span>
+              </div>
+              {hevyStatus?.profileUrl ? (
+                <a href={hevyStatus.profileUrl} target="_blank" rel="noreferrer">
+                  Profile <ExternalLink size={13} aria-hidden="true" />
+                </a>
+              ) : null}
+            </div>
+            <label className="strength-hevy-toggle">
+              <input
+                type="checkbox"
+                checked={Boolean(hevyStatus?.includeWarmups)}
+                disabled={hevyBusy}
+                onChange={(event) => void changeWarmupSetting(event.target.checked)}
+              />
+              <span>
+                <strong>Include warm-up sets</strong>
+                <small>Count warm-ups in sets, volume, and lift records.</small>
+              </span>
+            </label>
+            <p className="strength-hevy-privacy">
+              CorosLink reads completed workouts only. It never writes to Hevy or
+              sends Hevy workouts to COROS.
+            </p>
+            <footer>
+              <button
+                type="button"
+                className="secondary-button danger"
+                disabled={hevyBusy}
+                onClick={() => void disconnectHevyAccount()}
+              >
+                Disconnect and erase cache
+              </button>
+              <button
+                type="button"
+                className="primary-button"
+                disabled={hevyBusy}
+                onClick={() => setHevyDialogOpen(false)}
+              >
+                Done
+              </button>
+            </footer>
+          </>
+        ) : (
+          <form onSubmit={connectHevyAccount}>
+            <p>
+              Hevy&apos;s developer API requires Hevy Pro. Create a key in your
+              Hevy web settings, then paste it below.
+            </p>
+            <a
+              className="strength-hevy-developer-link"
+              href="https://hevy.com/settings?developer"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Open Hevy developer settings
+              <ExternalLink size={14} aria-hidden="true" />
+            </a>
+            <label className="field">
+              <span>Hevy API key</span>
+              <input
+                type="password"
+                value={hevyApiKey}
+                autoComplete="off"
+                spellCheck={false}
+                placeholder="Paste API key"
+                disabled={hevyBusy}
+                onChange={(event) => setHevyApiKey(event.target.value)}
+              />
+            </label>
+            <p className="strength-hevy-privacy">
+              The key is encrypted with your operating system&apos;s credential
+              storage and is never exposed to the page after connection.
+            </p>
+            <button
+              type="submit"
+              className="primary-button"
+              disabled={hevyBusy || !hevyApiKey.trim()}
+            >
+              {hevyBusy ? <Loader2 className="spin" size={16} aria-hidden="true" /> : <Link2 size={16} aria-hidden="true" />}
+              Connect Hevy
+            </button>
+          </form>
+        )}
+
+        {hevyDialogError ? (
+          <p className="strength-hevy-error" role="alert">{hevyDialogError}</p>
+        ) : null}
+      </section>
+    </div>
+  ) : null;
+
   // The controls only appear once there is something to control: on the
   // connect screen a window picker and a Refresh button would both be dead.
   const renderHeader = (withControls: boolean) => (
@@ -680,9 +991,30 @@ export function StrengthView({
               : `Your lifting from ${activeWindow.phrase}, muscle by muscle.`}
         </p>
       </div>
-      {withControls ? (
-        <div className="strength-header-controls">
-          <div className="strength-window" role="group" aria-label="Time covered">
+      <div className="strength-header-controls">
+        {withControls ? (
+          <>
+          <div className="strength-segment strength-source" role="group" aria-label="Strength source">
+            {(
+              [
+                ["combined", "Combined", !(corosConnected && hevyConnected)],
+                ["hevy", "Hevy", !hevyConnected],
+                ["coros", "COROS", !corosConnected]
+              ] as const
+            ).map(([id, label, disabled]) => (
+              <button
+                key={id}
+                type="button"
+                disabled={disabled}
+                className={source === id ? "is-active" : ""}
+                aria-pressed={source === id}
+                onClick={() => setSource(id)}
+              >
+                <span className="strength-segment-label">{label}</span>
+              </button>
+            ))}
+          </div>
+          <div className="strength-segment strength-window" role="group" aria-label="Time covered">
             {WINDOW_OPTIONS.map((option) => (
               <button
                 key={option.days}
@@ -691,29 +1023,68 @@ export function StrengthView({
                 aria-pressed={days === option.days}
                 onClick={() => setDays(option.days)}
               >
-                {option.label}
+                <span className="strength-segment-label">{option.label}</span>
               </button>
             ))}
           </div>
+          </>
+        ) : null}
+        <div className="strength-header-actions">
+          {withControls ? (
+            <button
+              type="button"
+              className="strength-action"
+              disabled={loading || sampleMode}
+              onClick={() => void runSync(true)}
+            >
+              {loading ? (
+                <Loader2 className="spin" size={14} aria-hidden="true" />
+              ) : (
+                <RefreshCw size={14} aria-hidden="true" />
+              )}
+              Refresh
+            </button>
+          ) : null}
           <button
             type="button"
-            className="strength-refresh"
-            disabled={loading || sampleMode}
-            onClick={() => void runSync(true)}
+            className="strength-action"
+            onClick={() => {
+              setHevyDialogError(null);
+              setHevyDialogOpen(true);
+            }}
           >
-            {loading ? (
-              <Loader2 className="spin" size={14} aria-hidden="true" />
+            {hevyConnected ? (
+              <>
+                <span className="strength-hevy-dot" aria-hidden="true" />
+                <Settings2 size={14} aria-hidden="true" />
+                Hevy
+              </>
             ) : (
-              <RefreshCw size={14} aria-hidden="true" />
+              <>
+                <Link2 size={14} aria-hidden="true" />
+                Connect Hevy
+              </>
             )}
-            Refresh
           </button>
         </div>
-      ) : null}
+      </div>
     </header>
   );
 
-  if (!connected && !sampleMode) {
+  if (hevyStatusLoading && !corosConnected && !sampleMode) {
+    return (
+      <section className="strength-view">
+        {renderHeader(false)}
+        <p className="strength-notice" role="status">
+          <Loader2 className="spin" size={14} aria-hidden="true" />
+          Checking strength connections…
+        </p>
+        {hevyDialog}
+      </section>
+    );
+  }
+
+  if (!anyConnected && !sampleMode) {
     return (
       <section className="strength-view">
         {renderHeader(false)}
@@ -722,19 +1093,30 @@ export function StrengthView({
           <span className="strength-connect-icon" aria-hidden="true">
             <LockKeyhole size={22} />
           </span>
-          <h3>Connect COROS to see your lifting</h3>
+          <h3>Connect a strength source</h3>
           <p>
-            Your gym sessions live in your Training Hub account. Once it&apos;s
-            connected, every set you log appears here.
+            Import completed workouts from Hevy, read sessions from COROS
+            Training Hub, or connect both for one combined history.
           </p>
-          <button type="button" className="primary-button" onClick={onOpenTraining}>
-            Open Training Hub
-          </button>
+          <div className="strength-connect-actions">
+            <button
+              type="button"
+              className="primary-button"
+              onClick={() => setHevyDialogOpen(true)}
+            >
+              <Link2 size={16} aria-hidden="true" />
+              Connect Hevy
+            </button>
+            <button type="button" className="secondary-button" onClick={onOpenTraining}>
+              Open Training Hub
+            </button>
+          </div>
         </section>
 
         {sampleButton ? (
           <div className="strength-sample-cta">{sampleButton}</div>
         ) : null}
+        {hevyDialog}
       </section>
     );
   }
@@ -742,6 +1124,7 @@ export function StrengthView({
   return (
     <section className="strength-view">
       {renderHeader(true)}
+      {hevyDialog}
 
       {sampleMode ? (
         <p className="strength-notice is-sample" role="status">
@@ -758,6 +1141,14 @@ export function StrengthView({
           {error}
         </p>
       ) : null}
+
+      {!sampleMode
+        ? warnings.map((warning) => (
+            <p className="strength-notice is-warning" role="status" key={warning}>
+              {warning} Showing the most recent cached workouts instead.
+            </p>
+          ))
+        : null}
 
       {pending > 0 && !sampleMode ? (
         <p className="strength-notice" role="status">
@@ -809,7 +1200,9 @@ export function StrengthView({
               <RotateCw size={15} aria-hidden="true" />
             </button>
             <div className="strength-segmented is-quiet" role="group" aria-label="Heat metric">
-              {METRIC_OPTIONS.map((option) => (
+              {METRIC_OPTIONS.filter(
+                (option) => source === "coros" || option.id !== "time"
+              ).map((option) => (
                 <button
                   key={option.id}
                   type="button"
@@ -1195,7 +1588,14 @@ export function StrengthView({
                   <li key={session.activityId}>
                     <div className="strength-session-head">
                       <strong>{session.name?.trim() || "Strength session"}</strong>
-                      <span>{formatSessionDate(session.startTime)}</span>
+                      <div className="strength-session-meta">
+                        {sessionSourceLabel(session) ? (
+                          <span className="strength-session-source">
+                            {sessionSourceLabel(session)}
+                          </span>
+                        ) : null}
+                        <span>{formatSessionDate(session.startTime)}</span>
+                      </div>
                     </div>
                     <p className="strength-session-facts">
                       <span>{detail.sets} sets</span>

--- a/src/strength/exerciseExplorerData.ts
+++ b/src/strength/exerciseExplorerData.ts
@@ -1,6 +1,9 @@
 import type { StrengthSession, StrengthSet } from "../../electron/types";
 import { resolveExerciseName } from "../training/exerciseNames";
-import { estimateOneRepMax } from "./strengthAnalytics";
+import {
+  canonicalExerciseDisplayName,
+  estimateOneRepMax
+} from "./strengthAnalytics";
 
 const EPSILON = 0.01;
 
@@ -97,7 +100,9 @@ export function explorerExerciseName(
   rawName: string | undefined
 ): string {
   const resolved = resolveExerciseName(nameKey, rawName);
-  return /^[TS]\d/.test(resolved) ? "Unnamed exercise" : resolved;
+  return /^[TS]\d/.test(resolved)
+    ? "Unnamed exercise"
+    : canonicalExerciseDisplayName(resolved);
 }
 
 function repRangeFor(reps: number): RepRangeDefinition | undefined {

--- a/src/strength/muscles.ts
+++ b/src/strength/muscles.ts
@@ -387,6 +387,53 @@ const targetsCache = new Map<string, ExerciseTargets>();
 
 const NO_TARGETS: ExerciseTargets = { activations: [], mobility: false };
 
+const HEVY_GROUPS: Record<string, MuscleId[]> = {
+  abdominals: ["abs"],
+  shoulders: ["shoulders"],
+  biceps: ["biceps"],
+  triceps: ["triceps"],
+  forearms: ["forearms"],
+  quadriceps: ["quads"],
+  hamstrings: ["hamstrings"],
+  calves: ["calves"],
+  glutes: ["glutes"],
+  abductors: ["glutes"],
+  adductors: ["adductors"],
+  lats: ["lats"],
+  upper_back: ["lats", "traps"],
+  traps: ["traps"],
+  lower_back: ["lowerBack"],
+  chest: ["chest"],
+  neck: ["neck"],
+  full_body: ["chest", "lats", "quads", "glutes", "abs"]
+};
+
+/** Use provider muscle metadata only when the richer name rules cannot resolve. */
+export function resolveProviderMuscleTargets(
+  primary: string | undefined,
+  secondary: string[] | undefined
+): ExerciseTargets {
+  const weights = new Map<MuscleId, number>();
+  for (const muscle of HEVY_GROUPS[primary ?? ""] ?? []) {
+    weights.set(muscle, (weights.get(muscle) ?? 0) + 1);
+  }
+  for (const group of secondary ?? []) {
+    for (const muscle of HEVY_GROUPS[group] ?? []) {
+      weights.set(muscle, (weights.get(muscle) ?? 0) + SECONDARY_WEIGHT);
+    }
+  }
+  const total = [...weights.values()].reduce((sum, weight) => sum + weight, 0);
+  return total <= 0
+    ? NO_TARGETS
+    : {
+        mobility: false,
+        activations: [...weights.entries()].map(([muscle, weight]) => ({
+          muscle,
+          share: weight / total
+        }))
+      };
+}
+
 /**
  * Resolve a display exercise name into weighted muscle activations. Unknown
  * names return no activations rather than a guess, so the body map only ever

--- a/src/strength/strength.css
+++ b/src/strength/strength.css
@@ -197,22 +197,29 @@
 }
 
 /*
- * Window picker. Deliberately not the `.strength-segmented` used inside the
- * body panel: that one is instrument chrome sitting on the figure's stage,
- * this one is page chrome and reads as part of the title line.
+ * Header control cluster. One segmented system for the two view pickers and
+ * a quieter ghost for the actions, so the row reads "choose what you're
+ * looking at, then act on it". The pickers share a container and a height
+ * (38px, matching the actions), and the only warm element is the active
+ * source pill — the page's "work is warm" rule marking the loudest control.
+ * Deliberately not the `.strength-segmented` used inside the body panel:
+ * that one is instrument chrome sitting on the figure's stage.
  */
-.strength-window {
+.strength-segment {
   display: inline-flex;
-  gap: 2px;
+  align-items: center;
+  /* Spacing lives on the bloom's animated margins, not the container's gap,
+     so folded buttons leave no slivers behind. */
+  gap: 0;
   padding: 3px;
-  border: 1px solid var(--sx-edge);
+  border: 1px solid var(--sx-hairline);
   border-radius: var(--radius-pill);
   background: var(--sx-well);
 }
 
-.strength-window button {
-  min-height: 32px;
-  padding: 0 15px;
+.strength-segment button {
+  min-height: 30px;
+  padding: 0 14px;
   border: 0;
   border-radius: var(--radius-pill);
   background: transparent;
@@ -221,13 +228,42 @@
   font-weight: 500;
   letter-spacing: -0.005em;
   white-space: nowrap;
+  overflow: hidden;
+  /* The fold (pointer leaving): one quick, uniform close. The bloom's
+     springier transition replaces this while the group is open. */
   transition:
+    margin-left 0.2s cubic-bezier(0.6, 0.04, 0.3, 1),
+    max-width 0.2s cubic-bezier(0.6, 0.04, 0.3, 1),
+    padding-inline 0.2s cubic-bezier(0.6, 0.04, 0.3, 1),
     background 0.18s ease,
+    box-shadow 0.18s ease,
     color 0.18s ease;
 }
 
-.strength-window button:hover:not(.is-active) {
+.strength-segment button:hover:not(.is-active):not(:disabled) {
   color: var(--text-primary);
+}
+
+.strength-segment button:focus-visible,
+.strength-action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.strength-segment button:disabled {
+  opacity: 0.36;
+  cursor: not-allowed;
+}
+
+/* The source picker decides what the page is about, so its active pill gets
+   the ember; the window picker only filters it and stays neutral. */
+.strength-source button.is-active {
+  background: color-mix(in srgb, var(--sx-ember) 22%, var(--sx-raised));
+  color: var(--text-primary);
+  font-weight: 600;
+  box-shadow:
+    var(--sx-lift),
+    inset 0 0 0 1px color-mix(in srgb, var(--sx-ember) 42%, transparent);
 }
 
 .strength-window button.is-active {
@@ -237,33 +273,160 @@
   box-shadow: var(--sx-lift);
 }
 
-.strength-refresh {
+/*
+ * Both pickers rest folded: just the active choice showing, so the header
+ * reads "Combined · 3 months" instead of seven competing labels. Hovering
+ * blooms the alternatives open; the fold comes the instant the pointer
+ * leaves.
+ *
+ * The bloom keys on :hover and :has(:focus-visible) — deliberately not
+ * :focus-within. A mouse click focuses the clicked button without
+ * :focus-visible, so the group never stays pinned open after the pointer
+ * is gone; tabbing in with a keyboard still blooms it.
+ *
+ * The motion is split on purpose. Entering uses the bloom rule's
+ * transition: a soft spring on the geometry with a left-to-right cascade,
+ * while each label drifts in a beat later on its own transform — so text
+ * is never sliced by the clipping edge. Leaving uses the base rule: one
+ * quick, uniform close, labels gone before the fold reaches them.
+ */
+.strength-segment-label {
+  display: inline-block;
+  transition:
+    opacity 0.1s ease,
+    transform 0.1s ease;
+}
+
+.strength-segment button:not(.is-active) {
+  max-width: 0;
+  margin-left: 0;
+  padding-inline: 0;
+}
+
+.strength-segment button:not(.is-active) .strength-segment-label {
+  opacity: 0;
+  transform: translateX(-5px);
+}
+
+.strength-segment:is(:hover, :has(:focus-visible)) button:not(.is-active) {
+  max-width: 110px;
+  padding-inline: 14px;
+  transition:
+    margin-left 0.36s cubic-bezier(0.32, 1.28, 0.46, 1),
+    max-width 0.36s cubic-bezier(0.32, 1.28, 0.46, 1),
+    padding-inline 0.36s cubic-bezier(0.32, 1.28, 0.46, 1),
+    background 0.18s ease,
+    box-shadow 0.18s ease,
+    color 0.18s ease;
+}
+
+.strength-segment:is(:hover, :has(:focus-visible)) button + button {
+  margin-left: 2px;
+}
+
+/* The bloom cascades: each option opens a beat after the one before it,
+   and its label follows a beat behind that. Delays are listed per property
+   so only the geometry is staggered — hover feedback (background, color)
+   on an already-open option stays instant. */
+.strength-segment:is(:hover, :has(:focus-visible)) button:nth-child(2) {
+  transition-delay: 45ms, 45ms, 45ms, 0s, 0s, 0s;
+}
+
+.strength-segment:is(:hover, :has(:focus-visible)) button:nth-child(3) {
+  transition-delay: 90ms, 90ms, 90ms, 0s, 0s, 0s;
+}
+
+.strength-segment:is(:hover, :has(:focus-visible)) button:nth-child(4) {
+  transition-delay: 135ms, 135ms, 135ms, 0s, 0s, 0s;
+}
+
+.strength-segment:is(:hover, :has(:focus-visible)) button:not(.is-active) .strength-segment-label {
+  opacity: 1;
+  transform: translateX(0);
+  transition:
+    opacity 0.18s ease 90ms,
+    transform 0.3s cubic-bezier(0.22, 0.9, 0.3, 1) 90ms;
+}
+
+.strength-segment:is(:hover, :has(:focus-visible)) button:nth-child(2) .strength-segment-label {
+  transition-delay: 135ms;
+}
+
+.strength-segment:is(:hover, :has(:focus-visible)) button:nth-child(3) .strength-segment-label {
+  transition-delay: 180ms;
+}
+
+.strength-segment:is(:hover, :has(:focus-visible)) button:nth-child(4) .strength-segment-label {
+  transition-delay: 225ms;
+}
+
+/* While a group is open its active pill stays lit as the "you are here"
+   anchor the eye returns to as the row moves: a warmer ember ring for the
+   source, a brighter raise for the neutral window picker. */
+.strength-source:is(:hover, :has(:focus-visible)) button.is-active {
+  box-shadow:
+    var(--sx-lift),
+    inset 0 0 0 1px color-mix(in srgb, var(--sx-ember) 60%, transparent);
+}
+
+.strength-window:is(:hover, :has(:focus-visible)) button.is-active {
+  background: color-mix(in srgb, var(--text-primary) 14%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .strength-segment button,
+  .strength-segment:is(:hover, :has(:focus-visible)) button:not(.is-active),
+  .strength-segment .strength-segment-label,
+  .strength-segment:is(:hover, :has(:focus-visible)) button:not(.is-active) .strength-segment-label {
+    transition: none;
+  }
+}
+
+.strength-header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: 4px;
+}
+
+.strength-action {
   display: inline-flex;
   align-items: center;
   gap: 7px;
   min-height: 38px;
-  padding: 0 16px;
+  padding: 0 15px;
   border: 1px solid var(--sx-edge);
   border-radius: var(--radius-pill);
-  background: var(--sx-well);
+  background: transparent;
   color: var(--text-secondary);
   font-size: 13px;
   font-weight: 500;
   letter-spacing: -0.005em;
+  white-space: nowrap;
   transition:
+    background 0.18s ease,
     border-color 0.18s ease,
-    color 0.18s ease,
-    background 0.18s ease;
+    color 0.18s ease;
 }
 
-.strength-refresh:hover:not(:disabled) {
-  border-color: var(--accent-glow);
-  background: var(--sx-raised);
+.strength-action:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--sx-ember) 38%, var(--sx-edge));
+  background: var(--sx-well);
   color: var(--text-primary);
 }
 
-.strength-refresh:disabled {
+.strength-action:disabled {
   opacity: 0.55;
+}
+
+/* Connection state on the Hevy action: a steady teal heartbeat, the app's
+   own "linked" language, kept tiny so it never competes with the ember. */
+.strength-hevy-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent-glow);
 }
 
 .strength-segmented {
@@ -324,6 +487,12 @@
 }
 
 .strength-notice.is-sample {
+  border-color: var(--warning-border);
+  background: var(--warning-bg);
+  color: var(--warning-text);
+}
+
+.strength-notice.is-warning {
   border-color: var(--warning-border);
   background: var(--warning-bg);
   color: var(--warning-text);
@@ -2690,6 +2859,26 @@
   font-size: 12px;
 }
 
+.strength-session-meta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 7px;
+  flex-shrink: 0;
+}
+
+.strength-session-head .strength-session-source {
+  padding: 2px 7px;
+  border: 1px solid color-mix(in srgb, var(--sport-strength) 24%, transparent);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--sport-strength) 10%, transparent);
+  color: color-mix(in srgb, var(--sport-strength) 72%, var(--text-primary));
+  font-size: 9px;
+  font-weight: 750;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+}
+
 .strength-session-facts {
   display: flex;
   flex-wrap: wrap;
@@ -2783,6 +2972,203 @@
 
 .strength-connect .primary-button {
   margin-top: 12px;
+}
+
+.strength-connect-actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+.strength-connect-actions .primary-button {
+  margin-top: 0;
+}
+
+/* ---------- Hevy connection ---------- */
+
+.strength-hevy-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(4, 7, 10, 0.72);
+  backdrop-filter: blur(10px);
+}
+
+:root[data-theme="paper"] .strength-hevy-backdrop {
+  background: rgba(35, 31, 25, 0.42);
+}
+
+.strength-hevy-dialog {
+  width: min(520px, 100%);
+  max-height: min(720px, calc(100vh - 48px));
+  overflow: auto;
+  padding: 24px;
+  border: 1px solid var(--sx-edge);
+  border-radius: 22px;
+  background: var(--panel-bg-solid, var(--panel-bg));
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.38);
+}
+
+.strength-hevy-dialog > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 22px;
+}
+
+.strength-hevy-dialog .eyebrow {
+  margin: 0 0 5px;
+}
+
+.strength-hevy-dialog h2 {
+  margin: 0;
+  font-size: 24px;
+  letter-spacing: -0.025em;
+}
+
+.strength-hevy-close {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid var(--sx-edge);
+  border-radius: 50%;
+  background: var(--sx-well);
+  color: var(--text-secondary);
+}
+
+.strength-hevy-account {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--sx-hairline);
+  border-radius: 16px;
+  background: var(--sx-well);
+}
+
+.strength-hevy-mark {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border-radius: 12px;
+  background: #1976ff;
+  color: white;
+  font-size: 18px;
+  font-weight: 800;
+}
+
+.strength-hevy-account div {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.strength-hevy-account strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.strength-hevy-account div > span,
+.strength-hevy-dialog form > p,
+.strength-hevy-privacy {
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.strength-hevy-account a,
+.strength-hevy-developer-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--accent);
+  font-size: 12.5px;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.strength-hevy-toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  margin-top: 16px;
+  padding: 14px;
+  border: 1px solid var(--sx-hairline);
+  border-radius: 14px;
+}
+
+.strength-hevy-toggle input {
+  margin-top: 3px;
+}
+
+.strength-hevy-toggle span {
+  display: grid;
+  gap: 3px;
+}
+
+.strength-hevy-toggle small {
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.strength-hevy-dialog form {
+  display: grid;
+  gap: 15px;
+}
+
+.strength-hevy-dialog form > p,
+.strength-hevy-privacy {
+  margin: 0;
+}
+
+.strength-hevy-dialog footer {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.strength-hevy-dialog .danger {
+  color: var(--danger, #e16068);
+}
+
+.strength-hevy-error {
+  margin: 16px 0 0;
+  padding: 10px 12px;
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--danger, #e16068) 12%, transparent);
+  color: var(--danger, #e16068);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+
+@media (max-width: 700px) {
+  .strength-session-head {
+    align-items: flex-start;
+  }
+
+  .strength-session-meta {
+    align-items: flex-end;
+    flex-direction: column-reverse;
+    gap: 4px;
+  }
+
+  .strength-hevy-dialog footer {
+    align-items: stretch;
+    flex-direction: column-reverse;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/strength/strengthAnalytics.ts
+++ b/src/strength/strengthAnalytics.ts
@@ -8,10 +8,19 @@
  * press adds a full set to the chest and a quarter-set to the triceps.
  */
 
-import type { StrengthSession, UnitSystem } from "../../electron/types";
+import type {
+  StrengthExercise,
+  StrengthSession,
+  UnitSystem
+} from "../../electron/types";
 import { resolveExerciseName } from "../training/exerciseNames";
 import { kilogramsToDisplayWeight, weightUnit } from "../units/units";
-import { MUSCLES, resolveExerciseTargets, type MuscleId } from "./muscles";
+import {
+  MUSCLES,
+  resolveExerciseTargets,
+  resolveProviderMuscleTargets,
+  type MuscleId
+} from "./muscles";
 
 /** What the body map shades muscles by. */
 export type HeatMetric = "sets" | "volume" | "time";
@@ -212,9 +221,34 @@ interface ExerciseAccumulator {
  * Resolve a display name for one exercise, falling back to the body region or
  * the raw key when COROS gives us an unmapped code.
  */
+export function canonicalExerciseDisplayName(name: string): string {
+  const suffix = name.match(/\s*\((barbell|dumbbell|machine)\)\s*$/i)?.[1]?.toLowerCase();
+  const base = suffix
+    ? name.replace(/\s*\((barbell|dumbbell|machine)\)\s*$/i, "").trim()
+    : name.trim();
+  if (suffix === "dumbbell" && !/^dumbbell\b/i.test(base)) {
+    return `Dumbbell ${base}`;
+  }
+  if (suffix === "machine" && !/\bmachine\b/i.test(base)) {
+    return `${base} Machine`;
+  }
+  return base || name;
+}
+
 function exerciseDisplayName(nameKey: string, rawName: string | undefined): string {
   const resolved = resolveExerciseName(nameKey, rawName);
-  return /^[TS]\d/.test(resolved) ? "Unnamed exercise" : resolved;
+  return /^[TS]\d/.test(resolved)
+    ? "Unnamed exercise"
+    : canonicalExerciseDisplayName(resolved);
+}
+
+function exerciseTargets(exercise: StrengthExercise, name: string) {
+  const named = resolveExerciseTargets(name);
+  if (named.mobility || named.activations.length > 0) return named;
+  return resolveProviderMuscleTargets(
+    exercise.primaryMuscleGroup,
+    exercise.secondaryMuscleGroups
+  );
 }
 
 export function buildStrengthAnalytics(
@@ -272,7 +306,7 @@ export function buildStrengthAnalytics(
 
     for (const exercise of session.detail.exercises) {
       const name = exerciseDisplayName(exercise.nameKey, exercise.rawName);
-      const targets = resolveExerciseTargets(name);
+      const targets = exerciseTargets(exercise, name);
       const setCount = exercise.entries.length;
 
       let exerciseReps = 0;

--- a/src/strength/strengthAnalytics.ts
+++ b/src/strength/strengthAnalytics.ts
@@ -538,7 +538,7 @@ export function formatVolumeKg(
   unitSystem: UnitSystem
 ): string {
   if (unitSystem === "metric" && value >= 1000) {
-    return `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)}t`;
+    return `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)} tonnes`;
   }
   return `${Math.round(kilogramsToDisplayWeight(value, unitSystem)).toLocaleString()} ${weightUnit(unitSystem)}`;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -23138,6 +23138,18 @@ tr.data-intervals-row-missing {
   max-height: min(760px, calc(100dvh - 48px));
 }
 
+/* Logging an activity is a half-minute of typing, not a workspace. The dialog
+   is sized to the form so it never opens as a screen of empty black. */
+.calendar-modal-workspace.calendar-modal-activity {
+  width: min(660px, 100%);
+  height: auto;
+  max-height: min(720px, calc(100dvh - 48px));
+}
+
+.calendar-modal-workspace.calendar-modal-activity > .calendar-modal-body {
+  flex: 0 1 auto;
+}
+
 .calendar-modal-workspace.calendar-modal-quick > .calendar-modal-body {
   flex: 0 1 auto;
 }
@@ -23688,10 +23700,154 @@ tr.data-intervals-row-missing {
   color: var(--text-secondary);
 }
 
+.calendar-activity-body {
+  gap: 20px;
+}
+
+.calendar-activity-section {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+}
+
+/* Section headings outrank the field labels beneath them by weight and ink,
+   not by shouting in tracked capitals. */
+.calendar-activity-section > h4,
+.calendar-activity-section-head > h4 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 12.5px;
+  font-weight: 650;
+}
+
+.calendar-activity-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.calendar-activity-search-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: none;
+  padding: 3px 5px;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  font-weight: 600;
+  transition: color 0.15s ease;
+}
+
+.calendar-activity-search-toggle:hover:not(:disabled),
+.calendar-activity-search-toggle:focus-visible {
+  color: var(--accent-strong);
+}
+
+.calendar-activity-search-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
 .calendar-activity-sport-picker {
   display: flex;
   flex-direction: column;
   gap: 10px;
+}
+
+/* These fields hold three digits at most, so they keep a compact width and
+   stay left-aligned instead of stretching to fill the dialog. */
+.calendar-activity-section .calendar-field-row {
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.calendar-activity-section .calendar-field-row > .calendar-field {
+  flex: 0 1 190px;
+  min-width: 150px;
+}
+
+/* Units live inside the field so labels stay plain nouns, and an empty field
+   shows an em dash — something no one can mistake for a recorded number. */
+.calendar-unit-control,
+.calendar-duration-control {
+  display: flex;
+  align-items: center;
+  min-height: 40px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--glass-bg);
+  padding: 0 12px;
+}
+
+.calendar-unit-control {
+  gap: 8px;
+}
+
+.calendar-duration-control {
+  gap: 16px;
+}
+
+.calendar-unit-control:focus-within,
+.calendar-duration-control:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-glow);
+}
+
+.calendar-duration-part {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.calendar-field .calendar-unit-control input,
+.calendar-field .calendar-duration-control input {
+  width: 100%;
+  min-height: 38px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.calendar-field .calendar-duration-control input {
+  width: 2.4em;
+  text-align: right;
+}
+
+.calendar-field .calendar-unit-control input:focus,
+.calendar-field .calendar-duration-control input:focus {
+  border: 0;
+  box-shadow: none;
+  outline: none;
+}
+
+/* The box lights up for either duration segment, so the segment itself still
+   has to say which one has the caret. */
+.calendar-field .calendar-unit-control input:focus-visible,
+.calendar-field .calendar-duration-control input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.calendar-unit-control em,
+.calendar-duration-control em {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  font-style: normal;
+  font-weight: 620;
+}
+
+.calendar-modal-footer.calendar-activity-footer {
+  justify-content: space-between;
+}
+
+.calendar-activity-footer .calendar-activity-hint {
+  min-width: 0;
 }
 
 .calendar-sport-grid {
@@ -23759,10 +23915,6 @@ tr.data-intervals-row-missing {
 .calendar-sport-card:disabled {
   cursor: not-allowed;
   opacity: 0.55;
-}
-
-.calendar-sport-search {
-  flex: none;
 }
 
 .calendar-sport-search-control {
@@ -25625,156 +25777,168 @@ tr.data-intervals-row-missing {
   gap: 10px;
 }
 
-.exercise-inline-video {
-  min-width: 0;
-  overflow: hidden;
-  border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--glass-border));
-  border-radius: var(--radius-md);
-  background:
-    linear-gradient(180deg, color-mix(in srgb, var(--accent-soft) 34%, transparent), transparent 42%),
-    color-mix(in srgb, var(--glass-bg) 92%, var(--bg-base));
-  box-shadow: var(--glass-inset);
-}
+/* --- movement demonstration plate --- */
 
-.exercise-inline-video-header {
-  display: flex;
-  min-height: 48px;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 9px 10px 9px 12px;
-  border-bottom: 1px solid var(--glass-border);
-}
-
-.exercise-inline-video-header > div:first-child {
+/* COROS films every demonstration on a white cyclorama, so the stage is lit
+   like the clip rather than cut out of the dark UI: the video meets its own
+   background and the figure stands on a studio sweep instead of in a
+   letterbox. */
+.exercise-preview {
   display: grid;
   min-width: 0;
-  gap: 2px;
+  gap: 9px;
 }
 
-.exercise-inline-video-header strong,
-.exercise-inline-video-header span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.exercise-inline-video-header strong {
-  color: var(--text-primary);
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.exercise-inline-video-header > div:first-child > span {
-  color: var(--text-muted);
-  font-size: 9.5px;
-}
-
-.exercise-inline-video-actions {
-  display: flex;
-  flex: 0 0 auto;
-  align-items: center;
-  gap: 6px;
-}
-
-.exercise-inline-video-actions > span {
-  min-width: 34px;
-  color: var(--text-muted);
-  font-size: 9.5px;
-  font-variant-numeric: tabular-nums;
-  text-align: center;
-}
-
-.exercise-inline-video-actions > button {
-  display: grid;
-  width: 28px;
-  height: 28px;
-  place-items: center;
-  border: 1px solid var(--glass-border);
-  border-radius: 7px;
-  background: var(--glass-bg);
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease, transform 0.15s ease;
-}
-
-.exercise-inline-video-actions > button:hover,
-.exercise-inline-video-actions > button:focus-visible {
-  border-color: color-mix(in srgb, var(--accent) 54%, var(--glass-border));
-  background: var(--accent-soft);
-  color: var(--accent-strong);
-  outline: none;
-}
-
-.exercise-inline-video-actions > button:active {
-  transform: translateY(1px);
-}
-
-.exercise-inline-video-stage {
+.exercise-preview-stage {
   position: relative;
   display: grid;
   width: 100%;
-  min-height: 190px;
-  aspect-ratio: 16 / 9;
+  aspect-ratio: 4 / 5;
   place-items: center;
   overflow: hidden;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
   background:
-    radial-gradient(circle at 50% 46%, color-mix(in srgb, var(--accent-soft) 46%, transparent), transparent 46%),
-    #11151a;
+    radial-gradient(118% 84% at 50% 4%, #ffffff 0%, #f1f2f4 58%, #dfe3e8 100%);
+  box-shadow: var(--glass-inset);
+  max-height: 420px;
 }
 
-.exercise-inline-video-stage video {
+.exercise-preview-stage video {
   grid-area: 1 / 1;
   width: 100%;
   height: 100%;
-  min-height: 190px;
   opacity: 0;
   background: transparent;
   object-fit: contain;
   transition: opacity 0.18s ease;
 }
 
-.exercise-inline-video-stage video.is-ready {
+.exercise-preview-stage video.is-ready {
   opacity: 1;
 }
 
-.exercise-inline-video-loading,
-.exercise-inline-video-error {
+.exercise-preview-status {
   z-index: 1;
   grid-area: 1 / 1;
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  gap: 7px;
+  gap: 8px;
   padding: 16px;
-  color: var(--text-muted);
+  color: #6e7480;
   text-align: center;
 }
 
-.exercise-inline-video-loading > span {
-  width: 68px;
-  height: 44px;
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius-sm);
-  background:
-    linear-gradient(135deg, transparent 38%, color-mix(in srgb, var(--accent) 24%, transparent) 39% 61%, transparent 62%),
-    var(--glass-bg);
-}
-
-.exercise-inline-video-loading strong,
-.exercise-inline-video-error strong {
-  color: var(--text-secondary);
+.exercise-preview-status strong {
   font-size: 11px;
-  font-weight: 650;
+  font-weight: 640;
 }
 
-.exercise-inline-video-error svg {
-  color: var(--error-text);
-}
-
-.exercise-inline-video-error span {
+.exercise-preview-status span {
   font-size: 10px;
+}
+
+.exercise-preview-status.is-error svg {
+  color: #c0392b;
+}
+
+.exercise-preview-spinner {
+  width: 22px;
+  height: 22px;
+  border: 2px solid rgba(20, 24, 30, 0.14);
+  border-top-color: rgba(20, 24, 30, 0.44);
+  border-radius: 50%;
+  animation: exercise-preview-spin 0.9s linear infinite;
+}
+
+@keyframes exercise-preview-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .exercise-preview-spinner {
+    animation: none;
+  }
+}
+
+.exercise-preview-angles {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.exercise-preview-angles > span {
+  min-width: 96px;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.exercise-preview-angles > button {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  place-items: center;
+  border: 1px solid var(--glass-border);
+  border-radius: 7px;
+  background: var(--glass-bg);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.exercise-preview-angles > button:hover,
+.exercise-preview-angles > button:focus-visible {
+  border-color: color-mix(in srgb, var(--step-color, var(--accent)) 54%, var(--glass-border));
+  background: color-mix(in srgb, var(--step-color, var(--accent)) 14%, transparent);
+  color: var(--text-primary);
+  outline: none;
+}
+
+.exercise-preview-note {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  line-height: 1.45;
+}
+
+.exercise-preview-targets h5 {
+  margin: 0 0 7px;
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  font-weight: 600;
+}
+
+.exercise-preview-targets ul {
+  display: flex;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+  gap: 4px;
+  list-style: none;
+}
+
+.exercise-preview-targets li {
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
+  padding: 3px 9px;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 560;
+  white-space: nowrap;
+}
+
+/* Prime movers carry the step's own hue; the rest stay as supporting text. */
+.exercise-preview-targets li.is-prime {
+  border-color: color-mix(in srgb, var(--step-color, var(--accent)) 46%, transparent);
+  background: color-mix(in srgb, var(--step-color, var(--accent)) 15%, transparent);
+  color: var(--text-primary);
+  font-weight: 640;
 }
 
 @media (min-width: 1100px) and (min-height: 700px) {
@@ -25817,7 +25981,7 @@ tr.data-intervals-row-missing {
     padding: 2px 2px 2px 0;
   }
 
-  .calendar-builder-row-content.has-exercise-workspace:has(.exercise-combobox.has-inline-video) .exercise-inline-video {
+  .calendar-builder-row-content.has-exercise-workspace:has(.exercise-combobox.has-inline-video) .exercise-preview {
     grid-column: 2;
     grid-row: 1 / -1;
     align-self: start;
@@ -25842,24 +26006,12 @@ tr.data-intervals-row-missing {
     flex-basis: 48px;
   }
 
-  .calendar-builder-row .exercise-combobox.has-inline-video .exercise-inline-video {
+  .calendar-builder-row .exercise-combobox.has-inline-video .exercise-preview {
     align-self: start;
   }
 
-  .calendar-builder-row .exercise-combobox.has-inline-video .exercise-inline-video-header {
-    min-height: 56px;
-    padding-inline: 15px 12px;
-  }
-
-  .calendar-builder-row .exercise-combobox.has-inline-video .exercise-inline-video-header strong {
-    font-size: 13.5px;
-  }
-
-  .calendar-builder-row .exercise-combobox.has-inline-video .exercise-inline-video-stage,
-  .calendar-builder-row .exercise-combobox.has-inline-video .exercise-inline-video-stage video {
-    height: clamp(300px, 29vw, 440px);
-    min-height: 300px;
-    aspect-ratio: auto;
+  .calendar-builder-row .exercise-combobox.has-inline-video .exercise-preview-stage {
+    max-height: clamp(300px, 32vw, 440px);
   }
 }
 
@@ -25876,15 +26028,305 @@ tr.data-intervals-row-missing {
   background: rgba(38, 34, 28, 0.065);
 }
 
-:root[data-theme="paper"] .exercise-inline-video {
-  border-color: var(--glass-border);
-  background: var(--glass-bg-elevated);
-  box-shadow: var(--shadow-elevated), var(--glass-inset);
+@media (prefers-reduced-motion: reduce) {
+  .exercise-preview-stage video,
+  .exercise-preview-angles > button {
+    transition: none;
+  }
+}
+
+/* --- strength training step --------------------------------------------
+   A strength set is written the way it is trained: sets × work @ load, then
+   rest. The editor is that line — one instrument with the operators inside
+   it — rather than a column of interchangeable fields. Everything else on
+   the step stays quiet so the line is the thing you read first. */
+
+.calendar-builder-row-reveal:has(.strength-step),
+.calendar-builder-repeat-child-reveal:has(.strength-step) {
+  container: strength-step / inline-size;
+}
+
+.calendar-builder-row-content.strength-step {
+  display: grid;
+  align-items: start;
+  gap: 18px;
+}
+
+.strength-step-form {
+  display: grid;
+  min-width: 0;
+  align-content: start;
+  gap: 16px;
+}
+
+/* Step type keeps the builder's own control shape — label, then the select on
+   its own row — so a Strength step reads the same as every other step kind. */
+.strength-step-kind {
+  max-width: 260px;
+}
+
+.strength-block {
+  display: grid;
+  min-width: 0;
+  gap: 7px;
+}
+
+/* Section labels match .calendar-builder-control's label, so the panel has one
+   labelling voice rather than a second, louder one. */
+.strength-block > h4 {
+  margin: 0;
+  min-height: 15px;
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  font-weight: 600;
+}
+
+.strength-block-note {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  line-height: 1.45;
+}
+
+/* --- the set line --- */
+
+.set-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--glass-bg) 55%, transparent);
+  box-shadow: var(--glass-inset);
+}
+
+.set-line-cell {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+  gap: 3px;
+  padding: 10px 15px 12px;
+  transition: background 0.15s ease;
+}
+
+.set-line-cell:focus-within {
+  background: color-mix(in srgb, var(--step-color, var(--accent)) 10%, transparent);
+}
+
+.set-line-cell > span:first-child {
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.set-line-compound {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Operators sit on the numbers' baseline, not the cell's centre line. */
+.set-line-operator {
+  display: flex;
+  align-self: flex-end;
+  align-items: center;
+  padding: 0 3px 15px;
+  color: var(--text-muted);
+  font-size: 17px;
+  opacity: 0.5;
+  user-select: none;
+}
+
+.calendar-builder-row .set-line input,
+.calendar-builder-row .set-line select {
+  width: auto;
+  min-height: 0;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-primary);
+}
+
+.calendar-builder-row .set-line input {
+  padding: 0;
+  font-size: 27px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  appearance: textfield;
+}
+
+.calendar-builder-row .set-line input::-webkit-inner-spin-button,
+.calendar-builder-row .set-line input::-webkit-outer-spin-button {
+  appearance: none;
+  margin: 0;
+}
+
+.calendar-builder-row .set-line input:focus,
+.calendar-builder-row .set-line select:focus {
+  border: 0;
+  box-shadow: none;
+  outline: none;
+}
+
+.calendar-builder-row .set-line input:focus-visible,
+.calendar-builder-row .set-line select:focus-visible,
+.calendar-builder-row .rest-picker input:focus-visible,
+.calendar-builder-row .rest-picker button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--step-color, var(--accent)) 80%, transparent);
+  outline-offset: 3px;
+}
+
+.calendar-builder-row .set-line-cell > input {
+  width: 2.6em;
+}
+
+.calendar-builder-row .set-line-compound > input {
+  width: 3.2em;
+}
+
+/* The unit and load pickers stay legible as controls: a hairline pill inside
+   the strip, never a bare word that only looks like a label. */
+.calendar-builder-row .set-line select {
+  flex: 0 1 auto;
+  padding: 5px 8px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--glass-bg);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.calendar-builder-row .set-line select:hover {
+  background: var(--glass-bg-hover);
+}
+
+.set-line-cell.is-load select {
+  font-size: 13px;
+}
+
+.set-line-open {
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 2.1;
+}
+
+.set-line-weight {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.calendar-builder-row .set-line-weight input {
+  width: 3.4em;
+  font-size: 22px;
+}
+
+.set-line-weight em {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-style: normal;
+  font-weight: 620;
+}
+
+.set-line-readout {
+  margin: 0;
+  padding-left: 2px;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* --- rest between sets --- */
+
+.rest-picker {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.calendar-builder-row .rest-picker > button {
+  min-height: 32px;
+  padding: 0 13px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--glass-bg) 55%, transparent);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 620;
+  font-variant-numeric: tabular-nums;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.calendar-builder-row .rest-picker > button:hover {
+  border-color: color-mix(in srgb, var(--text-primary) 22%, var(--glass-border));
+  background: var(--glass-bg-hover);
+  color: var(--text-primary);
+}
+
+.calendar-builder-row .rest-picker > button.is-selected {
+  border-color: color-mix(in srgb, var(--step-color, var(--accent)) 55%, transparent);
+  background: color-mix(in srgb, var(--step-color, var(--accent)) 18%, transparent);
+  color: var(--text-primary);
+}
+
+.rest-picker-custom {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: 3px;
+}
+
+.calendar-builder-row .rest-picker-custom input {
+  width: 66px;
+  min-height: 32px;
+  border-radius: var(--radius-pill);
+  padding: 0 10px;
+  font-size: 12.5px;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.calendar-builder-row .rest-picker-custom input:focus {
+  border-color: color-mix(in srgb, var(--step-color, var(--accent)) 70%, var(--glass-border));
+  box-shadow: none;
+}
+
+.rest-picker-custom em {
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-style: normal;
+  font-weight: 620;
+}
+
+/* --- movement plate column --- */
+
+.strength-step-aside {
+  min-width: 0;
+  max-width: 300px;
+}
+
+/* The step splits into two columns only once there is a movement to show, so
+   an unpicked step keeps the full width instead of reserving an empty gutter. */
+@container strength-step (min-width: 760px) {
+  .calendar-builder-row-content.strength-step:has(.strength-step-aside) {
+    grid-template-columns: minmax(0, 1fr) clamp(200px, 26%, 280px);
+    column-gap: 24px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .exercise-inline-video-stage video,
-  .exercise-inline-video-actions > button {
+  .set-line-cell,
+  .calendar-builder-row .rest-picker > button {
     transition: none;
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -311,6 +311,233 @@ input::placeholder {
   flex-shrink: 0;
 }
 
+/* A deliberately tactile little thank-you CTA. Warm "buy me a coffee" amber
+   with a toon offset edge, a slow shine sweep, and a cup wobble — personality
+   without changing the rest of the shell. Hardcoded honey tones read equally
+   well on the dark and paper themes. */
+.donate-button {
+  --donate-ink: #41260a;
+  --donate-edge: #a0620a;
+  --donate-shadow: #8a5403;
+  --donate-glow: rgba(247, 183, 51, 0.38);
+  --donate-cream: rgba(255, 246, 220, 0.85);
+
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-width: 92px;
+  height: 34px;
+  padding: 0 13px 0 10px;
+  border: 2px solid var(--donate-edge);
+  border-radius: var(--radius-pill);
+  background: linear-gradient(
+    180deg,
+    #ffd76a 0%,
+    #f7b733 56%,
+    #eda314 100%
+  );
+  box-shadow:
+    0 3px 0 var(--donate-shadow),
+    0 7px 16px var(--donate-glow),
+    inset 0 1px 0 var(--donate-cream);
+  color: var(--donate-ink);
+  font-family: var(--font-display);
+  font-size: 12px;
+  font-weight: 780;
+  letter-spacing: -0.01em;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+  transform: translateY(-1px) rotate(-1deg);
+  transform-origin: 50% 70%;
+  transition:
+    transform 240ms cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 180ms cubic-bezier(0.16, 1, 0.3, 1),
+    filter 180ms ease;
+}
+
+.donate-button::before {
+  content: "";
+  position: absolute;
+  inset: 2px 5px auto;
+  z-index: -1;
+  height: 7px;
+  border-radius: var(--radius-pill);
+  background: rgba(255, 248, 226, 0.42);
+  pointer-events: none;
+}
+
+/* Slow diagonal gloss that sweeps across the pill. Sits above the gradient
+   but below the icon and label. */
+.donate-button::after {
+  content: "";
+  position: absolute;
+  top: -18%;
+  bottom: -18%;
+  left: 0;
+  z-index: 0;
+  width: 46%;
+  background: linear-gradient(
+    100deg,
+    transparent 0%,
+    rgba(255, 252, 240, 0.16) 20%,
+    rgba(255, 252, 240, 0.6) 50%,
+    rgba(255, 252, 240, 0.16) 80%,
+    transparent 100%
+  );
+  transform: translateX(-190%) skewX(-18deg);
+  pointer-events: none;
+}
+
+.donate-button:hover {
+  filter: saturate(1.1) brightness(1.05);
+  transform: translateY(-3px) rotate(1deg) scale(1.035);
+  box-shadow:
+    0 5px 0 var(--donate-shadow),
+    0 11px 24px rgba(247, 183, 51, 0.48),
+    inset 0 1px 0 rgba(255, 246, 220, 0.95);
+}
+
+.donate-button:active {
+  transform: translateY(2px) rotate(0deg) scale(0.97);
+  box-shadow:
+    0 1px 0 var(--donate-shadow),
+    0 3px 8px rgba(247, 183, 51, 0.3),
+    inset 0 1px 0 rgba(255, 246, 220, 0.7);
+}
+
+.donate-button:focus-visible {
+  outline: 3px solid rgba(255, 214, 106, 0.9);
+  outline-offset: 3px;
+}
+
+.donate-button-art {
+  position: relative;
+  z-index: 1;
+  display: inline-grid;
+  place-items: center;
+  width: 19px;
+  height: 20px;
+  flex: 0 0 auto;
+}
+
+.donate-button-label {
+  position: relative;
+  z-index: 1;
+}
+
+.donate-button-cup {
+  filter: drop-shadow(0 1px 0 rgba(255, 246, 220, 0.55));
+  transform-origin: 50% 80%;
+}
+
+.donate-button-spark {
+  position: absolute;
+  top: -5px;
+  right: -6px;
+  opacity: 0.48;
+  transform: scale(0.72) rotate(-10deg);
+  transform-origin: center;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .donate-button::after {
+    animation: donate-shine 4.4s cubic-bezier(0.45, 0, 0.2, 1) infinite;
+  }
+
+  .donate-button-spark {
+    animation: donate-sparkle 3.6s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+  }
+
+  .donate-button:hover .donate-button-cup {
+    animation: donate-cup-wobble 560ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .donate-button,
+  .donate-button:hover,
+  .donate-button:active {
+    transform: none;
+    transition: filter 100ms ease;
+  }
+}
+
+@keyframes donate-shine {
+  0%,
+  52% {
+    transform: translateX(-190%) skewX(-18deg);
+  }
+
+  82%,
+  100% {
+    transform: translateX(460%) skewX(-18deg);
+  }
+}
+
+@keyframes donate-sparkle {
+  0%,
+  68%,
+  100% {
+    opacity: 0.35;
+    transform: scale(0.7) rotate(-12deg);
+  }
+
+  76% {
+    opacity: 1;
+    transform: scale(1.24) rotate(8deg);
+  }
+
+  84% {
+    opacity: 0.56;
+    transform: scale(0.88) rotate(0deg);
+  }
+}
+
+@keyframes donate-cup-wobble {
+  0%,
+  100% {
+    transform: rotate(0deg) translateY(0);
+  }
+
+  28% {
+    transform: rotate(-11deg) translateY(-1px);
+  }
+
+  56% {
+    transform: rotate(9deg) translateY(-2px);
+  }
+
+  78% {
+    transform: rotate(-4deg) translateY(-1px);
+  }
+}
+
+@media (max-width: 560px) {
+  .donate-button {
+    width: 34px;
+    min-width: 34px;
+    padding: 0;
+    gap: 0;
+  }
+
+  .donate-button-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+}
+
 .app-header--slim {
   grid-template-columns: minmax(0, 1fr);
   min-height: 52px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -18165,43 +18165,107 @@ tr.data-intervals-row-missing {
   to { background-position: -200% 0; }
 }
 
-.chat-thinking-preview {
-  margin: 0;
-  font-size: 12px;
-  line-height: 1.5;
-  font-style: italic;
-  color: var(--text-muted);
-  opacity: 0.85;
-  white-space: pre-wrap;
-  word-break: break-word;
-  max-height: 108px;
-  overflow: hidden;
+.chat-bubble-streaming {
+  width: min(100%, 620px);
 }
 
-/* Collapsible thought process once the answer starts streaming */
+.chat-thinking-text .chat-markdown > :first-child {
+  margin-top: 0;
+}
+
+.chat-thinking-text .chat-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+/* Compact, user-controlled safe reasoning summary. */
 .chat-thinking {
   margin-bottom: 8px;
-  border-left: 2px solid var(--glass-border);
-  padding-left: 10px;
+  width: min(100%, 560px);
 }
 
 .chat-thinking summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: fit-content;
+  min-height: 24px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  padding: 2px 7px;
   cursor: pointer;
-  font-size: 12px;
-  font-weight: 600;
+  font-size: 11px;
+  font-weight: 650;
   color: var(--text-muted);
   user-select: none;
+  transition: color 0.18s ease, border-color 0.18s ease,
+    background 0.18s ease;
+}
+
+.chat-thinking summary:hover,
+.chat-thinking[open] summary {
+  border-color: var(--glass-border);
+  background: var(--glass-bg);
+  color: var(--text-secondary);
+}
+
+.chat-thinking summary::before {
+  content: "›";
+  display: inline-block;
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1;
+  transform: rotate(0deg);
+  transition: transform 0.18s ease;
+}
+
+.chat-thinking[open] summary::before {
+  transform: rotate(90deg);
+}
+
+.chat-thinking summary small {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--accent-strong);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.035em;
+  text-transform: uppercase;
+}
+
+.chat-thinking summary i {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 6px var(--accent-glow);
+  animation: chat-dot-pulse 1.3s ease-in-out infinite;
 }
 
 .chat-thinking-text {
-  margin: 6px 0 0;
-  font-size: 12px;
-  line-height: 1.5;
-  color: var(--text-muted);
-  white-space: pre-wrap;
-  word-break: break-word;
-  max-height: 220px;
+  margin: 5px 0 0 8px;
+  max-height: 180px;
   overflow-y: auto;
+  border-left: 1px solid var(--glass-border);
+  padding: 4px 0 4px 10px;
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
+.chat-thinking-text .chat-markdown {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.chat-thinking-text .chat-markdown h1,
+.chat-thinking-text .chat-markdown h2,
+.chat-thinking-text .chat-markdown h3,
+.chat-thinking-text .chat-markdown h4 {
+  margin: 7px 0 2px;
+  font: inherit;
+  font-weight: 700;
+  color: var(--text-secondary);
 }
 
 @keyframes chat-row-enter {
@@ -18280,6 +18344,7 @@ tr.data-intervals-row-missing {
   .chat-row,
   .chat-avatar,
   .chat-typing span,
+  .chat-thinking summary i,
   .chat-mcp-pill.connected::before,
   .chat-mcp-panel {
     animation: none;
@@ -18751,6 +18816,148 @@ tr.data-intervals-row-missing {
   background: transparent;
   border: none;
   box-shadow: none;
+}
+
+.chat-bubble-coach-prompt {
+  width: min(100%, 560px);
+  padding: 0 !important;
+}
+
+.chat-coach-prompt {
+  display: grid;
+  gap: 12px;
+  border: 1px solid color-mix(in srgb, var(--accent) 52%, var(--glass-border));
+  border-radius: var(--radius-md);
+  background: linear-gradient(
+    145deg,
+    color-mix(in srgb, var(--accent-soft) 72%, var(--glass-bg-elevated)),
+    var(--glass-bg)
+  );
+  padding: 15px;
+  box-shadow: 0 10px 28px color-mix(in srgb, var(--accent-glow) 48%, transparent),
+    var(--glass-inset);
+}
+
+.chat-coach-prompt.is-answered {
+  border-color: var(--glass-border);
+  background: var(--glass-bg);
+  box-shadow: var(--glass-inset);
+}
+
+.chat-coach-prompt-header {
+  display: grid;
+  gap: 7px;
+}
+
+.chat-coach-prompt-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  color: var(--accent-strong);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.045em;
+  text-transform: uppercase;
+}
+
+.chat-coach-prompt.is-answered .chat-coach-prompt-status {
+  color: var(--text-muted);
+}
+
+.chat-coach-prompt-header h4 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 15px;
+  font-weight: 650;
+  line-height: 1.45;
+}
+
+.chat-coach-prompt-choices {
+  display: grid;
+  gap: 8px;
+}
+
+.chat-coach-prompt-choice {
+  display: grid;
+  gap: 3px;
+  width: 100%;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--surface) 58%, transparent);
+  color: var(--text-primary);
+  padding: 10px 12px;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.18s ease, background 0.18s ease,
+    transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.chat-coach-prompt-choice > span {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.chat-coach-prompt-choice em {
+  border-radius: var(--radius-pill);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  padding: 2px 7px;
+  font-size: 9px;
+  font-style: normal;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.chat-coach-prompt-choice small {
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.chat-coach-prompt-choice:hover:not(:disabled) {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  transform: translateY(-1px);
+  box-shadow: 0 5px 16px var(--accent-glow);
+}
+
+.chat-coach-prompt-choice.is-selected {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.chat-coach-prompt-choice:disabled {
+  cursor: default;
+  opacity: 0.62;
+}
+
+.chat-coach-prompt-choice.is-selected:disabled {
+  opacity: 1;
+}
+
+.chat-coach-prompt-custom {
+  width: fit-content;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  padding: 0;
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.chat-coach-prompt-custom:hover:not(:disabled) {
+  color: var(--accent-strong);
+}
+
+.chat-coach-prompt-custom:disabled {
+  opacity: 0.55;
+  cursor: default;
 }
 
 .chat-plan-card {

--- a/src/styles.css
+++ b/src/styles.css
@@ -18875,7 +18875,33 @@ tr.data-intervals-row-missing {
 
 .chat-plan-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
+}
+
+.chat-plan-review {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+  background: var(--glass-bg);
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.chat-plan-review:hover:not(:disabled) {
+  border-color: var(--chat-signal-border);
+  color: var(--text-primary);
+  background: var(--glass-bg-hover);
+}
+
+.chat-plan-review:disabled {
+  opacity: 0.65;
+  cursor: default;
 }
 
 .chat-plan-upload {

--- a/src/styles.css
+++ b/src/styles.css
@@ -18811,6 +18811,62 @@ tr.data-intervals-row-missing {
   color: var(--text-secondary);
 }
 
+.chat-plan-confirmation {
+  display: grid;
+  gap: 10px;
+  padding: 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--glass-bg) 76%, transparent);
+}
+
+.chat-plan-confirmation label {
+  display: grid;
+  gap: 5px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.chat-plan-confirmation select {
+  min-height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  background: var(--bg-base);
+}
+
+.chat-plan-facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px 12px;
+  margin: 0;
+}
+
+.chat-plan-facts div {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 11px;
+}
+
+.chat-plan-facts dt { color: var(--text-muted); }
+.chat-plan-facts dd { margin: 0; color: var(--text-primary); text-align: right; }
+
+.chat-plan-write-preview {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.chat-plan-write-preview strong { color: var(--text-primary); }
+.chat-plan-write-preview p { margin: 5px 0 0; }
+.chat-plan-write-preview ul {
+  max-height: 116px;
+  overflow-y: auto;
+  margin: 5px 0 0;
+  padding-left: 18px;
+}
+
 .chat-plan-success {
   margin: 0;
   font-size: 12px;

--- a/src/training-library/PlanCompare.tsx
+++ b/src/training-library/PlanCompare.tsx
@@ -1,0 +1,106 @@
+import { AlertTriangle, Check, Scale, X } from "lucide-react";
+import { useMemo } from "react";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from "recharts";
+import type { TrainingPlanDocument } from "../../electron/types";
+import { compareTrainingPlans } from "../../electron/trainingPlanDomain";
+
+interface PlanCompareProps {
+  plans: TrainingPlanDocument[];
+  selectedIds: string[];
+  onSelectionChange: (ids: string[]) => void;
+  onClose: () => void;
+}
+const COLORS = ["var(--accent-strong)", "var(--accent-gold)", "#5f8fc9"];
+
+function durationLabel(seconds: number): string {
+  const hours = seconds / 3600;
+  return hours < 10 ? `${hours.toFixed(1)} hr` : `${Math.round(hours)} hr`;
+}
+
+export function PlanCompare({ plans, selectedIds, onSelectionChange, onClose }: PlanCompareProps) {
+  const selected = plans.filter((plan) => selectedIds.includes(plan.id)).slice(0, 3);
+  const comparison = useMemo(() => compareTrainingPlans(selected), [selected]);
+  const chartData = useMemo(() => {
+    const maxWeeks = Math.max(0, ...comparison.summaries.map((summary) => summary.weekCount));
+    return Array.from({ length: maxWeeks }, (_, weekIndex) => {
+      const row: Record<string, string | number> = { week: `W${weekIndex + 1}` };
+      for (const summary of comparison.summaries) {
+        row[summary.planId] = Math.round(summary.weekly[weekIndex]?.trainingLoad ?? 0);
+      }
+      return row;
+    });
+  }, [comparison]);
+
+  const toggle = (id: string) => {
+    if (selectedIds.includes(id)) {
+      onSelectionChange(selectedIds.filter((value) => value !== id));
+    } else if (selectedIds.length < 3) {
+      onSelectionChange([...selectedIds, id]);
+    }
+  };
+
+  return <section className="plan-compare" aria-labelledby="plan-compare-title">
+    <header>
+      <div><p className="tl-eyebrow">Plan comparison</p><h2 id="plan-compare-title">Compare structure and load</h2><p>Select two or three plans. Estimates come from their structured workout definitions.</p></div>
+      <button type="button" className="ghost-button" onClick={onClose}><X size={15} /> Close</button>
+    </header>
+
+    <div className="plan-compare-picker" aria-label="Plans to compare">
+      {plans.map((plan) => {
+        const active = selectedIds.includes(plan.id);
+        return <button type="button" className={active ? "is-selected" : ""} aria-pressed={active} key={plan.id} onClick={() => toggle(plan.id)} disabled={!active && selectedIds.length >= 3}>{active ? <Check size={14} /> : <Scale size={14} />}<span><strong>{plan.name}</strong><small>{plan.weekCount} weeks</small></span></button>;
+      })}
+    </div>
+
+    {selected.length < 2 ? <div className="tl-empty"><h3>Pick a second plan</h3><p>The comparison appears as soon as two plans are selected.</p></div> : <>
+      <div className="plan-compare-grid" style={{ gridTemplateColumns: `repeat(${selected.length}, minmax(0, 1fr))` }}>
+        {comparison.summaries.map((summary) => <article key={summary.planId}>
+          <h3>{summary.name}</h3>
+          <dl>
+            <div><dt>Total duration</dt><dd>{durationLabel(summary.durationSeconds)}</dd></div>
+            <div><dt>Total distance</dt><dd>{(summary.distanceMeters / 1000).toFixed(1)} km</dd></div>
+            <div><dt>Estimated load</dt><dd>{Math.round(summary.trainingLoad)}</dd></div>
+            <div><dt>Workouts</dt><dd>{summary.workouts}</dd></div>
+            <div><dt>Peak week</dt><dd>{summary.peakWeek ?? "-"}</dd></div>
+            <div><dt>Recovery days</dt><dd>{summary.restDays}</dd></div>
+            <div><dt>Strength sets</dt><dd>{summary.strengthSets || "-"}</dd></div>
+            <div><dt>Conflicts</dt><dd>{summary.conflictCount}</dd></div>
+            <div><dt>Clear taper</dt><dd>{summary.taperDetected ? "Yes" : "No"}</dd></div>
+          </dl>
+          <div className="plan-compare-sports">{Object.entries(summary.sportDistribution).map(([sport, count]) => <span key={sport}>{sport} <strong>{count}</strong></span>)}</div>
+          {summary.longestWorkout ? <p className="plan-compare-longest"><small>Longest workout</small><strong>{summary.longestWorkout.name}</strong><span>{durationLabel(summary.longestWorkout.durationSeconds)}</span></p> : null}
+        </article>)}
+      </div>
+
+      <section className="plan-compare-chart" aria-label={`Weekly training-load chart comparing ${comparison.summaries.map((summary) => summary.name).join(", ")}`}>
+        <div><h3>Weekly load progression</h3><p>The chart shows estimated structured-workout load by week.</p></div>
+        <ResponsiveContainer width="100%" height={260}>
+          <LineChart data={chartData} margin={{ top: 12, right: 18, left: -12, bottom: 0 }}>
+            <CartesianGrid stroke="var(--glass-border)" vertical={false} />
+            <XAxis dataKey="week" stroke="var(--text-muted)" tickLine={false} axisLine={false} />
+            <YAxis stroke="var(--text-muted)" tickLine={false} axisLine={false} />
+            <Tooltip contentStyle={{ background: "var(--surface)", border: "1px solid var(--glass-border)", borderRadius: 10 }} />
+            <Legend />
+            {comparison.summaries.map((summary, index) => <Line key={summary.planId} dataKey={summary.planId} name={summary.name} type="monotone" stroke={COLORS[index]} strokeWidth={2} dot={{ r: 3 }} activeDot={{ r: 5 }} />)}
+          </LineChart>
+        </ResponsiveContainer>
+      </section>
+
+      <section className="plan-compare-insights">
+        <h3>Structural insights</h3>
+        {comparison.insights.length ? comparison.insights.map((insight) => <p key={insight}><AlertTriangle size={15} />{insight}</p>) : <p><Check size={15} />No major progression or scheduling flags were found in these estimates.</p>}
+        {comparison.sharedWorkoutNames.length ? <p><Check size={15} />Shared workouts: {comparison.sharedWorkoutNames.join(", ")}.</p> : null}
+        <small>These flags support planning review and are not medical advice.</small>
+      </section>
+    </>}
+  </section>;
+}

--- a/src/training-library/PlanEditor.tsx
+++ b/src/training-library/PlanEditor.tsx
@@ -1,0 +1,316 @@
+import {
+  AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+  CalendarRange,
+  Copy,
+  CornerDownLeft,
+  Plus,
+  Redo2,
+  RotateCcw,
+  Save,
+  Trash2,
+  Undo2,
+  X
+} from "lucide-react";
+import { useEffect, useMemo, useState, type DragEvent } from "react";
+import type {
+  PlanWorkoutEntryInput,
+  TrainingLibraryWorkout,
+  TrainingPlanDocument,
+  TrainingPlanEntry,
+  WorkoutSport
+} from "../../electron/types";
+import {
+  duplicateTrainingPlanWeek,
+  insertRecoveryWeek,
+  planEntryFromWorkout,
+  reorderTrainingPlanWeek,
+  shiftTrainingPlan,
+  summarizeTrainingPlan,
+  validateTrainingPlan,
+  workoutSportFromType
+} from "../../electron/trainingPlanDomain";
+import { formatWorkoutSport, WORKOUT_SPORTS } from "../../electron/workoutCapabilities";
+
+interface PlanEditorProps {
+  initialPlan: TrainingPlanDocument;
+  workouts: TrainingLibraryWorkout[];
+  onSave: (plan: TrainingPlanDocument) => Promise<void>;
+  onClose: () => void;
+}
+
+const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function withDerivedSportMix(plan: TrainingPlanDocument): TrainingPlanDocument {
+  const sports = plan.entries
+    .map((entry) => entry.workout?.sport)
+    .filter((sport): sport is WorkoutSport => Boolean(sport));
+  return { ...plan, sportMix: [...new Set(sports)], updatedAt: new Date().toISOString() };
+}
+
+function removeWeek(plan: TrainingPlanDocument, weekIndex: number): TrainingPlanDocument {
+  return withDerivedSportMix({
+    ...plan,
+    weekCount: Math.max(1, plan.weekCount - 1),
+    entries: plan.entries
+      .filter((entry) => entry.weekIndex !== weekIndex)
+      .map((entry) => ({
+        ...entry,
+        weekIndex: entry.weekIndex > weekIndex ? entry.weekIndex - 1 : entry.weekIndex
+      })),
+    phases: plan.phases.filter((phase) => phase.startWeek <= Math.max(1, plan.weekCount - 1)),
+    syncState: plan.source === "coros" ? "pending" : "local"
+  });
+}
+
+function entryDate(plan: TrainingPlanDocument, weekIndex: number, dayIndex: number): string | undefined {
+  if (!plan.startDate) return undefined;
+  const date = new Date(`${plan.startDate}T12:00:00`);
+  if (Number.isNaN(date.valueOf())) return undefined;
+  date.setDate(date.getDate() + weekIndex * 7 + dayIndex);
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function mondayOf(value: string): string {
+  const date = new Date(`${value}T12:00:00`);
+  if (Number.isNaN(date.valueOf())) return value;
+  date.setDate(date.getDate() - ((date.getDay() + 6) % 7));
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+export function PlanEditor({ initialPlan, workouts, onSave, onClose }: PlanEditorProps) {
+  const [history, setHistory] = useState<TrainingPlanDocument[]>([structuredClone(initialPlan)]);
+  const [historyIndex, setHistoryIndex] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [showNewWorkout, setShowNewWorkout] = useState(false);
+  const [newWorkoutName, setNewWorkoutName] = useState("");
+  const [newWorkoutSport, setNewWorkoutSport] = useState<WorkoutSport>("run");
+  const [newWorkoutMinutes, setNewWorkoutMinutes] = useState("45");
+  const plan = history[historyIndex]!;
+  const dirty = JSON.stringify(plan) !== JSON.stringify(initialPlan);
+  const validation = useMemo(() => validateTrainingPlan(plan), [plan]);
+  const summary = useMemo(() => summarizeTrainingPlan(plan), [plan]);
+
+  useEffect(() => {
+    const protect = (event: BeforeUnloadEvent) => {
+      if (!dirty) return;
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", protect);
+    return () => window.removeEventListener("beforeunload", protect);
+  }, [dirty]);
+
+  const commit = (next: TrainingPlanDocument) => {
+    const normalized = withDerivedSportMix(next);
+    setHistory((current) => [...current.slice(0, historyIndex + 1), normalized]);
+    setHistoryIndex((current) => current + 1);
+  };
+
+  const patchPlan = (patch: Partial<TrainingPlanDocument>) => commit({ ...plan, ...patch });
+
+  const addLibraryWorkout = (workout: TrainingLibraryWorkout) => {
+    const sport = workoutSportFromType(workout.sportType) ?? "run";
+    const source: PlanWorkoutEntryInput = {
+      key: `library:${workout.id}`,
+      name: workout.name,
+      sport,
+      save_to_library: false
+    };
+    const entry = planEntryFromWorkout(source, 0, undefined, workout.id);
+    entry.plannedTrainingLoad = workout.trainingLoad;
+    commit({ ...plan, entries: [...plan.entries, entry] });
+  };
+
+  const createWorkout = () => {
+    if (!newWorkoutName.trim()) return;
+    const minutes = Math.max(1, Number(newWorkoutMinutes) || 1);
+    const workout: PlanWorkoutEntryInput = {
+      key: `local:${Date.now()}`,
+      name: newWorkoutName.trim(),
+      sport: newWorkoutSport,
+      steps: [
+        {
+          kind: "training",
+          target_type: "time",
+          target_duration_seconds: minutes * 60,
+          intensity: { type: "none" }
+        }
+      ],
+      save_to_library: false
+    };
+    commit({ ...plan, entries: [...plan.entries, planEntryFromWorkout(workout, 0)] });
+    setNewWorkoutName("");
+    setShowNewWorkout(false);
+  };
+
+  const moveEntry = (entryId: string, weekIndex: number, dayIndex?: number) => {
+    commit({
+      ...plan,
+      entries: plan.entries.map((entry) =>
+        entry.id === entryId ? { ...entry, weekIndex, dayIndex } : entry
+      )
+    });
+  };
+
+  const removeEntry = (entryId: string) => {
+    commit({ ...plan, entries: plan.entries.filter((entry) => entry.id !== entryId) });
+  };
+
+  const addRest = (weekIndex: number, dayIndex: number) => {
+    const rest: TrainingPlanEntry = {
+      id: `rest:${Date.now()}:${weekIndex}:${dayIndex}`,
+      kind: "rest",
+      weekIndex,
+      dayIndex,
+      sortOrder: 0,
+      title: "Rest day"
+    };
+    commit({ ...plan, entries: [...plan.entries, rest] });
+  };
+
+  const close = () => {
+    if (dirty && !window.confirm("Discard unsaved plan changes?")) return;
+    onClose();
+  };
+
+  const save = async () => {
+    if (validation.some((issue) => issue.severity === "error")) return;
+    setSaving(true);
+    try {
+      await onSave(plan);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const drop = (event: DragEvent, weekIndex: number, dayIndex?: number) => {
+    event.preventDefault();
+    const entryId = event.dataTransfer.getData("text/training-plan-entry");
+    if (entryId) moveEntry(entryId, weekIndex, dayIndex);
+  };
+
+  const unscheduled = plan.entries.filter(
+    (entry) => entry.kind === "workout" && entry.dayIndex === undefined
+  );
+
+  return (
+    <section className="plan-editor" aria-label={`Edit ${plan.name}`}>
+      <header className="plan-editor-header">
+        <div>
+          <p className="tl-eyebrow">Plan editor</p>
+          <input
+            className="plan-editor-name"
+            aria-label="Plan name"
+            value={plan.name}
+            onChange={(event) => patchPlan({ name: event.target.value })}
+          />
+          <p>{summary.weekCount} weeks, {summary.workouts} workouts, {Math.round(summary.trainingLoad)} estimated load</p>
+          {plan.source === "coros" ? <span className="plan-editor-source-warning">Native source · Save creates a local copy</span> : null}
+        </div>
+        <div className="plan-editor-header-actions">
+          <button type="button" className="icon-button" aria-label="Undo" disabled={historyIndex === 0} onClick={() => setHistoryIndex((index) => index - 1)}><Undo2 size={17} /></button>
+          <button type="button" className="icon-button" aria-label="Redo" disabled={historyIndex === history.length - 1} onClick={() => setHistoryIndex((index) => index + 1)}><Redo2 size={17} /></button>
+          <button type="button" className="ghost-button" onClick={close}><X size={15} /> Close</button>
+          <button type="button" className="primary-button" disabled={saving || validation.some((issue) => issue.severity === "error")} onClick={() => void save()}><Save size={15} /> {saving ? "Saving..." : "Save plan"}</button>
+        </div>
+      </header>
+
+      <div className="plan-editor-layout">
+        <aside className="plan-editor-sidebar">
+          <section>
+            <h3>Plan details</h3>
+            <label><span>Description</span><textarea value={plan.description} onChange={(event) => patchPlan({ description: event.target.value })} /></label>
+            <label><span>Goal</span><input value={plan.goal} onChange={(event) => patchPlan({ goal: event.target.value })} /></label>
+            <label><span>Difficulty</span><select value={plan.difficulty} onChange={(event) => patchPlan({ difficulty: event.target.value as TrainingPlanDocument["difficulty"] })}><option value="beginner">Beginner</option><option value="intermediate">Intermediate</option><option value="advanced">Advanced</option><option value="custom">Custom</option></select></label>
+            <label><span>Week 1 Monday</span><span className="plan-editor-date"><CalendarRange size={15} /><input type="date" value={plan.startDate ?? ""} onChange={(event) => commit(shiftTrainingPlan(plan, mondayOf(event.target.value)))} /></span></label>
+            <label><span>Notes</span><textarea value={plan.notes} onChange={(event) => patchPlan({ notes: event.target.value })} /></label>
+          </section>
+
+          <section>
+            <div className="plan-editor-section-title"><h3>Workout library</h3><button type="button" className="icon-button" aria-label="Create a new workout" onClick={() => setShowNewWorkout((value) => !value)}><Plus size={16} /></button></div>
+            {showNewWorkout ? <div className="plan-editor-new-workout">
+              <label><span>Name</span><input value={newWorkoutName} onChange={(event) => setNewWorkoutName(event.target.value)} /></label>
+              <label><span>Sport</span><select value={newWorkoutSport} onChange={(event) => setNewWorkoutSport(event.target.value as WorkoutSport)}>{WORKOUT_SPORTS.map((sport) => <option key={sport} value={sport}>{formatWorkoutSport(sport)}</option>)}</select></label>
+              <label><span>Duration</span><span className="plan-editor-duration"><input type="number" min="1" value={newWorkoutMinutes} onChange={(event) => setNewWorkoutMinutes(event.target.value)} /><em>min</em></span></label>
+              <button type="button" className="primary-button" disabled={!newWorkoutName.trim()} onClick={createWorkout}>Add to holding area</button>
+            </div> : null}
+            <div className="plan-editor-library-list">
+              {workouts.slice(0, 40).map((workout) => <button type="button" key={workout.id} onClick={() => addLibraryWorkout(workout)}><span><strong>{workout.name}</strong><small>{formatWorkoutSport(workoutSportFromType(workout.sportType) ?? "run")}</small></span><Plus size={14} /></button>)}
+            </div>
+          </section>
+
+          <section>
+            <h3>Plan phases</h3>
+            <div className="plan-editor-phases">
+              {plan.phases.map((phase) => <span key={phase.id}>{phase.name} <small>W{phase.startWeek}-W{phase.endWeek}</small><button type="button" aria-label={`Remove ${phase.name}`} onClick={() => patchPlan({ phases: plan.phases.filter((item) => item.id !== phase.id) })}><X size={12} /></button></span>)}
+              <button type="button" className="ghost-button" onClick={() => patchPlan({ phases: [...plan.phases, { id: `phase:${Date.now()}`, name: "Base", kind: "base", startWeek: 1, endWeek: Math.max(1, Math.ceil(plan.weekCount / 2)) }] })}><Plus size={13} /> Add phase</button>
+            </div>
+          </section>
+        </aside>
+
+        <main className="plan-editor-main">
+          <section className="plan-holding-area" onDragOver={(event) => event.preventDefault()} onDrop={(event) => drop(event, 0, undefined)}>
+            <div><h3>Holding area</h3><p>Drag unscheduled workouts into a day.</p></div>
+            <div className="plan-holding-list">
+              {unscheduled.length === 0 ? <span className="plan-editor-empty-inline">No unscheduled workouts</span> : unscheduled.map((entry) => <PlanEntryCard key={entry.id} entry={entry} onRemove={() => removeEntry(entry.id)} />)}
+            </div>
+          </section>
+
+          <div className="plan-week-list">
+            {Array.from({ length: plan.weekCount }, (_, weekIndex) => {
+              const weekEntries = plan.entries.filter((entry) => entry.weekIndex === weekIndex && entry.dayIndex !== undefined);
+              const weekSummary = summary.weekly[weekIndex];
+              return <section className="plan-week" key={weekIndex}>
+                <header>
+                  <div><h3>Week {weekIndex + 1}</h3><p>{weekSummary?.workouts ?? 0} workouts, {Math.round(weekSummary?.trainingLoad ?? 0)} load</p></div>
+                  <div>
+                    <button type="button" className="icon-button" aria-label={`Move week ${weekIndex + 1} up`} disabled={weekIndex === 0} onClick={() => commit(reorderTrainingPlanWeek(plan, weekIndex, weekIndex - 1))}><ArrowUp size={15} /></button>
+                    <button type="button" className="icon-button" aria-label={`Move week ${weekIndex + 1} down`} disabled={weekIndex === plan.weekCount - 1} onClick={() => commit(reorderTrainingPlanWeek(plan, weekIndex, weekIndex + 1))}><ArrowDown size={15} /></button>
+                    <button type="button" className="icon-button" aria-label={`Duplicate week ${weekIndex + 1}`} onClick={() => commit(duplicateTrainingPlanWeek(plan, weekIndex))}><Copy size={15} /></button>
+                    <button type="button" className="icon-button" aria-label={`Insert recovery week after week ${weekIndex + 1}`} onClick={() => commit(insertRecoveryWeek(plan, weekIndex))}><RotateCcw size={15} /></button>
+                    <button type="button" className="icon-button danger" aria-label={`Delete week ${weekIndex + 1}`} disabled={plan.weekCount <= 1} onClick={() => { if (weekEntries.length === 0 || window.confirm(`Delete week ${weekIndex + 1} and its ${weekEntries.length} item${weekEntries.length === 1 ? "" : "s"}?`)) commit(removeWeek(plan, weekIndex)); }}><Trash2 size={15} /></button>
+                  </div>
+                </header>
+                <div className="plan-week-days">
+                  {DAY_NAMES.map((day, dayIndex) => {
+                    const entries = weekEntries.filter((entry) => entry.dayIndex === dayIndex).sort((a, b) => a.sortOrder - b.sortOrder);
+                    return <div className="plan-day" key={day} onDragOver={(event) => event.preventDefault()} onDrop={(event) => drop(event, weekIndex, dayIndex)}>
+                      <div className="plan-day-heading"><span><strong>{day}</strong><small>{entryDate(plan, weekIndex, dayIndex)}</small></span><button type="button" aria-label={`Add rest day on ${day}`} onClick={() => addRest(weekIndex, dayIndex)}><CornerDownLeft size={13} /></button></div>
+                      <div className="plan-day-entries">
+                        {entries.map((entry) => <PlanEntryCard key={entry.id} entry={entry} onRemove={() => removeEntry(entry.id)} />)}
+                      </div>
+                    </div>;
+                  })}
+                </div>
+              </section>;
+            })}
+          </div>
+          <button type="button" className="plan-add-week" onClick={() => patchPlan({ weekCount: plan.weekCount + 1 })}><Plus size={15} /> Add week</button>
+        </main>
+
+        <aside className="plan-editor-preview">
+          <h3>Save preview</h3>
+          <dl>
+            <div><dt>Workouts</dt><dd>{summary.workouts}</dd></div>
+            <div><dt>Duration</dt><dd>{Math.round(summary.durationSeconds / 360) / 10} hr</dd></div>
+            <div><dt>Distance</dt><dd>{Math.round(summary.distanceMeters / 100) / 10} km</dd></div>
+            <div><dt>Training load</dt><dd>{Math.round(summary.trainingLoad)}</dd></div>
+            <div><dt>Rest days</dt><dd>{summary.restDays}</dd></div>
+            <div><dt>Peak week</dt><dd>{summary.peakWeek ?? "-"}</dd></div>
+          </dl>
+          {plan.source === "coros" ? <div className="plan-editor-limitation"><AlertTriangle size={16} /><p>This edit will be saved as a local plan. Native plan writes remain disabled until verified.</p></div> : null}
+          {validation.length ? <div className="plan-editor-validation" aria-live="polite">{validation.map((issue, index) => <p className={issue.severity} key={`${issue.path}:${index}`}><AlertTriangle size={13} />{issue.message}</p>)}</div> : <p className="plan-editor-valid">Ready to save.</p>}
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function PlanEntryCard({ entry, onRemove }: { entry: TrainingPlanEntry; onRemove: () => void }) {
+  return <article className={`plan-entry-card is-${entry.kind}`} draggable={entry.kind === "workout"} onDragStart={(event) => event.dataTransfer.setData("text/training-plan-entry", entry.id)}>
+    <span><strong>{entry.title ?? (entry.kind === "rest" ? "Rest day" : "Note")}</strong>{entry.workout?.sport ? <small>{formatWorkoutSport(entry.workout.sport)}</small> : null}</span>
+    <button type="button" aria-label={`Remove ${entry.title ?? entry.kind}`} onClick={onRemove}><X size={12} /></button>
+  </article>;
+}

--- a/src/training-library/PlanEditor.tsx
+++ b/src/training-library/PlanEditor.tsx
@@ -1,14 +1,20 @@
 import {
   AlertTriangle,
   ArrowDown,
+  ArrowLeft,
   ArrowUp,
   CalendarRange,
+  CalendarPlus,
+  CalendarX,
+  CloudOff,
   Copy,
   CornerDownLeft,
+  Pencil,
   Plus,
   Redo2,
   RotateCcw,
   Save,
+  Search,
   Trash2,
   Undo2,
   X
@@ -23,24 +29,46 @@ import type {
 } from "../../electron/types";
 import {
   duplicateTrainingPlanWeek,
+  activeTrainingPlanCalendarInstall,
   insertRecoveryWeek,
   planEntryFromWorkout,
   reorderTrainingPlanWeek,
   shiftTrainingPlan,
   summarizeTrainingPlan,
+  trainingPlanCalendarRevision,
   validateTrainingPlan,
   workoutSportFromType
 } from "../../electron/trainingPlanDomain";
 import { formatWorkoutSport, WORKOUT_SPORTS } from "../../electron/workoutCapabilities";
+import type { CorosLinkApi } from "../coroslink-api";
+import { WorkoutEditorModal } from "../calendar/WorkoutEditorModal";
+import { replaceTrainingPlanEntryWorkout } from "../../electron/planWorkoutEditor";
+import { Ridge } from "./Ridge";
 
 interface PlanEditorProps {
+  api: CorosLinkApi;
   initialPlan: TrainingPlanDocument;
   workouts: TrainingLibraryWorkout[];
+  calendarEnabled: boolean;
+  offline: boolean;
+  onCalendar: (plan: TrainingPlanDocument, operation?: "install" | "remove") => void;
   onSave: (plan: TrainingPlanDocument) => Promise<void>;
   onClose: () => void;
 }
 
 const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+/** Entry cards and library rows carry a dot in the sport's own colour. */
+const SPORT_DOT_CATEGORY: Record<string, string> = {
+  run: "run",
+  bike: "bike",
+  strength: "strength"
+};
+
+function sportDotCategory(sport: WorkoutSport | undefined): string | undefined {
+  if (!sport) return undefined;
+  return SPORT_DOT_CATEGORY[sport] ?? "other";
+}
 
 function withDerivedSportMix(plan: TrainingPlanDocument): TrainingPlanDocument {
   const sports = plan.entries
@@ -79,7 +107,7 @@ function mondayOf(value: string): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 }
 
-export function PlanEditor({ initialPlan, workouts, onSave, onClose }: PlanEditorProps) {
+export function PlanEditor({ api, initialPlan, workouts, calendarEnabled, offline, onCalendar, onSave, onClose }: PlanEditorProps) {
   const [history, setHistory] = useState<TrainingPlanDocument[]>([structuredClone(initialPlan)]);
   const [historyIndex, setHistoryIndex] = useState(0);
   const [saving, setSaving] = useState(false);
@@ -87,10 +115,25 @@ export function PlanEditor({ initialPlan, workouts, onSave, onClose }: PlanEdito
   const [newWorkoutName, setNewWorkoutName] = useState("");
   const [newWorkoutSport, setNewWorkoutSport] = useState<WorkoutSport>("run");
   const [newWorkoutMinutes, setNewWorkoutMinutes] = useState("45");
+  const [libraryQuery, setLibraryQuery] = useState("");
+  const [dropTarget, setDropTarget] = useState<string | null>(null);
+  const [editingEntryId, setEditingEntryId] = useState<string | null>(null);
+  const [workoutEditorError, setWorkoutEditorError] = useState<string | null>(null);
   const plan = history[historyIndex]!;
+  const editingEntry = plan.entries.find((entry) => entry.id === editingEntryId);
   const dirty = JSON.stringify(plan) !== JSON.stringify(initialPlan);
   const validation = useMemo(() => validateTrainingPlan(plan), [plan]);
   const summary = useMemo(() => summarizeTrainingPlan(plan), [plan]);
+  const calendarInstall = activeTrainingPlanCalendarInstall(plan);
+  const retryingInstall = calendarInstall?.state === "partial" && calendarInstall.lastOperation === "install";
+  const calendarDiffers = Boolean(calendarInstall && calendarInstall.planRevision !== trainingPlanCalendarRevision(plan));
+  const libraryMatches = useMemo(() => {
+    const query = libraryQuery.trim().toLowerCase();
+    const matches = query
+      ? workouts.filter((workout) => workout.name.toLowerCase().includes(query))
+      : workouts;
+    return matches.slice(0, 40);
+  }, [workouts, libraryQuery]);
 
   useEffect(() => {
     const protect = (event: BeforeUnloadEvent) => {
@@ -158,6 +201,16 @@ export function PlanEditor({ initialPlan, workouts, onSave, onClose }: PlanEdito
     commit({ ...plan, entries: plan.entries.filter((entry) => entry.id !== entryId) });
   };
 
+  const applyWorkoutEdit = (entryId: string, workout: PlanWorkoutEntryInput) => {
+    commit({
+      ...plan,
+      entries: plan.entries.map((entry) => entry.id === entryId
+        ? replaceTrainingPlanEntryWorkout(entry, workout)
+        : entry)
+    });
+    setEditingEntryId(null);
+  };
+
   const addRest = (weekIndex: number, dayIndex: number) => {
     const rest: TrainingPlanEntry = {
       id: `rest:${Date.now()}:${weekIndex}:${dayIndex}`,
@@ -191,6 +244,24 @@ export function PlanEditor({ initialPlan, workouts, onSave, onClose }: PlanEdito
     if (entryId) moveEntry(entryId, weekIndex, dayIndex);
   };
 
+  /** Lights the day (or the holding area) a dragged card is hovering over. */
+  const dropTargetProps = (key: string, handleDrop: (event: DragEvent) => void) => ({
+    onDragOver: (event: DragEvent) => {
+      event.preventDefault();
+      if (dropTarget !== key) setDropTarget(key);
+    },
+    onDragLeave: (event: DragEvent) => {
+      const next = event.relatedTarget as Node | null;
+      if (!next || !event.currentTarget.contains(next)) {
+        setDropTarget((current) => (current === key ? null : current));
+      }
+    },
+    onDrop: (event: DragEvent) => {
+      setDropTarget(null);
+      handleDrop(event);
+    }
+  });
+
   const unscheduled = plan.entries.filter(
     (entry) => entry.kind === "workout" && entry.dayIndex === undefined
   );
@@ -207,12 +278,16 @@ export function PlanEditor({ initialPlan, workouts, onSave, onClose }: PlanEdito
             onChange={(event) => patchPlan({ name: event.target.value })}
           />
           <p>{summary.weekCount} weeks, {summary.workouts} workouts, {Math.round(summary.trainingLoad)} estimated load</p>
+          {dirty ? <span className="plan-editor-dirty">Unsaved changes</span> : null}
+          {calendarDiffers ? <span className="plan-editor-source-warning">Calendar differs · Remove and reinstall to apply edits</span> : null}
           {plan.source === "coros" ? <span className="plan-editor-source-warning">Native source · Save creates a local copy</span> : null}
         </div>
         <div className="plan-editor-header-actions">
           <button type="button" className="icon-button" aria-label="Undo" disabled={historyIndex === 0} onClick={() => setHistoryIndex((index) => index - 1)}><Undo2 size={17} /></button>
           <button type="button" className="icon-button" aria-label="Redo" disabled={historyIndex === history.length - 1} onClick={() => setHistoryIndex((index) => index + 1)}><Redo2 size={17} /></button>
-          <button type="button" className="ghost-button" onClick={close}><X size={15} /> Close</button>
+          <button type="button" className="ghost-button" onClick={close}><ArrowLeft size={15} /> Back to library</button>
+          {calendarEnabled ? <button type="button" className="ghost-button" disabled={dirty || offline || saving} title={dirty ? "Save the plan before changing its calendar installation" : offline ? "Reconnect to COROS to change the calendar" : undefined} onClick={() => onCalendar(plan, retryingInstall ? "install" : undefined)}>{offline ? <CloudOff size={15} /> : calendarInstall && !retryingInstall ? <CalendarX size={15} /> : <CalendarPlus size={15} />}{retryingInstall ? "Retry calendar install" : calendarInstall ? "Remove from calendar" : "Add to calendar"}</button> : null}
+          {calendarEnabled && retryingInstall ? <button type="button" className="ghost-button" disabled={dirty || offline || saving} onClick={() => onCalendar(plan, "remove")}><CalendarX size={15} /> Remove partial install</button> : null}
           <button type="button" className="primary-button" disabled={saving || validation.some((issue) => issue.severity === "error")} onClick={() => void save()}><Save size={15} /> {saving ? "Saving..." : "Save plan"}</button>
         </div>
       </header>
@@ -229,15 +304,34 @@ export function PlanEditor({ initialPlan, workouts, onSave, onClose }: PlanEdito
           </section>
 
           <section>
-            <div className="plan-editor-section-title"><h3>Workout library</h3><button type="button" className="icon-button" aria-label="Create a new workout" onClick={() => setShowNewWorkout((value) => !value)}><Plus size={16} /></button></div>
+            <div className="plan-editor-section-title">
+              <div>
+                <h3>Workout library</h3>
+                <span>{workouts.length} saved</span>
+              </div>
+              <button
+                type="button"
+                className={`icon-button${showNewWorkout ? " is-active" : ""}`}
+                aria-label={showNewWorkout ? "Close new workout form" : "Create a new workout"}
+                aria-expanded={showNewWorkout}
+                onClick={() => setShowNewWorkout((value) => !value)}
+              >
+                {showNewWorkout ? <X size={15} /> : <Plus size={16} />}
+              </button>
+            </div>
             {showNewWorkout ? <div className="plan-editor-new-workout">
               <label><span>Name</span><input value={newWorkoutName} onChange={(event) => setNewWorkoutName(event.target.value)} /></label>
               <label><span>Sport</span><select value={newWorkoutSport} onChange={(event) => setNewWorkoutSport(event.target.value as WorkoutSport)}>{WORKOUT_SPORTS.map((sport) => <option key={sport} value={sport}>{formatWorkoutSport(sport)}</option>)}</select></label>
               <label><span>Duration</span><span className="plan-editor-duration"><input type="number" min="1" value={newWorkoutMinutes} onChange={(event) => setNewWorkoutMinutes(event.target.value)} /><em>min</em></span></label>
               <button type="button" className="primary-button" disabled={!newWorkoutName.trim()} onClick={createWorkout}>Add to holding area</button>
             </div> : null}
+            <div className="plan-editor-library-search">
+              <Search size={15} aria-hidden />
+              <input value={libraryQuery} onChange={(event) => setLibraryQuery(event.target.value)} placeholder="Filter workouts" aria-label="Filter workouts" />
+              {libraryQuery ? <button type="button" aria-label="Clear workout filter" onClick={() => setLibraryQuery("")}><X size={13} /></button> : null}
+            </div>
             <div className="plan-editor-library-list">
-              {workouts.slice(0, 40).map((workout) => <button type="button" key={workout.id} onClick={() => addLibraryWorkout(workout)}><span><strong>{workout.name}</strong><small>{formatWorkoutSport(workoutSportFromType(workout.sportType) ?? "run")}</small></span><Plus size={14} /></button>)}
+              {libraryMatches.length === 0 ? <p className="plan-editor-empty-inline">No workouts match your filter.</p> : libraryMatches.map((workout) => <button type="button" key={workout.id} data-sport={sportDotCategory(workoutSportFromType(workout.sportType))} aria-label={`Add ${workout.name} to plan`} onClick={() => addLibraryWorkout(workout)}><span><strong>{workout.name}</strong><small>{formatWorkoutSport(workoutSportFromType(workout.sportType) ?? "run")}</small></span><span className="plan-editor-library-add" aria-hidden="true"><Plus size={14} /></span></button>)}
             </div>
           </section>
 
@@ -251,10 +345,10 @@ export function PlanEditor({ initialPlan, workouts, onSave, onClose }: PlanEdito
         </aside>
 
         <main className="plan-editor-main">
-          <section className="plan-holding-area" onDragOver={(event) => event.preventDefault()} onDrop={(event) => drop(event, 0, undefined)}>
+          <section className={`plan-holding-area${dropTarget === "holding" ? " is-drop-target" : ""}`} {...dropTargetProps("holding", (event) => drop(event, 0, undefined))}>
             <div><h3>Holding area</h3><p>Drag unscheduled workouts into a day.</p></div>
             <div className="plan-holding-list">
-              {unscheduled.length === 0 ? <span className="plan-editor-empty-inline">No unscheduled workouts</span> : unscheduled.map((entry) => <PlanEntryCard key={entry.id} entry={entry} onRemove={() => removeEntry(entry.id)} />)}
+              {unscheduled.length === 0 ? <span className="plan-editor-empty-inline">No unscheduled workouts</span> : unscheduled.map((entry) => <PlanEntryCard key={entry.id} entry={entry} onEdit={() => setEditingEntryId(entry.id)} onRemove={() => removeEntry(entry.id)} />)}
             </div>
           </section>
 
@@ -264,7 +358,7 @@ export function PlanEditor({ initialPlan, workouts, onSave, onClose }: PlanEdito
               const weekSummary = summary.weekly[weekIndex];
               return <section className="plan-week" key={weekIndex}>
                 <header>
-                  <div><h3>Week {weekIndex + 1}</h3><p>{weekSummary?.workouts ?? 0} workouts, {Math.round(weekSummary?.trainingLoad ?? 0)} load</p></div>
+                  <div><h3>Week {weekIndex + 1}</h3><p>{weekSummary?.workouts ?? 0} workouts · {Math.round((weekSummary?.durationSeconds ?? 0) / 360) / 10} hr · {Math.round(weekSummary?.trainingLoad ?? 0)} load</p></div>
                   <div>
                     <button type="button" className="icon-button" aria-label={`Move week ${weekIndex + 1} up`} disabled={weekIndex === 0} onClick={() => commit(reorderTrainingPlanWeek(plan, weekIndex, weekIndex - 1))}><ArrowUp size={15} /></button>
                     <button type="button" className="icon-button" aria-label={`Move week ${weekIndex + 1} down`} disabled={weekIndex === plan.weekCount - 1} onClick={() => commit(reorderTrainingPlanWeek(plan, weekIndex, weekIndex + 1))}><ArrowDown size={15} /></button>
@@ -276,10 +370,11 @@ export function PlanEditor({ initialPlan, workouts, onSave, onClose }: PlanEdito
                 <div className="plan-week-days">
                   {DAY_NAMES.map((day, dayIndex) => {
                     const entries = weekEntries.filter((entry) => entry.dayIndex === dayIndex).sort((a, b) => a.sortOrder - b.sortOrder);
-                    return <div className="plan-day" key={day} onDragOver={(event) => event.preventDefault()} onDrop={(event) => drop(event, weekIndex, dayIndex)}>
+                    const dayKey = `week-${weekIndex}-day-${dayIndex}`;
+                    return <div className={`plan-day${dropTarget === dayKey ? " is-drop-target" : ""}`} key={day} {...dropTargetProps(dayKey, (event) => drop(event, weekIndex, dayIndex))}>
                       <div className="plan-day-heading"><span><strong>{day}</strong><small>{entryDate(plan, weekIndex, dayIndex)}</small></span><button type="button" aria-label={`Add rest day on ${day}`} onClick={() => addRest(weekIndex, dayIndex)}><CornerDownLeft size={13} /></button></div>
                       <div className="plan-day-entries">
-                        {entries.map((entry) => <PlanEntryCard key={entry.id} entry={entry} onRemove={() => removeEntry(entry.id)} />)}
+                        {entries.map((entry) => <PlanEntryCard key={entry.id} entry={entry} onEdit={() => setEditingEntryId(entry.id)} onRemove={() => removeEntry(entry.id)} />)}
                       </div>
                     </div>;
                   })}
@@ -292,6 +387,14 @@ export function PlanEditor({ initialPlan, workouts, onSave, onClose }: PlanEdito
 
         <aside className="plan-editor-preview">
           <h3>Save preview</h3>
+          <Ridge
+            values={summary.weekly.map((week) => week.trainingLoad)}
+            peakWeek={summary.peakWeek}
+            unit="load"
+            variant="load"
+            label={`Estimated weekly training load across the ${summary.weekCount} weeks`}
+          />
+          <p className="plan-editor-preview-note">Estimated load by week</p>
           <dl>
             <div><dt>Workouts</dt><dd>{summary.workouts}</dd></div>
             <div><dt>Duration</dt><dd>{Math.round(summary.durationSeconds / 360) / 10} hr</dd></div>
@@ -304,13 +407,26 @@ export function PlanEditor({ initialPlan, workouts, onSave, onClose }: PlanEdito
           {validation.length ? <div className="plan-editor-validation" aria-live="polite">{validation.map((issue, index) => <p className={issue.severity} key={`${issue.path}:${index}`}><AlertTriangle size={13} />{issue.message}</p>)}</div> : <p className="plan-editor-valid">Ready to save.</p>}
         </aside>
       </div>
+      {workoutEditorError ? <div className="plan-editor-workout-error" role="alert"><AlertTriangle size={14} />{workoutEditorError}<button type="button" onClick={() => setWorkoutEditorError(null)}><X size={12} /></button></div> : null}
+      {editingEntry?.kind === "workout" ? (
+        <WorkoutEditorModal
+          api={api}
+          planEntry={editingEntry}
+          onClose={() => setEditingEntryId(null)}
+          onSavedToPlan={(workout) => applyWorkoutEdit(editingEntry.id, workout)}
+          onError={setWorkoutEditorError}
+        />
+      ) : null}
     </section>
   );
 }
 
-function PlanEntryCard({ entry, onRemove }: { entry: TrainingPlanEntry; onRemove: () => void }) {
-  return <article className={`plan-entry-card is-${entry.kind}`} draggable={entry.kind === "workout"} onDragStart={(event) => event.dataTransfer.setData("text/training-plan-entry", entry.id)}>
+function PlanEntryCard({ entry, onEdit, onRemove }: { entry: TrainingPlanEntry; onEdit: () => void; onRemove: () => void }) {
+  return <article className={`plan-entry-card is-${entry.kind}`} data-sport={sportDotCategory(entry.workout?.sport)} draggable={entry.kind === "workout"} onDragStart={(event) => event.dataTransfer.setData("text/training-plan-entry", entry.id)}>
     <span><strong>{entry.title ?? (entry.kind === "rest" ? "Rest day" : "Note")}</strong>{entry.workout?.sport ? <small>{formatWorkoutSport(entry.workout.sport)}</small> : null}</span>
-    <button type="button" aria-label={`Remove ${entry.title ?? entry.kind}`} onClick={onRemove}><X size={12} /></button>
+    <span className="plan-entry-actions">
+      {entry.kind === "workout" ? <button type="button" aria-label={`Edit ${entry.title ?? "workout"}`} onClick={onEdit}><Pencil size={12} /></button> : null}
+      <button type="button" aria-label={`Remove ${entry.title ?? entry.kind}`} onClick={onRemove}><X size={12} /></button>
+    </span>
   </article>;
 }

--- a/src/training-library/Ridge.tsx
+++ b/src/training-library/Ridge.tsx
@@ -1,0 +1,100 @@
+/**
+ * The Training Library draws exactly one kind of picture: a ridge of weekly
+ * training load. `Ridge` puts it on an index row so a plan can be recognised by
+ * its silhouette; `BulletRidge` puts the same axis at reading size so planned
+ * load can be compared against what was actually completed.
+ *
+ * Both keep to a single hue. Height carries the number; nothing else is encoded.
+ */
+
+/** Bars below this share of the peak still get a visible stub. */
+const MINIMUM_SHARE = 0.09;
+/** Only the leading bars stagger, so long plans still settle quickly. */
+const STAGGER_LIMIT = 22;
+
+interface RidgeProps {
+  /** One value per week, in week order. */
+  values: number[];
+  /** 1-based peak week from the plan summary, marked at full strength. */
+  peakWeek?: number;
+  /** Names the quantity, e.g. "load" or "sessions". Used for the tooltip. */
+  unit: string;
+  /**
+   * The accent hue is reserved for training load. A plan with no load data
+   * falls back to session counts, which is drawn in grey so the column's
+   * heading is never contradicted by a bar that looks like load.
+   */
+  variant: "load" | "count";
+  /** Full sentence for assistive technology. */
+  label: string;
+}
+
+export function Ridge({ values, peakWeek, unit, variant, label }: RidgeProps) {
+  if (values.length === 0) {
+    return <span className="tl-ridge is-blank" aria-label="No weeks">&mdash;</span>;
+  }
+
+  const peak = Math.max(...values);
+
+  return (
+    <span
+      className={`tl-ridge${variant === "count" ? " is-count" : ""}`}
+      role="img"
+      aria-label={label}
+    >
+      {values.map((value, index) => {
+        const share = peak > 0 ? value / peak : 0;
+        const marked = peakWeek !== undefined && index === peakWeek - 1 && value > 0;
+        return (
+          <span
+            key={index}
+            className={`tl-ridge-bar${value > 0 ? "" : " is-empty"}${marked ? " is-peak" : ""}`}
+            style={{
+              "--tl-bar-height": value > 0 ? `${Math.max(share, MINIMUM_SHARE) * 100}%` : "2px",
+              "--tl-bar-index": index < STAGGER_LIMIT ? index : STAGGER_LIMIT
+            } as React.CSSProperties}
+          >
+            <span className="sr-only">
+              Week {index + 1}: {Math.round(value)} {unit}
+            </span>
+          </span>
+        );
+      })}
+    </span>
+  );
+}
+
+export interface BulletWeek {
+  weekLabel: string;
+  planned: number;
+  completed: number;
+}
+
+interface BulletRidgeProps {
+  weeks: BulletWeek[];
+  label: string;
+}
+
+/**
+ * Planned load is the pale full-width bar; completed load is the solid bar
+ * inside it. A solid bar taller than its pale bar means the week ran over plan.
+ */
+export function BulletRidge({ weeks, label }: BulletRidgeProps) {
+  const peak = Math.max(1, ...weeks.map((week) => Math.max(week.planned, week.completed)));
+
+  return (
+    <div className="tl-bullets" role="img" aria-label={label}>
+      {weeks.map((week, index) => (
+        <span
+          className="tl-bullet"
+          key={week.weekLabel}
+          title={`${week.weekLabel} — planned ${Math.round(week.planned)}, done ${Math.round(week.completed)}`}
+          style={{ "--tl-bar-index": index < STAGGER_LIMIT ? index : STAGGER_LIMIT } as React.CSSProperties}
+        >
+          <b style={{ "--tl-bar-height": `${(week.planned / peak) * 100}%` } as React.CSSProperties} />
+          <i style={{ "--tl-bar-height": `${(week.completed / peak) * 100}%` } as React.CSSProperties} />
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/training-library/TrainingLibraryView.tsx
+++ b/src/training-library/TrainingLibraryView.tsx
@@ -1,0 +1,1406 @@
+import {
+  AlertTriangle,
+  BookOpen,
+  CalendarClock,
+  CloudOff,
+  Copy,
+  FolderPlus,
+  Heart,
+  LayoutGrid,
+  List,
+  Plus,
+  RefreshCw,
+  Scale,
+  Search,
+  SkipForward,
+  Tag,
+  Trash2,
+  X
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type {
+  TrainingActivityMatch,
+  TrainingCollection,
+  TrainingHubActivity,
+  TrainingHubStatus,
+  TrainingLibrarySnapshot,
+  TrainingPlanDocument,
+  TrainingPlanMetadataPatch
+} from "../../electron/types";
+import {
+  createTrainingPlan,
+  planEntryFromWorkout,
+  summarizeTrainingPlan,
+  workoutSportFromType
+} from "../../electron/trainingPlanDomain";
+import type { CorosLinkApi } from "../coroslink-api";
+import { formatWorkoutSport } from "../../electron/workoutCapabilities";
+import { SelectDropdown } from "../components/SelectDropdown";
+import { BulletRidge, Ridge, type BulletWeek } from "./Ridge";
+import { PlanCompare } from "./PlanCompare";
+import { PlanEditor } from "./PlanEditor";
+import { WorkoutWorkspace } from "./WorkoutWorkspace";
+import "./trainingLibrary.css";
+
+interface TrainingLibraryViewProps {
+  api: CorosLinkApi;
+  status: TrainingHubStatus | null;
+  onOpenTraining: () => void;
+  onMessage: (message: string) => void;
+  onError: (message: string | null) => void;
+}
+
+type LibrarySection = "workouts" | "plans" | "templates" | "adherence";
+
+const SECTIONS: Array<{ id: LibrarySection; label: string }> = [
+  { id: "workouts", label: "Workouts" },
+  { id: "plans", label: "Plans" },
+  { id: "templates", label: "Templates" },
+  { id: "adherence", label: "Adherence" }
+];
+
+/** Sync states worth interrupting the reader for. Everything else stays quiet. */
+const UNSETTLED_SYNC = new Set(["pending", "conflicted", "failed", "stale"]);
+
+function happenDay(offset: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() + offset);
+  return `${date.getFullYear()}${String(date.getMonth() + 1).padStart(2, "0")}${String(date.getDate()).padStart(2, "0")}`;
+}
+
+function happenDayToDate(value: string): Date {
+  return new Date(`${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}T12:00:00`);
+}
+
+function shortDate(date: Date): string {
+  return Number.isNaN(date.valueOf())
+    ? "Unknown"
+    : date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function weekdayLabel(date: Date): string {
+  return Number.isNaN(date.valueOf())
+    ? ""
+    : date.toLocaleDateString(undefined, { weekday: "short" });
+}
+
+function activityDate(activity: TrainingHubActivity): string {
+  const value = activity.startTime ?? 0;
+  return shortDate(new Date(value > 10_000_000_000 ? value : value * 1000));
+}
+
+function formatDuration(seconds?: number): string {
+  if (!seconds) return "—";
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.round((seconds % 3600) / 60);
+  return hours ? `${hours}h ${minutes}m` : `${minutes}m`;
+}
+
+/** Compact elapsed time for the ledger's Updated column. */
+function elapsedLabel(iso: string): string {
+  const then = new Date(iso).valueOf();
+  if (Number.isNaN(then)) return "—";
+  const days = Math.round((Date.now() - then) / 86_400_000);
+  if (days <= 0) return "today";
+  if (days === 1) return "1 day";
+  if (days < 7) return `${days} days`;
+  const weeks = Math.round(days / 7);
+  if (weeks < 6) return `${weeks} wk`;
+  const months = Math.round(days / 30);
+  return months < 12 ? `${months} mo` : `${Math.round(days / 365)} yr`;
+}
+
+function planStartLabel(plan: TrainingPlanDocument): string {
+  if (!plan.startDate) return "Unscheduled";
+  const date = new Date(`${plan.startDate}T12:00:00`);
+  return Number.isNaN(date.valueOf()) ? "Unscheduled" : `Starts ${shortDate(date)}`;
+}
+
+function sourceLabel(source: TrainingPlanDocument["source"]): string {
+  if (source === "coros") return "COROS";
+  if (source === "coach") return "Coach";
+  if (source === "template") return "Template";
+  return "Local";
+}
+
+export function TrainingLibraryView({
+  api,
+  status,
+  onOpenTraining,
+  onMessage,
+  onError
+}: TrainingLibraryViewProps) {
+  const [section, setSection] = useState<LibrarySection>("workouts");
+  const [snapshot, setSnapshot] = useState<TrainingLibrarySnapshot | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [fatalError, setFatalError] = useState<string | null>(null);
+  const [editingPlan, setEditingPlan] = useState<TrainingPlanDocument | null>(null);
+  const [compareOpen, setCompareOpen] = useState(false);
+  const [compareIds, setCompareIds] = useState<string[]>([]);
+  const [pendingPlanDelete, setPendingPlanDelete] = useState<TrainingPlanDocument | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setFatalError(null);
+    try {
+      setSnapshot(await api.getTrainingLibrarySnapshot());
+    } catch (cause) {
+      setFatalError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }, [api]);
+
+  useEffect(() => {
+    if (status?.authenticated) void load();
+  }, [load, status?.authenticated]);
+
+  if (!status?.authenticated) {
+    return (
+      <section className="training-library-gate">
+        <BookOpen size={30} strokeWidth={1.5} />
+        <h1>Training Library</h1>
+        <p>Connect COROS Training Hub to load your workouts, plans, and completed activities.</p>
+        <button type="button" className="primary-button" onClick={onOpenTraining}>
+          Connect Training Hub
+        </button>
+      </section>
+    );
+  }
+
+  if (!snapshot && loading) {
+    return (
+      <section className="training-library-view">
+        <header className="tl-masthead">
+          <h1>Training Library</h1>
+        </header>
+        <div className="tl-skeleton" aria-label="Loading the training library">
+          {Array.from({ length: 7 }, (_, index) => (
+            <span key={index} />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (!snapshot && fatalError) {
+    return (
+      <section className="training-library-gate">
+        <AlertTriangle size={30} strokeWidth={1.5} />
+        <h1>The library didn&rsquo;t load</h1>
+        <p>{fatalError}</p>
+        <button type="button" className="primary-button" onClick={() => void load()}>
+          Try again
+        </button>
+      </section>
+    );
+  }
+
+  const current = snapshot!;
+  const plans = current.plans.filter((plan) => plan.source !== "template");
+  const templates = current.plans.filter((plan) => plan.source === "template");
+  const counts: Record<LibrarySection, number> = {
+    workouts: current.workouts.length,
+    plans: plans.length,
+    templates: templates.length,
+    adherence: current.matches.length
+  };
+
+  const savePlan = async (plan: TrainingPlanDocument) => {
+    try {
+      const saved = await api.saveLocalTrainingPlan(plan);
+      setEditingPlan(null);
+      onMessage(`Saved "${saved.name}" as a local ${saved.source === "template" ? "template" : "plan"}.`);
+      await load();
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  const createPlan = (source: "local" | "template") =>
+    setEditingPlan(createTrainingPlan(source === "template" ? "New template" : "New plan", source));
+
+  const openPlan = async (plan: TrainingPlanDocument) => {
+    if (plan.source !== "coros" || !plan.remoteId) {
+      setEditingPlan(plan);
+      return;
+    }
+    setLoading(true);
+    try {
+      setEditingPlan(await api.getNativeTrainingPlan(plan.remoteId));
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause));
+      setEditingPlan(plan);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const duplicatePlan = async (plan: TrainingPlanDocument) => {
+    const duplicate = createTrainingPlan(
+      `${plan.name} Copy`,
+      plan.source === "template" ? "template" : "local"
+    );
+    duplicate.description = plan.description;
+    duplicate.goal = plan.goal;
+    duplicate.difficulty = plan.difficulty;
+    duplicate.notes = plan.notes;
+    duplicate.sportMix = [...plan.sportMix];
+    duplicate.weekCount = plan.weekCount;
+    duplicate.startDate = plan.startDate;
+    duplicate.phases = structuredClone(plan.phases).map((phase, index) => ({
+      ...phase,
+      id: `${duplicate.id}:phase:${index}`
+    }));
+    duplicate.entries = structuredClone(plan.entries).map((entry, index) => ({
+      ...entry,
+      id: `${duplicate.id}:entry:${index}`,
+      remotePlanProgramId: undefined
+    }));
+    await savePlan(duplicate);
+  };
+
+  const deletePlan = async () => {
+    if (!pendingPlanDelete) return;
+    try {
+      await api.deleteLocalTrainingPlan(pendingPlanDelete.id, true);
+      onMessage(`Deleted "${pendingPlanDelete.name}".`);
+      setPendingPlanDelete(null);
+      await load();
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  const stateLabel = current.offline ? "Offline · cached" : current.stale ? "Partial sync" : "Synced";
+
+  return (
+    <section className="training-library-view">
+      <header className="tl-masthead">
+        <div>
+          <h1>Training Library</h1>
+          <p className="tl-census">
+            <span>
+              <b>{counts.workouts}</b> workouts
+            </span>
+            <span>
+              <b>{counts.plans}</b> plans
+            </span>
+            <span>
+              <b>{counts.templates}</b> templates
+            </span>
+            <span>
+              <b>{counts.adherence}</b> planned sessions
+            </span>
+          </p>
+        </div>
+        <div className="tl-masthead-actions">
+          <span className={`tl-state${current.stale || current.offline ? " is-stale" : ""}`}>
+            {current.offline ? <CloudOff size={13} /> : null}
+            {stateLabel}
+          </span>
+          <button
+            type="button"
+            className="ghost-button"
+            disabled={loading}
+            onClick={() => void load()}
+          >
+            <RefreshCw size={14} className={loading ? "is-spinning" : ""} /> Refresh
+          </button>
+        </div>
+      </header>
+
+      {current.partialFailures.length ? (
+        <details className="tl-notice">
+          <summary>
+            <AlertTriangle size={14} />
+            Some COROS data didn&rsquo;t refresh. Cached items are still shown.
+          </summary>
+          {current.partialFailures.map((failure) => (
+            <p key={failure}>{failure}</p>
+          ))}
+        </details>
+      ) : null}
+
+      <nav className="tl-sections" aria-label="Library sections">
+        {SECTIONS.map(({ id, label }) => (
+          <button
+            type="button"
+            key={id}
+            aria-current={section === id ? "page" : undefined}
+            onClick={() => setSection(id)}
+          >
+            {label}
+            <span>{counts[id]}</span>
+          </button>
+        ))}
+      </nav>
+
+      {section === "workouts" ? (
+        <WorkoutWorkspace
+          api={api}
+          workouts={current.workouts}
+          collections={current.collections}
+          onRefresh={load}
+          onMessage={onMessage}
+          onError={onError}
+        />
+      ) : null}
+
+      {section === "plans" ? (
+        <PlanIndex
+          api={api}
+          noun="plan"
+          plans={plans}
+          collections={current.collections}
+          readOnlyReason={current.nativePlanWrites.reason}
+          onCreate={() => createPlan("local")}
+          onOpen={(plan) => void openPlan(plan)}
+          onDuplicate={(plan) => void duplicatePlan(plan)}
+          onDelete={setPendingPlanDelete}
+          onRefresh={load}
+          onError={onError}
+          onCompare={(ids) => {
+            setCompareIds(ids);
+            setCompareOpen(true);
+          }}
+        />
+      ) : null}
+
+      {section === "templates" ? (
+        <TemplateSection
+          api={api}
+          templates={templates}
+          collections={current.collections}
+          onCreate={() => createPlan("template")}
+          onOpen={setEditingPlan}
+          onDuplicate={(plan) => void duplicatePlan(plan)}
+          onDelete={setPendingPlanDelete}
+          onRefresh={load}
+          onMessage={onMessage}
+          onError={onError}
+        />
+      ) : null}
+
+      {section === "adherence" ? (
+        <AdherenceSection
+          api={api}
+          matches={current.matches}
+          onRefresh={load}
+          onMessage={onMessage}
+          onError={onError}
+        />
+      ) : null}
+
+      {editingPlan ? (
+        <PlanEditor
+          initialPlan={editingPlan}
+          workouts={current.workouts}
+          onSave={savePlan}
+          onClose={() => setEditingPlan(null)}
+        />
+      ) : null}
+
+      {compareOpen ? (
+        <PlanCompare
+          plans={plans}
+          selectedIds={compareIds}
+          onSelectionChange={setCompareIds}
+          onClose={() => setCompareOpen(false)}
+        />
+      ) : null}
+
+      {pendingPlanDelete ? (
+        <div className="tl-dialog-backdrop">
+          <section
+            className="tl-dialog"
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="plan-delete-title"
+          >
+            <h2 id="plan-delete-title">
+              Delete &ldquo;{pendingPlanDelete.name}&rdquo;?
+            </h2>
+            <p>
+              This removes the local copy and its {pendingPlanDelete.entries.length} item
+              {pendingPlanDelete.entries.length === 1 ? "" : "s"}. Plans stored on COROS are not
+              touched.
+            </p>
+            <footer>
+              <button type="button" className="ghost-button" onClick={() => setPendingPlanDelete(null)}>
+                Cancel
+              </button>
+              <button type="button" className="primary-button danger" onClick={() => void deletePlan()}>
+                Delete plan
+              </button>
+            </footer>
+          </section>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+type PlanColumn = "name" | "weeks" | "sessions" | "load" | "updated";
+
+interface PlanSort {
+  column: PlanColumn;
+  descending: boolean;
+}
+
+const PLAN_COLUMNS: Array<{ id: PlanColumn; label: string; numeric: boolean }> = [
+  { id: "weeks", label: "Weeks", numeric: true },
+  { id: "sessions", label: "Sessions", numeric: true },
+  { id: "load", label: "Load", numeric: true },
+  { id: "updated", label: "Updated", numeric: true }
+];
+
+/** Tiles have no column headings to click, so sorting gets its own control. */
+const PLAN_SORT_OPTIONS: Array<{ value: PlanColumn; label: string }> = [
+  { value: "updated", label: "Recently updated" },
+  { value: "name", label: "Name" },
+  { value: "weeks", label: "Weeks" },
+  { value: "sessions", label: "Sessions" },
+  { value: "load", label: "Training load" }
+];
+
+/**
+ * Everything a tile and a row both need, derived once so the two layouts can
+ * never drift apart on what a plan says.
+ */
+function planView(
+  plan: TrainingPlanDocument,
+  summary: ReturnType<typeof summarizeTrainingPlan> | undefined,
+  noun: "plan" | "template"
+) {
+  const weekly = summary?.weekly ?? [];
+  const hasLoad = weekly.some((week) => week.trainingLoad > 0);
+  const sports = plan.sportMix.map((sport) => formatWorkoutSport(sport)).join(", ");
+  const context =
+    plan.goal || plan.description || sports || `${sourceLabel(plan.source)} ${noun}`;
+
+  return {
+    context,
+    sessions: summary?.workouts ?? 0,
+    load: summary?.trainingLoad ? Math.round(summary.trainingLoad) : 0,
+    details: [context, planStartLabel(plan), sourceLabel(plan.source)],
+    ridge: {
+      values: weekly.map((week) => (hasLoad ? week.trainingLoad : week.workouts)),
+      peakWeek: hasLoad ? summary?.peakWeek : undefined,
+      unit: hasLoad ? "load" : "sessions",
+      variant: hasLoad ? ("load" as const) : ("count" as const),
+      label: `${hasLoad ? "Training load" : "Sessions"} across ${weekly.length} weeks`
+    }
+  };
+}
+
+interface PlanIndexProps {
+  api: CorosLinkApi;
+  noun: "plan" | "template";
+  plans: TrainingPlanDocument[];
+  collections: TrainingCollection[];
+  readOnlyReason?: string;
+  onCreate: () => void;
+  onOpen: (plan: TrainingPlanDocument) => void;
+  onDuplicate: (plan: TrainingPlanDocument) => void;
+  onDelete: (plan: TrainingPlanDocument) => void;
+  onRefresh: () => Promise<void>;
+  onError: (message: string | null) => void;
+  onCompare?: (ids: string[]) => void;
+}
+
+function PlanIndex({
+  api,
+  noun,
+  plans,
+  collections,
+  readOnlyReason,
+  onCreate,
+  onOpen,
+  onDuplicate,
+  onDelete,
+  onRefresh,
+  onError,
+  onCompare
+}: PlanIndexProps) {
+  const [query, setQuery] = useState("");
+  const [scope, setScope] = useState("all");
+  const [sort, setSort] = useState<PlanSort>({ column: "updated", descending: true });
+  const [layout, setLayout] = useState<"grid" | "list">("grid");
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const summaries = useMemo(
+    () => new Map(plans.map((plan) => [plan.id, summarizeTrainingPlan(plan)])),
+    [plans]
+  );
+
+  const scopes = useMemo(() => {
+    const options = [{ id: "all", label: "All" }];
+    if (plans.some((plan) => plan.favorite)) options.push({ id: "favorite", label: "Favorites" });
+    for (const source of ["coros", "local", "coach"] as const) {
+      if (plans.some((plan) => plan.source === source)) {
+        options.push({ id: source, label: sourceLabel(source) });
+      }
+    }
+    if (plans.some((plan) => UNSETTLED_SYNC.has(plan.syncState))) {
+      options.push({ id: "unsettled", label: "Needs attention" });
+    }
+    if (plans.some((plan) => plan.archived)) options.push({ id: "archived", label: "Archived" });
+    return options;
+  }, [plans]);
+
+  const visible = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    const matching = plans.filter((plan) => {
+      if (needle) {
+        const haystack = `${plan.name} ${plan.description} ${plan.goal} ${plan.tags.join(" ")} ${plan.sportMix.join(" ")}`;
+        if (!haystack.toLowerCase().includes(needle)) return false;
+      }
+      if (scope === "favorite") return plan.favorite;
+      if (scope === "unsettled") return UNSETTLED_SYNC.has(plan.syncState);
+      if (scope === "archived") return plan.archived;
+      if (scope !== "all") return plan.source === scope && !plan.archived;
+      return !plan.archived;
+    });
+
+    const direction = sort.descending ? -1 : 1;
+    return matching.sort((left, right) => {
+      const leftSummary = summaries.get(left.id);
+      const rightSummary = summaries.get(right.id);
+      if (sort.column === "name") return left.name.localeCompare(right.name) * direction;
+      if (sort.column === "weeks") return (left.weekCount - right.weekCount) * direction;
+      if (sort.column === "sessions") {
+        return ((leftSummary?.workouts ?? 0) - (rightSummary?.workouts ?? 0)) * direction;
+      }
+      if (sort.column === "load") {
+        return ((leftSummary?.trainingLoad ?? 0) - (rightSummary?.trainingLoad ?? 0)) * direction;
+      }
+      return left.updatedAt.localeCompare(right.updatedAt) * direction;
+    });
+  }, [plans, query, scope, sort, summaries]);
+
+  const update = async (planId: string, patch: TrainingPlanMetadataPatch) => {
+    try {
+      await api.updateTrainingPlanMetadata(planId, patch);
+      await onRefresh();
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  const updateSelected = async (patch: TrainingPlanMetadataPatch) => {
+    try {
+      await Promise.all(selected.map((id) => api.updateTrainingPlanMetadata(id, patch)));
+      await onRefresh();
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  const toggleSort = (column: PlanColumn) =>
+    setSort((current) =>
+      current.column === column
+        ? { column, descending: !current.descending }
+        : { column, descending: column !== "name" }
+    );
+
+  const sortIndicator = (column: PlanColumn) =>
+    sort.column === column ? (sort.descending ? " ↓" : " ↑") : "";
+
+  /** Selection and row actions are identical in both layouts. */
+  const selectMark = (plan: TrainingPlanDocument, isSelected: boolean) => (
+    <button
+      type="button"
+      className="tl-mark"
+      role="checkbox"
+      aria-checked={isSelected}
+      aria-label={`Select ${plan.name}`}
+      onClick={() =>
+        setSelected((current) =>
+          current.includes(plan.id)
+            ? current.filter((id) => id !== plan.id)
+            : current.length < 3
+              ? [...current, plan.id]
+              : current
+        )
+      }
+    />
+  );
+
+  const planActions = (plan: TrainingPlanDocument) => (
+    <>
+      <button
+        type="button"
+        aria-label={plan.favorite ? "Remove from favorites" : "Add to favorites"}
+        onClick={() => void update(plan.id, { favorite: !plan.favorite })}
+      >
+        <Heart size={14} fill={plan.favorite ? "currentColor" : "none"} />
+      </button>
+      <button type="button" aria-label={`Duplicate ${plan.name}`} onClick={() => onDuplicate(plan)}>
+        <Copy size={14} />
+      </button>
+      {plan.source !== "coros" ? (
+        <button
+          type="button"
+          className="danger"
+          aria-label={`Delete ${plan.name}`}
+          onClick={() => onDelete(plan)}
+        >
+          <Trash2 size={14} />
+        </button>
+      ) : null}
+    </>
+  );
+
+  return (
+    <div className="tl-panel">
+      <div className="tl-filters">
+        <label className="tl-search">
+          <Search size={15} />
+          <span className="sr-only">Search {noun}s</span>
+          <input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={`Search ${noun}s, goals, and tags`}
+          />
+        </label>
+        <div className="tl-chips" role="group" aria-label={`Filter ${noun}s`}>
+          {scopes.map((option) => (
+            <button
+              type="button"
+              key={option.id}
+              aria-pressed={scope === option.id}
+              onClick={() => setScope(option.id)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+        <div className="tl-filters-tail">
+          <SelectDropdown
+            className="tl-quiet-select"
+            label={`Sort ${noun}s`}
+            value={sort.column}
+            options={PLAN_SORT_OPTIONS}
+            onChange={(value) =>
+              setSort({ column: value, descending: value !== "name" })
+            }
+          />
+          <div className="tl-layout-switch" role="group" aria-label={`${noun} layout`}>
+            <button
+              type="button"
+              aria-pressed={layout === "grid"}
+              aria-label="Show tiles"
+              onClick={() => setLayout("grid")}
+            >
+              <LayoutGrid size={14} />
+            </button>
+            <button
+              type="button"
+              aria-pressed={layout === "list"}
+              aria-label="Show list"
+              onClick={() => setLayout("list")}
+            >
+              <List size={14} />
+            </button>
+          </div>
+          <button type="button" className="primary-button" onClick={onCreate}>
+            <Plus size={14} /> New {noun}
+          </button>
+        </div>
+      </div>
+
+      {readOnlyReason ? (
+        <p className="tl-inline-note">
+          <AlertTriangle size={14} />
+          COROS plans open as read-only copies here. {readOnlyReason}
+        </p>
+      ) : null}
+
+      {selected.length ? (
+        <div className="tl-bulk" role="toolbar" aria-label={`Actions for selected ${noun}s`}>
+          <strong>{selected.length} selected</strong>
+          {onCompare ? (
+            <button
+              type="button"
+              disabled={selected.length < 2 || selected.length > 3}
+              onClick={() => onCompare(selected)}
+            >
+              <Scale size={13} /> Compare
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => {
+              const value = window.prompt("Tags, separated by commas", "");
+              if (value === null) return;
+              void updateSelected({
+                tags: value
+                  .split(",")
+                  .map((item) => item.trim())
+                  .filter(Boolean)
+              });
+            }}
+          >
+            <Tag size={13} /> Tag
+          </button>
+          {collections.length ? (
+            <SelectDropdown
+              className="tl-quiet-select"
+              label={`Move selected ${noun}s to a collection`}
+              value=""
+              options={[
+                { value: "", label: "Move to collection" },
+                ...collections.map((collection) => ({
+                  value: collection.id,
+                  label: collection.name
+                }))
+              ]}
+              onChange={(value) => {
+                if (value) void updateSelected({ collectionId: value });
+              }}
+            />
+          ) : null}
+          <button type="button" aria-label="Clear selection" onClick={() => setSelected([])}>
+            <X size={13} />
+          </button>
+        </div>
+      ) : null}
+
+      {visible.length === 0 ? (
+        <div className="tl-empty">
+          <h3>{query || scope !== "all" ? `No ${noun}s match` : `No ${noun}s yet`}</h3>
+          <p>
+            {query || scope !== "all"
+              ? "Clear the search or choose another filter."
+              : noun === "plan"
+                ? "Build a plan here, or refresh to pull plans from COROS."
+                : "Save a plan as a template, or turn a completed activity into one."}
+          </p>
+        </div>
+      ) : layout === "grid" ? (
+        <ul className="tl-grid" role="list">
+          {visible.map((plan) => {
+            const view = planView(plan, summaries.get(plan.id), noun);
+            const isSelected = selected.includes(plan.id);
+
+            return (
+              <li className={`tl-card${isSelected ? " is-selected" : ""}`} key={plan.id}>
+                {selectMark(plan, isSelected)}
+                <button type="button" className="tl-card-open" onClick={() => onOpen(plan)}>
+                  <span className="tl-card-top">
+                    {plan.favorite ? (
+                      <Heart size={11} fill="currentColor" strokeWidth={0} aria-label="Favorite" />
+                    ) : null}
+                    <em>{sourceLabel(plan.source)}</em>
+                    {UNSETTLED_SYNC.has(plan.syncState) ? (
+                      <i className="tl-flag">{plan.syncState}</i>
+                    ) : null}
+                  </span>
+                  <span className="tl-card-name">{plan.name}</span>
+                  <span className="tl-card-note">
+                    {view.context} · {planStartLabel(plan)}
+                  </span>
+                  <Ridge {...view.ridge} />
+                  <span className="tl-card-figs">
+                    <span>
+                      <b>{plan.weekCount}</b>
+                      <small>weeks</small>
+                    </span>
+                    <span>
+                      <b className={view.sessions ? "" : "is-nil"}>{view.sessions || "—"}</b>
+                      <small>sessions</small>
+                    </span>
+                    <span>
+                      <b className={view.load ? "" : "is-nil"}>{view.load || "—"}</b>
+                      <small>load</small>
+                    </span>
+                  </span>
+                </button>
+                <div className="tl-card-actions">{planActions(plan)}</div>
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <div className="tl-index">
+          <div className="tl-index-head tl-plan-row">
+            <span />
+            <button
+              type="button"
+              className="tl-sortable"
+              aria-pressed={sort.column === "name"}
+              onClick={() => toggleSort("name")}
+            >
+              {noun}
+              {sortIndicator("name")}
+            </button>
+            {PLAN_COLUMNS.map((column) => (
+              <button
+                type="button"
+                key={column.id}
+                className="tl-sortable is-numeric"
+                aria-pressed={sort.column === column.id}
+                onClick={() => toggleSort(column.id)}
+              >
+                {column.label}
+                {sortIndicator(column.id)}
+              </button>
+            ))}
+            <span className="tl-column-label">Weekly load</span>
+            <span />
+          </div>
+
+          <ul role="list">
+            {visible.map((plan) => {
+              const view = planView(plan, summaries.get(plan.id), noun);
+              const isSelected = selected.includes(plan.id);
+
+              return (
+                <li className={`tl-plan-row tl-row${isSelected ? " is-selected" : ""}`} key={plan.id}>
+                  {selectMark(plan, isSelected)}
+                  <button type="button" className="tl-row-open" onClick={() => onOpen(plan)}>
+                    <span className="tl-row-name">
+                      {plan.favorite ? (
+                        <Heart size={12} fill="currentColor" strokeWidth={0} aria-label="Favorite" />
+                      ) : null}
+                      {plan.name}
+                    </span>
+                    <span className="tl-row-sub">
+                      {view.details.map((detail, index) => (
+                        <em key={index}>{detail}</em>
+                      ))}
+                      {UNSETTLED_SYNC.has(plan.syncState) ? (
+                        <i className="tl-flag">{plan.syncState}</i>
+                      ) : null}
+                    </span>
+                  </button>
+                  <span className="tl-fig">{plan.weekCount}</span>
+                  <span className={`tl-fig${view.sessions ? "" : " is-nil"}`}>
+                    {view.sessions || "—"}
+                  </span>
+                  <span className={`tl-fig${view.load ? "" : " is-nil"}`}>{view.load || "—"}</span>
+                  <span className="tl-fig is-quiet">{elapsedLabel(plan.updatedAt)}</span>
+                  <Ridge {...view.ridge} />
+                  <div className="tl-row-actions">{planActions(plan)}</div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface TemplateSectionProps {
+  api: CorosLinkApi;
+  templates: TrainingPlanDocument[];
+  collections: TrainingCollection[];
+  onCreate: () => void;
+  onOpen: (plan: TrainingPlanDocument) => void;
+  onDuplicate: (plan: TrainingPlanDocument) => void;
+  onDelete: (plan: TrainingPlanDocument) => void;
+  onRefresh: () => Promise<void>;
+  onMessage: (message: string) => void;
+  onError: (message: string | null) => void;
+}
+
+function TemplateSection({
+  api,
+  templates,
+  collections,
+  onCreate,
+  onOpen,
+  onDuplicate,
+  onDelete,
+  onRefresh,
+  onMessage,
+  onError
+}: TemplateSectionProps) {
+  const [newCollection, setNewCollection] = useState("");
+
+  const saveCollection = async () => {
+    if (!newCollection.trim()) return;
+    try {
+      await api.saveTrainingCollection({ id: "", name: newCollection.trim() });
+      setNewCollection("");
+      onMessage(`Created the collection "${newCollection.trim()}".`);
+      await onRefresh();
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  return (
+    <div className="tl-template-layout">
+      <PlanIndex
+        api={api}
+        noun="template"
+        plans={templates}
+        collections={collections}
+        onCreate={onCreate}
+        onOpen={onOpen}
+        onDuplicate={onDuplicate}
+        onDelete={onDelete}
+        onRefresh={onRefresh}
+        onError={onError}
+      />
+
+      <aside className="tl-panel tl-collections">
+        <header>
+          <h2>Collections</h2>
+          <p>Local grouping. Nothing here changes a COROS record.</p>
+        </header>
+        <form
+          className="tl-collection-create"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void saveCollection();
+          }}
+        >
+          <input
+            aria-label="New collection name"
+            value={newCollection}
+            onChange={(event) => setNewCollection(event.target.value)}
+            placeholder="Collection name"
+          />
+          <button type="submit" className="ghost-button" disabled={!newCollection.trim()}>
+            <FolderPlus size={14} /> Create
+          </button>
+        </form>
+        {collections.length ? (
+          <ul role="list">
+            {collections.map((collection) => (
+              <li key={collection.id}>
+                <span>
+                  <strong>{collection.name}</strong>
+                  <small>
+                    {templates.filter((plan) => plan.collectionId === collection.id).length} templates
+                  </small>
+                </span>
+                <button
+                  type="button"
+                  aria-label={`Delete the collection ${collection.name}`}
+                  onClick={() => {
+                    if (
+                      !window.confirm(
+                        `Delete the collection "${collection.name}"? Its templates stay in the library.`
+                      )
+                    ) {
+                      return;
+                    }
+                    void api
+                      .deleteTrainingCollection(collection.id, true)
+                      .then(onRefresh)
+                      .catch((cause: unknown) =>
+                        onError(cause instanceof Error ? cause.message : String(cause))
+                      );
+                  }}
+                >
+                  <Trash2 size={13} />
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="tl-collections-empty">
+            No collections yet. Name one above to start grouping templates.
+          </p>
+        )}
+      </aside>
+    </div>
+  );
+}
+
+const ADHERENCE_STATES: Array<{ id: string; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "completed", label: "Completed" },
+  { id: "partial", label: "Partial" },
+  { id: "missed", label: "Missed" },
+  { id: "skipped", label: "Skipped" },
+  { id: "rescheduled", label: "Rescheduled" },
+  { id: "upcoming", label: "Upcoming" }
+];
+
+interface AdherenceSectionProps {
+  api: CorosLinkApi;
+  matches: TrainingActivityMatch[];
+  onRefresh: () => Promise<void>;
+  onMessage: (message: string) => void;
+  onError: (message: string | null) => void;
+}
+
+function AdherenceSection({ api, matches, onRefresh, onMessage, onError }: AdherenceSectionProps) {
+  const [activities, setActivities] = useState<TrainingHubActivity[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [state, setState] = useState("all");
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [activityList] = await Promise.all([
+        api.listTrainingHubActivities(1, 200, happenDay(-120), happenDay(30)),
+        api.refreshTrainingActivityMatches(happenDay(-120), happenDay(30))
+      ]);
+      setActivities(activityList);
+      await onRefresh();
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  }, [api, onError, onRefresh]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const ordered = useMemo(
+    () => [...matches].sort((left, right) => right.happenDay.localeCompare(left.happenDay)),
+    [matches]
+  );
+  const visible = ordered.filter((match) => state === "all" || match.status === state);
+  const settled = matches.filter((match) => match.status !== "upcoming");
+  const honoured = matches.filter(
+    (match) => match.status === "completed" || match.status === "partial"
+  );
+  const completion = settled.length ? Math.round((honoured.length / settled.length) * 100) : 0;
+
+  /** Weekly planned-versus-completed load, oldest week first. */
+  const weeks = useMemo<BulletWeek[]>(() => {
+    const buckets = new Map<string, BulletWeek>();
+    for (const match of matches) {
+      const date = happenDayToDate(match.happenDay);
+      if (Number.isNaN(date.valueOf())) continue;
+      const monday = new Date(date);
+      monday.setDate(monday.getDate() - ((monday.getDay() + 6) % 7));
+      const key = monday.toISOString().slice(0, 10);
+      const bucket = buckets.get(key) ?? {
+        weekLabel: `Week of ${shortDate(monday)}`,
+        planned: 0,
+        completed: 0
+      };
+      bucket.planned += match.plannedTrainingLoad ?? 0;
+      bucket.completed += match.completedTrainingLoad ?? 0;
+      buckets.set(key, bucket);
+    }
+    return [...buckets.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([, week]) => week);
+  }, [matches]);
+
+  const statesPresent = ADHERENCE_STATES.filter(
+    (option) => option.id === "all" || matches.some((match) => match.status === option.id)
+  );
+
+  const activityOptions = useMemo(
+    () => [
+      { value: "", label: "Match an activity" },
+      ...activities.map((activity) => ({
+        value: activity.activityId,
+        label: `${activity.name ?? activity.sportName ?? "Activity"} · ${activityDate(activity)}`
+      }))
+    ],
+    [activities]
+  );
+
+  const createTemplate = async (activity: TrainingHubActivity) => {
+    const plan = createTrainingPlan(
+      `${activity.name || activity.sportName || "Activity"} Template`,
+      "template"
+    );
+    plan.weekCount = 1;
+    const sport = workoutSportFromType(activity.sportType) ?? "run";
+    plan.sportMix = [sport];
+    plan.description = `Created from a completed activity on ${activityDate(activity)}.`;
+    plan.entries = [
+      planEntryFromWorkout(
+        {
+          key: `activity:${activity.activityId}`,
+          name: activity.name || `${formatWorkoutSport(sport)} workout`,
+          sport,
+          distance_km: activity.distance ? activity.distance / 1000 : undefined,
+          steps: activity.duration
+            ? [
+                {
+                  kind: "training",
+                  target_type: "time",
+                  target_duration_seconds: activity.duration,
+                  intensity: { type: "none" }
+                }
+              ]
+            : undefined,
+          save_to_library: false
+        },
+        0,
+        0
+      )
+    ];
+    try {
+      await api.saveLocalTrainingPlan(plan);
+      onMessage(`Saved "${plan.name}" to Templates.`);
+      await onRefresh();
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  const linkActivity = async (match: TrainingActivityMatch, activityId?: string) => {
+    const activity = activities.find((item) => item.activityId === activityId);
+    try {
+      await api.saveManualActivityMatch({
+        ...match,
+        activityId,
+        status: activity ? "completed" : match.happenDay < happenDay(0) ? "missed" : "upcoming",
+        confidence: activity ? 1 : undefined,
+        manual: true,
+        completedDurationSeconds: activity?.duration,
+        completedDistanceMeters: activity?.distance,
+        completedTrainingLoad: activity?.trainingLoad,
+        updatedAt: new Date().toISOString()
+      });
+      await onRefresh();
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  return (
+    <div className="tl-adherence">
+      <section className="tl-panel tl-adherence-lede">
+        <header>
+          <div>
+            <h2>Planned against done</h2>
+            <p>
+              {settled.length
+                ? `${completion}% of ${settled.length} past sessions were matched to a completed activity.`
+                : "No past planned sessions in this range yet."}
+            </p>
+          </div>
+          <button type="button" className="ghost-button" disabled={loading} onClick={() => void refresh()}>
+            <RefreshCw size={14} className={loading ? "is-spinning" : ""} /> Refresh matches
+          </button>
+        </header>
+
+        {weeks.length ? (
+          <figure className="tl-adherence-chart">
+            <BulletRidge weeks={weeks} label="Planned and completed training load by week" />
+            <figcaption>
+              <span>
+                {weeks[0]?.weekLabel} &ndash; {weeks[weeks.length - 1]?.weekLabel}
+              </span>
+              <span className="tl-legend">
+                <em className="is-planned" /> planned
+                <em className="is-done" /> done
+              </span>
+            </figcaption>
+          </figure>
+        ) : null}
+
+        <dl className="tl-tally">
+          {(["completed", "partial", "missed", "upcoming"] as const).map((key) => (
+            <div key={key}>
+              <dt>{key}</dt>
+              <dd>{matches.filter((match) => match.status === key).length}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+
+      <div className="tl-panel">
+        <div className="tl-filters">
+          <div className="tl-chips" role="group" aria-label="Filter planned sessions">
+            {statesPresent.map((option) => (
+              <button
+                type="button"
+                key={option.id}
+                aria-pressed={state === option.id}
+                onClick={() => setState(option.id)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {visible.length === 0 ? (
+          <div className="tl-empty">
+            <h3>{matches.length ? "Nothing in this filter" : "Nothing to compare yet"}</h3>
+            <p>
+              {matches.length
+                ? "Choose another filter to see planned sessions."
+                : "Schedule workouts on the calendar, then refresh here after you finish them."}
+            </p>
+          </div>
+        ) : (
+          <div className="tl-index">
+            <div className="tl-index-head tl-match-row">
+              <span className="tl-column-label">Day</span>
+              <span className="tl-column-label">Planned</span>
+              <span className="tl-column-label">Completed</span>
+              <span className="tl-column-label is-numeric">Match</span>
+              <span />
+            </div>
+            <ul role="list">
+              {visible.map((match) => {
+                const date = happenDayToDate(match.happenDay);
+                const activity = activities.find((item) => item.activityId === match.activityId);
+                const completedParts = [
+                  formatDuration(match.completedDurationSeconds),
+                  match.completedDistanceMeters
+                    ? `${(match.completedDistanceMeters / 1000).toFixed(1)} km`
+                    : null,
+                  match.completedTrainingLoad ? `${Math.round(match.completedTrainingLoad)} load` : null
+                ].filter(Boolean);
+
+                return (
+                  <li className={`tl-match-row tl-row is-${match.status}`} key={match.id}>
+                    <span className="tl-match-day">
+                      <b>{shortDate(date)}</b>
+                      <small>{weekdayLabel(date)}</small>
+                    </span>
+                    <span className="tl-match-planned">
+                      <b>
+                        {match.plannedTrainingLoad
+                          ? `${Math.round(match.plannedTrainingLoad)} load`
+                          : "Structured workout"}
+                      </b>
+                      <small>
+                        {match.plannedDurationSeconds
+                          ? formatDuration(match.plannedDurationSeconds)
+                          : match.status}
+                      </small>
+                    </span>
+                    <span className="tl-match-done">
+                      <SelectDropdown
+                        className="tl-quiet-select is-wide"
+                        label={`Completed activity for ${shortDate(date)}`}
+                        value={match.activityId ?? ""}
+                        options={activityOptions}
+                        onChange={(value) => void linkActivity(match, value || undefined)}
+                      />
+                      {completedParts.length ? <small>{completedParts.join(" · ")}</small> : null}
+                    </span>
+                    <span className={`tl-fig${match.activityId ? "" : " is-nil"}`}>
+                      {match.manual
+                        ? "manual"
+                        : match.confidence
+                          ? `${Math.round(match.confidence * 100)}%`
+                          : "—"}
+                    </span>
+                    <div className="tl-row-actions">
+                      {match.status === "missed" ? (
+                        <button
+                          type="button"
+                          aria-label="Reschedule this session"
+                          onClick={() => {
+                            const value = window.prompt("New date (YYYY-MM-DD)");
+                            if (!value) return;
+                            void api
+                              .rescheduleWorkout(
+                                {
+                                  planId: match.schedulePlanId,
+                                  idInPlan: match.scheduleIdInPlan,
+                                  happenDay: match.happenDay
+                                },
+                                value.replace(/-/g, "")
+                              )
+                              .then(() => {
+                                onMessage("Rescheduled the session.");
+                                return refresh();
+                              })
+                              .catch((cause: unknown) =>
+                                onError(cause instanceof Error ? cause.message : String(cause))
+                              );
+                          }}
+                        >
+                          <CalendarClock size={14} />
+                        </button>
+                      ) : null}
+                      <button
+                        type="button"
+                        aria-label="Skip this session"
+                        onClick={() =>
+                          void api
+                            .saveManualActivityMatch({
+                              ...match,
+                              status: "skipped",
+                              manual: true,
+                              updatedAt: new Date().toISOString()
+                            })
+                            .then(onRefresh)
+                            .catch((cause: unknown) =>
+                              onError(cause instanceof Error ? cause.message : String(cause))
+                            )
+                        }
+                      >
+                        <SkipForward size={14} />
+                      </button>
+                      {activity && (activity.duration || activity.distance) ? (
+                        <button
+                          type="button"
+                          aria-label="Save this activity as a template"
+                          onClick={() => void createTemplate(activity)}
+                        >
+                          <Copy size={14} />
+                        </button>
+                      ) : null}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      <section className="tl-panel tl-recent">
+        <header>
+          <h2>Recent activities</h2>
+          <p>Open Training Hub for charts, laps, route, and strength detail.</p>
+        </header>
+        <div className="tl-index">
+          <div className="tl-index-head tl-activity-row">
+            <span className="tl-column-label">Activity</span>
+            <span className="tl-column-label is-numeric">Time</span>
+            <span className="tl-column-label is-numeric">Distance</span>
+            <span className="tl-column-label is-numeric">Load</span>
+            <span />
+          </div>
+          <ul role="list">
+            {activities.slice(0, 24).map((activity) => (
+              <li className="tl-activity-row tl-row" key={activity.activityId}>
+                <span className="tl-row-open is-static">
+                  <span className="tl-row-name">
+                    {activity.name ?? activity.sportName ?? "Activity"}
+                  </span>
+                  <span className="tl-row-sub">
+                    <em>{activityDate(activity)}</em>
+                    {activity.sportName ? <em>{activity.sportName}</em> : null}
+                  </span>
+                </span>
+                <span className="tl-fig">{formatDuration(activity.duration)}</span>
+                <span className={`tl-fig${activity.distance ? "" : " is-nil"}`}>
+                  {activity.distance ? `${(activity.distance / 1000).toFixed(1)}` : "—"}
+                </span>
+                <span className={`tl-fig${activity.trainingLoad ? "" : " is-nil"}`}>
+                  {activity.trainingLoad ? Math.round(activity.trainingLoad) : "—"}
+                </span>
+                <div className="tl-row-actions">
+                  {activity.duration || activity.distance ? (
+                    <button
+                      type="button"
+                      aria-label={`Save ${activity.name ?? "this activity"} as a template`}
+                      onClick={() => void createTemplate(activity)}
+                    >
+                      <Copy size={14} />
+                    </button>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/training-library/TrainingLibraryView.tsx
+++ b/src/training-library/TrainingLibraryView.tsx
@@ -1,7 +1,9 @@
 import {
   AlertTriangle,
   BookOpen,
+  Bookmark,
   CalendarClock,
+  CalendarRange,
   CloudOff,
   Copy,
   FolderPlus,
@@ -14,8 +16,10 @@ import {
   Search,
   SkipForward,
   Tag,
+  Target,
   Trash2,
-  X
+  X,
+  Zap
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type {
@@ -52,11 +56,11 @@ interface TrainingLibraryViewProps {
 
 type LibrarySection = "workouts" | "plans" | "templates" | "adherence";
 
-const SECTIONS: Array<{ id: LibrarySection; label: string }> = [
-  { id: "workouts", label: "Workouts" },
-  { id: "plans", label: "Plans" },
-  { id: "templates", label: "Templates" },
-  { id: "adherence", label: "Adherence" }
+const SECTIONS: Array<{ id: LibrarySection; label: string; icon: typeof Zap }> = [
+  { id: "workouts", label: "Workouts", icon: Zap },
+  { id: "plans", label: "Plans", icon: CalendarRange },
+  { id: "templates", label: "Templates", icon: Bookmark },
+  { id: "adherence", label: "Adherence", icon: Target }
 ];
 
 /** Sync states worth interrupting the reader for. Everything else stays quiet. */
@@ -176,7 +180,7 @@ export function TrainingLibraryView({
         </header>
         <div className="tl-skeleton" aria-label="Loading the training library">
           {Array.from({ length: 7 }, (_, index) => (
-            <span key={index} />
+            <span key={index} style={{ "--tl-row-index": index } as React.CSSProperties} />
           ))}
         </div>
       </section>
@@ -323,13 +327,14 @@ export function TrainingLibraryView({
       ) : null}
 
       <nav className="tl-sections" aria-label="Library sections">
-        {SECTIONS.map(({ id, label }) => (
+        {SECTIONS.map(({ id, label, icon: Icon }) => (
           <button
             type="button"
             key={id}
             aria-current={section === id ? "page" : undefined}
             onClick={() => setSection(id)}
           >
+            <Icon aria-hidden="true" />
             {label}
             <span>{counts[id]}</span>
           </button>
@@ -1198,7 +1203,7 @@ function AdherenceSection({ api, matches, onRefresh, onMessage, onError }: Adher
 
         <dl className="tl-tally">
           {(["completed", "partial", "missed", "upcoming"] as const).map((key) => (
-            <div key={key}>
+            <div key={key} data-status={key}>
               <dt>{key}</dt>
               <dd>{matches.filter((match) => match.status === key).length}</dd>
             </div>

--- a/src/training-library/TrainingLibraryView.tsx
+++ b/src/training-library/TrainingLibraryView.tsx
@@ -2,8 +2,10 @@ import {
   AlertTriangle,
   BookOpen,
   Bookmark,
+  CalendarPlus,
   CalendarClock,
   CalendarRange,
+  CalendarX,
   CloudOff,
   Copy,
   FolderPlus,
@@ -15,6 +17,7 @@ import {
   Scale,
   Search,
   SkipForward,
+  Sparkles,
   Tag,
   Target,
   Trash2,
@@ -33,8 +36,10 @@ import type {
 } from "../../electron/types";
 import {
   createTrainingPlan,
+  activeTrainingPlanCalendarInstall,
   planEntryFromWorkout,
   summarizeTrainingPlan,
+  trainingPlanCalendarRevision,
   workoutSportFromType
 } from "../../electron/trainingPlanDomain";
 import type { CorosLinkApi } from "../coroslink-api";
@@ -44,12 +49,17 @@ import { BulletRidge, Ridge, type BulletWeek } from "./Ridge";
 import { PlanCompare } from "./PlanCompare";
 import { PlanEditor } from "./PlanEditor";
 import { WorkoutWorkspace } from "./WorkoutWorkspace";
+import { TrainingPlanCalendarDialog } from "./TrainingPlanCalendarDialog";
+import { TrainingPlanGenerator } from "./TrainingPlanGenerator";
 import "./trainingLibrary.css";
 
 interface TrainingLibraryViewProps {
   api: CorosLinkApi;
   status: TrainingHubStatus | null;
   onOpenTraining: () => void;
+  onOpenCoach: (prompt?: string) => void;
+  pendingPlan?: TrainingPlanDocument | null;
+  onPendingPlanConsumed?: () => void;
   onMessage: (message: string) => void;
   onError: (message: string | null) => void;
 }
@@ -131,6 +141,9 @@ export function TrainingLibraryView({
   api,
   status,
   onOpenTraining,
+  onOpenCoach,
+  pendingPlan,
+  onPendingPlanConsumed,
   onMessage,
   onError
 }: TrainingLibraryViewProps) {
@@ -142,6 +155,8 @@ export function TrainingLibraryView({
   const [compareOpen, setCompareOpen] = useState(false);
   const [compareIds, setCompareIds] = useState<string[]>([]);
   const [pendingPlanDelete, setPendingPlanDelete] = useState<TrainingPlanDocument | null>(null);
+  const [generatorOpen, setGeneratorOpen] = useState(false);
+  const [calendarTarget, setCalendarTarget] = useState<{ plan: TrainingPlanDocument; operation?: "install" | "remove" } | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -158,6 +173,13 @@ export function TrainingLibraryView({
   useEffect(() => {
     if (status?.authenticated) void load();
   }, [load, status?.authenticated]);
+
+  useEffect(() => {
+    if (!status?.authenticated || !pendingPlan) return;
+    setSection("plans");
+    setEditingPlan(structuredClone(pendingPlan));
+    onPendingPlanConsumed?.();
+  }, [onPendingPlanConsumed, pendingPlan, status?.authenticated]);
 
   if (!status?.authenticated) {
     return (
@@ -261,6 +283,7 @@ export function TrainingLibraryView({
       id: `${duplicate.id}:entry:${index}`,
       remotePlanProgramId: undefined
     }));
+    duplicate.calendarInstalls = [];
     await savePlan(duplicate);
   };
 
@@ -332,6 +355,7 @@ export function TrainingLibraryView({
             type="button"
             key={id}
             aria-current={section === id ? "page" : undefined}
+            disabled={Boolean(editingPlan)}
             onClick={() => setSection(id)}
           >
             <Icon aria-hidden="true" />
@@ -341,70 +365,79 @@ export function TrainingLibraryView({
         ))}
       </nav>
 
-      {section === "workouts" ? (
-        <WorkoutWorkspace
-          api={api}
-          workouts={current.workouts}
-          collections={current.collections}
-          onRefresh={load}
-          onMessage={onMessage}
-          onError={onError}
-        />
-      ) : null}
-
-      {section === "plans" ? (
-        <PlanIndex
-          api={api}
-          noun="plan"
-          plans={plans}
-          collections={current.collections}
-          readOnlyReason={current.nativePlanWrites.reason}
-          onCreate={() => createPlan("local")}
-          onOpen={(plan) => void openPlan(plan)}
-          onDuplicate={(plan) => void duplicatePlan(plan)}
-          onDelete={setPendingPlanDelete}
-          onRefresh={load}
-          onError={onError}
-          onCompare={(ids) => {
-            setCompareIds(ids);
-            setCompareOpen(true);
-          }}
-        />
-      ) : null}
-
-      {section === "templates" ? (
-        <TemplateSection
-          api={api}
-          templates={templates}
-          collections={current.collections}
-          onCreate={() => createPlan("template")}
-          onOpen={setEditingPlan}
-          onDuplicate={(plan) => void duplicatePlan(plan)}
-          onDelete={setPendingPlanDelete}
-          onRefresh={load}
-          onMessage={onMessage}
-          onError={onError}
-        />
-      ) : null}
-
-      {section === "adherence" ? (
-        <AdherenceSection
-          api={api}
-          matches={current.matches}
-          onRefresh={load}
-          onMessage={onMessage}
-          onError={onError}
-        />
-      ) : null}
-
       {editingPlan ? (
         <PlanEditor
+          key={`${editingPlan.id}:${editingPlan.updatedAt}`}
+          api={api}
           initialPlan={editingPlan}
           workouts={current.workouts}
+          calendarEnabled={current.plans.some((plan) => plan.id === editingPlan.id) && editingPlan.source !== "coros"}
+          offline={current.offline}
+          onCalendar={(plan, operation) => setCalendarTarget({ plan, operation })}
           onSave={savePlan}
           onClose={() => setEditingPlan(null)}
         />
-      ) : null}
+      ) : (
+        <>
+          {section === "workouts" ? (
+            <WorkoutWorkspace
+              api={api}
+              workouts={current.workouts}
+              collections={current.collections}
+              onRefresh={load}
+              onMessage={onMessage}
+              onError={onError}
+            />
+          ) : null}
+
+          {section === "plans" ? (
+            <PlanIndex
+              api={api}
+              noun="plan"
+              plans={plans}
+              collections={current.collections}
+              onCreate={() => createPlan("local")}
+              onGenerate={() => setGeneratorOpen(true)}
+              onCalendar={(plan, operation) => setCalendarTarget({ plan, operation })}
+              offline={current.offline}
+              onOpen={(plan) => void openPlan(plan)}
+              onDuplicate={(plan) => void duplicatePlan(plan)}
+              onDelete={setPendingPlanDelete}
+              onRefresh={load}
+              onError={onError}
+              onCompare={(ids) => {
+                setCompareIds(ids);
+                setCompareOpen(true);
+              }}
+            />
+          ) : null}
+
+          {section === "templates" ? (
+            <TemplateSection
+              api={api}
+              templates={templates}
+              collections={current.collections}
+              onCreate={() => createPlan("template")}
+              onOpen={setEditingPlan}
+              onDuplicate={(plan) => void duplicatePlan(plan)}
+              onDelete={setPendingPlanDelete}
+              onRefresh={load}
+              onMessage={onMessage}
+              onError={onError}
+            />
+          ) : null}
+
+          {section === "adherence" ? (
+            <AdherenceSection
+              api={api}
+              matches={current.matches}
+              onRefresh={load}
+              onMessage={onMessage}
+              onError={onError}
+            />
+          ) : null}
+        </>
+      )}
 
       {compareOpen ? (
         <PlanCompare
@@ -414,6 +447,17 @@ export function TrainingLibraryView({
           onClose={() => setCompareOpen(false)}
         />
       ) : null}
+
+      {generatorOpen ? <TrainingPlanGenerator api={api} onClose={() => setGeneratorOpen(false)} onOpenCoach={onOpenCoach} onGenerated={(plan) => { setGeneratorOpen(false); setEditingPlan(plan); }} /> : null}
+
+      {calendarTarget ? <TrainingPlanCalendarDialog api={api} plan={calendarTarget.plan} requestedOperation={calendarTarget.operation} offline={current.offline} onClose={() => setCalendarTarget(null)} onComplete={(result) => {
+        setCalendarTarget(null);
+        if (editingPlan?.id === result.plan.id) setEditingPlan(result.plan);
+        if (result.failures.length) onMessage(`Updated ${result.scheduledCount + result.removedCount} calendar workout${result.scheduledCount + result.removedCount === 1 ? "" : "s"}; ${result.failures.length} need retry.`);
+        else if (result.scheduledCount) onMessage(`Added ${result.scheduledCount} workouts from "${result.plan.name}" to the COROS calendar.`);
+        else onMessage(`Removed ${result.removedCount} future workouts owned by "${result.plan.name}".`);
+        void load();
+      }} /> : null}
 
       {pendingPlanDelete ? (
         <div className="tl-dialog-backdrop">
@@ -504,8 +548,10 @@ interface PlanIndexProps {
   noun: "plan" | "template";
   plans: TrainingPlanDocument[];
   collections: TrainingCollection[];
-  readOnlyReason?: string;
   onCreate: () => void;
+  onGenerate?: () => void;
+  onCalendar?: (plan: TrainingPlanDocument, operation?: "install" | "remove") => void;
+  offline?: boolean;
   onOpen: (plan: TrainingPlanDocument) => void;
   onDuplicate: (plan: TrainingPlanDocument) => void;
   onDelete: (plan: TrainingPlanDocument) => void;
@@ -519,8 +565,10 @@ function PlanIndex({
   noun,
   plans,
   collections,
-  readOnlyReason,
   onCreate,
+  onGenerate,
+  onCalendar,
+  offline = false,
   onOpen,
   onDuplicate,
   onDelete,
@@ -632,8 +680,10 @@ function PlanIndex({
     />
   );
 
-  const planActions = (plan: TrainingPlanDocument) => (
-    <>
+  const planActions = (plan: TrainingPlanDocument) => {
+    const install = activeTrainingPlanCalendarInstall(plan);
+    const retryingInstall = install?.state === "partial" && install.lastOperation === "install";
+    return <>
       <button
         type="button"
         aria-label={plan.favorite ? "Remove from favorites" : "Add to favorites"}
@@ -644,18 +694,32 @@ function PlanIndex({
       <button type="button" aria-label={`Duplicate ${plan.name}`} onClick={() => onDuplicate(plan)}>
         <Copy size={14} />
       </button>
+      {noun === "plan" && plan.source !== "coros" && onCalendar ? (
+        <button
+          type="button"
+          disabled={offline}
+          title={offline ? "Reconnect to COROS to change the calendar" : undefined}
+          aria-label={`${install && !retryingInstall ? "Remove" : retryingInstall ? "Retry adding" : "Add"} ${plan.name} ${install && !retryingInstall ? "from" : "to"} calendar`}
+          onClick={() => onCalendar(plan, retryingInstall ? "install" : undefined)}
+        >
+          {install && !retryingInstall ? <CalendarX size={14} /> : <CalendarPlus size={14} />}
+        </button>
+      ) : null}
+      {noun === "plan" && plan.source !== "coros" && onCalendar && retryingInstall ? <button type="button" disabled={offline} aria-label={`Remove partial installation of ${plan.name} from calendar`} onClick={() => onCalendar(plan, "remove")}><CalendarX size={14} /></button> : null}
       {plan.source !== "coros" ? (
         <button
           type="button"
           className="danger"
+          disabled={Boolean(activeTrainingPlanCalendarInstall(plan))}
+          title={activeTrainingPlanCalendarInstall(plan) ? "Remove future plan-owned calendar workouts before deleting this plan" : undefined}
           aria-label={`Delete ${plan.name}`}
           onClick={() => onDelete(plan)}
         >
           <Trash2 size={14} />
         </button>
       ) : null}
-    </>
-  );
+    </>;
+  };
 
   return (
     <div className="tl-panel">
@@ -709,18 +773,12 @@ function PlanIndex({
               <List size={14} />
             </button>
           </div>
-          <button type="button" className="primary-button" onClick={onCreate}>
+          <button type="button" className={noun === "plan" && onGenerate ? "ghost-button" : "primary-button"} onClick={onCreate}>
             <Plus size={14} /> New {noun}
           </button>
+          {noun === "plan" && onGenerate ? <button type="button" className="primary-button tl-generate-button" onClick={onGenerate}><Sparkles size={14} /> Generate plan</button> : null}
         </div>
       </div>
-
-      {readOnlyReason ? (
-        <p className="tl-inline-note">
-          <AlertTriangle size={14} />
-          COROS plans open as read-only copies here. {readOnlyReason}
-        </p>
-      ) : null}
 
       {selected.length ? (
         <div className="tl-bulk" role="toolbar" aria-label={`Actions for selected ${noun}s`}>
@@ -801,6 +859,7 @@ function PlanIndex({
                     {UNSETTLED_SYNC.has(plan.syncState) ? (
                       <i className="tl-flag">{plan.syncState}</i>
                     ) : null}
+                    {activeTrainingPlanCalendarInstall(plan) && activeTrainingPlanCalendarInstall(plan)?.planRevision !== trainingPlanCalendarRevision(plan) ? <i className="tl-flag">Calendar differs</i> : null}
                   </span>
                   <span className="tl-card-name">{plan.name}</span>
                   <span className="tl-card-note">
@@ -878,6 +937,7 @@ function PlanIndex({
                       {UNSETTLED_SYNC.has(plan.syncState) ? (
                         <i className="tl-flag">{plan.syncState}</i>
                       ) : null}
+                      {activeTrainingPlanCalendarInstall(plan) && activeTrainingPlanCalendarInstall(plan)?.planRevision !== trainingPlanCalendarRevision(plan) ? <i className="tl-flag">Calendar differs</i> : null}
                     </span>
                   </button>
                   <span className="tl-fig">{plan.weekCount}</span>

--- a/src/training-library/TrainingPlanCalendarDialog.tsx
+++ b/src/training-library/TrainingPlanCalendarDialog.tsx
@@ -1,0 +1,144 @@
+import {
+  AlertTriangle,
+  CalendarPlus,
+  CalendarX,
+  CheckCircle2,
+  LoaderCircle,
+  RefreshCw,
+  X
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import type {
+  TrainingPlanCalendarMutationResult,
+  TrainingPlanCalendarPreview,
+  TrainingPlanDocument
+} from "../../electron/types";
+import { activeTrainingPlanCalendarInstall } from "../../electron/trainingPlanDomain";
+import type { CorosLinkApi } from "../coroslink-api";
+
+interface TrainingPlanCalendarDialogProps {
+  api: CorosLinkApi;
+  plan: TrainingPlanDocument;
+  offline: boolean;
+  requestedOperation?: "install" | "remove";
+  onClose: () => void;
+  onComplete: (result: TrainingPlanCalendarMutationResult) => void;
+}
+
+function mondayOnOrAfter(value = new Date()): string {
+  const date = new Date(value);
+  const offset = (8 - date.getDay()) % 7;
+  date.setDate(date.getDate() + offset);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+function displayDay(value: string): string {
+  const digits = value.replaceAll("-", "");
+  const date = new Date(`${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6)}T12:00:00`);
+  return Number.isNaN(date.valueOf()) ? value : date.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" });
+}
+
+function initialInstallDate(plan: TrainingPlanDocument): string {
+  const value = plan.startDate?.replaceAll("-", "");
+  if (value && /^\d{8}$/.test(value)) {
+    const dashed = `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6)}`;
+    const date = new Date(`${dashed}T12:00:00`);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (!Number.isNaN(date.valueOf()) && date >= today && date.getDay() === 1) return dashed;
+  }
+  return mondayOnOrAfter();
+}
+
+export function TrainingPlanCalendarDialog({ api, plan, offline, requestedOperation, onClose, onComplete }: TrainingPlanCalendarDialogProps) {
+  const install = activeTrainingPlanCalendarInstall(plan);
+  const operation = requestedOperation ?? (install && !(install.state === "partial" && install.lastOperation === "install") ? "remove" : "install");
+  const [startDate, setStartDate] = useState(() => initialInstallDate(plan));
+  const [preview, setPreview] = useState<TrainingPlanCalendarPreview | null>(null);
+  const [loading, setLoading] = useState(operation === "remove" && !offline);
+  const [mutating, setMutating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const conflictCount = useMemo(
+    () => preview?.conflicts.reduce((sum, conflict) => sum + conflict.existing.length, 0) ?? 0,
+    [preview]
+  );
+
+  const loadPreview = async () => {
+    if (offline) return;
+    setLoading(true);
+    setError(null);
+    setPreview(null);
+    try {
+      setPreview(operation === "install"
+        ? await api.previewTrainingPlanCalendar(plan.id, startDate)
+        : await api.previewTrainingPlanCalendarRemoval(plan.id));
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (operation === "remove" && !offline) void loadPreview();
+    // Removal has no editable date; it previews immediately on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || mutating) return;
+      event.preventDefault();
+      onClose();
+    };
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [mutating, onClose]);
+
+  const confirm = async () => {
+    if (!preview || preview.blockers.length > 0) return;
+    setMutating(true);
+    setError(null);
+    try {
+      const result = operation === "install"
+        ? await api.addTrainingPlanToCalendar(preview.previewId, true)
+        : await api.removeTrainingPlanFromCalendar(preview.previewId, true);
+      onComplete(result);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      setPreview(null);
+    } finally {
+      setMutating(false);
+    }
+  };
+
+  return <div className="plan-calendar-backdrop">
+    <section className="plan-calendar-dialog" role="dialog" aria-modal="true" aria-labelledby="plan-calendar-title">
+      <header>
+        <div><p className="tl-eyebrow">COROS calendar</p><h2 id="plan-calendar-title">{operation === "install" ? <CalendarPlus size={20} /> : <CalendarX size={20} />}{operation === "install" ? "Add plan to calendar" : "Remove plan from calendar"}</h2><p>{plan.name}</p></div>
+        <button type="button" className="icon-button" aria-label="Close calendar preview" disabled={mutating} onClick={onClose}><X size={17} /></button>
+      </header>
+
+      {offline ? <div className="plan-calendar-offline"><AlertTriangle size={18} /><div><strong>Calendar actions are unavailable offline</strong><p>Reconnect to COROS, refresh the Training Library, and try again.</p></div></div> : null}
+
+      {!offline && operation === "install" && !preview ? <div className="plan-calendar-start"><label><span>Week 1 Monday</span><input autoFocus type="date" value={startDate} disabled={loading} onChange={(event) => setStartDate(event.target.value)} /></label><p>The preview checks exact dates and shows same-day workouts. Existing workouts are kept and this plan is added alongside them.</p><button type="button" className="primary-button" disabled={loading || !startDate} onClick={() => void loadPreview()}>{loading ? <LoaderCircle className="is-spinning" size={15} /> : <CalendarPlus size={15} />}{loading ? "Checking calendar..." : "Preview dates"}</button></div> : null}
+
+      {!offline && loading ? <div className="plan-calendar-loading"><LoaderCircle className="is-spinning" size={22} /><strong>Checking the COROS calendar</strong><p>Comparing plan dates with current scheduled workouts.</p></div> : null}
+
+      {error ? <div className="plan-calendar-error" role="alert"><AlertTriangle size={17} /><div><strong>Refresh required</strong><p>{error}</p></div><button type="button" className="ghost-button" disabled={loading || mutating} onClick={() => void loadPreview()}><RefreshCw size={14} /> Try again</button></div> : null}
+
+      {preview ? <div className="plan-calendar-preview">
+        <div className="plan-calendar-summary"><span><strong>{preview.entries.length}</strong><small>{operation === "install" ? "workouts to add" : "future workouts to remove"}</small></span><span><strong>{displayDay(preview.startDate)}</strong><small>{operation === "install" ? "Week 1 starts" : "installed start"}</small></span><span className={conflictCount ? "has-conflict" : ""}><strong>{conflictCount}</strong><small>same-day conflicts</small></span></div>
+        {preview.blockers.length ? <div className="plan-calendar-blockers"><strong><AlertTriangle size={15} /> Resolve before continuing</strong>{preview.blockers.map((blocker) => <p key={blocker}>{blocker}</p>)}</div> : null}
+        <div className="plan-calendar-dates" role="list">{preview.entries.map((entry) => {
+          const conflict = preview.conflicts.find((item) => item.happenDay === entry.happenDay);
+          return <article key={`${entry.planEntryId}:${entry.happenDay}`} role="listitem"><time>{displayDay(entry.happenDay)}</time><div><strong>{entry.name}</strong>{conflict ? <small>{conflict.existing.length} existing: {conflict.existing.map((item) => item.name).join(", ")}</small> : <small><CheckCircle2 size={12} /> No same-day conflict</small>}</div></article>;
+        })}</div>
+        {operation === "remove" ? <p className="plan-calendar-safety">Only recorded occurrences owned by this plan dated today or later are removed. Past, completed, and unrelated workouts stay untouched.</p> : null}
+      </div> : null}
+
+      <footer><button type="button" className="ghost-button" disabled={mutating} onClick={onClose}>Cancel</button>{preview ? <button type="button" className={operation === "remove" ? "danger-button" : "primary-button"} disabled={mutating || preview.blockers.length > 0} onClick={() => void confirm()}>{mutating ? <LoaderCircle className="is-spinning" size={15} /> : operation === "install" ? <CalendarPlus size={15} /> : <CalendarX size={15} />}{mutating ? (operation === "install" ? "Adding serially..." : "Removing serially...") : operation === "install" ? "Add alongside conflicts" : "Remove future workouts"}</button> : null}</footer>
+    </section>
+  </div>;
+}

--- a/src/training-library/TrainingPlanGenerator.tsx
+++ b/src/training-library/TrainingPlanGenerator.tsx
@@ -1,0 +1,567 @@
+import {
+  AlertTriangle,
+  ArrowRight,
+  Bike,
+  CalendarDays,
+  Check,
+  Dumbbell,
+  Footprints,
+  Grip,
+  Hand,
+  Info,
+  LoaderCircle,
+  Minus,
+  Mountain,
+  Plus,
+  RotateCw,
+  Snowflake,
+  Sparkles,
+  Trophy,
+  Waves,
+  X
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+import type {
+  ChatProvider,
+  PlanDraftPreview,
+  TrainingPlanDocument,
+  TrainingPlanGenerationRequest,
+  WorkoutSport
+} from "../../electron/types";
+import { trainingPlanFromDraftPreview } from "../../electron/trainingPlanDomain";
+import { formatWorkoutSport, WORKOUT_SPORTS } from "../../electron/workoutCapabilities";
+import type { CorosLinkApi } from "../coroslink-api";
+import { useUnitSystem } from "../units/UnitSystemProvider";
+
+interface TrainingPlanGeneratorProps {
+  api: CorosLinkApi;
+  onClose: () => void;
+  onGenerated: (plan: TrainingPlanDocument) => void;
+  onOpenCoach: (prompt?: string) => void;
+}
+interface ProviderAvailability {
+  provider: ChatProvider;
+  label: string;
+  ready: boolean;
+  detail: string;
+}
+
+const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const DAY_NAMES_FULL = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+
+/**
+ * Sport chip identity: an icon plus the user's customizable sport color token.
+ * Mirrors BUILDER_SPORT_META in AddWorkoutModal.
+ */
+const SPORT_META: Record<WorkoutSport, { Icon: LucideIcon; colorVar: string }> = {
+  run: { Icon: Footprints, colorVar: "var(--sport-run)" },
+  bike: { Icon: Bike, colorVar: "var(--sport-bike)" },
+  swim: { Icon: Waves, colorVar: "var(--sport-other)" },
+  strength: { Icon: Dumbbell, colorVar: "var(--sport-strength)" },
+  trailRun: { Icon: Mountain, colorVar: "var(--sport-trail)" },
+  indoorClimb: { Icon: Grip, colorVar: "var(--sport-other)" },
+  bouldering: { Icon: Hand, colorVar: "var(--sport-other)" },
+  xcSki: { Icon: Snowflake, colorVar: "var(--sport-other)" },
+  hyrox: { Icon: Trophy, colorVar: "var(--sport-strength)" }
+};
+
+const DIFFICULTY_OPTIONS: { value: TrainingPlanGenerationRequest["difficulty"]; label: string; hint: string }[] = [
+  { value: "beginner", label: "Beginner", hint: "New to structured training" },
+  { value: "intermediate", label: "Intermediate", hint: "Training consistently" },
+  { value: "advanced", label: "Advanced", hint: "Strong high-volume base" },
+  { value: "custom", label: "Custom", hint: "Coach judges from your data" }
+];
+
+const EXAMPLE_GOALS = [
+  "Finish my first trail 50K comfortably",
+  "Build a consistent 5K run base",
+  "Hybrid strength and engine for HYROX"
+];
+
+/** Canonical generation stages in order; `id` matches the stage text set by stream events. */
+const STAGE_STEPS = [
+  { id: "Preparing Training Coach context", label: "Preparing context" },
+  { id: "Reviewing training context", label: "Reviewing your training" },
+  { id: "Building the plan structure", label: "Building plan structure" },
+  { id: "Validating workouts and dates", label: "Validating workouts" }
+];
+
+function nextMonday(): string {
+  const date = new Date();
+  const days = (8 - date.getDay()) % 7 || 7;
+  date.setDate(date.getDate() + days);
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+function providerName(provider: ChatProvider): string {
+  if (provider === "claude-code") return "Claude Code";
+  if (provider === "local") return "Local model";
+  return "ChatGPT";
+}
+
+function isMonday(value: string): boolean {
+  const date = new Date(`${value}T12:00:00`);
+  return !Number.isNaN(date.valueOf()) && date.getDay() === 1;
+}
+
+function generationPrompt(request: TrainingPlanGenerationRequest): string {
+  const available = request.availableDayIndexes.map((day) => DAY_NAMES[day]).join(", ");
+  return [
+    "Create a complete structured training plan for the athlete using the current Training Coach context, recovery metrics, recent activities, upcoming schedule, units, and privacy permissions.",
+    "Do not ask a follow-up question. Do not upload, schedule, save, delete, or otherwise write anything remotely.",
+    `Goal: ${request.goal}`,
+    `Sports (use only these): ${request.sports.join(", ")}`,
+    `Difficulty: ${request.difficulty}`,
+    `Length: exactly ${request.weeks} weeks`,
+    `Sessions: exactly ${request.sessionsPerWeek} workouts per week`,
+    `Week 1 Monday: ${request.startDate}`,
+    `Available workout days (use only these): ${available}`,
+    request.maxSessionMinutes ? `Maximum duration for every session: ${request.maxSessionMinutes} minutes` : "No explicit session-duration cap.",
+    request.constraints?.trim() ? `Additional constraints: ${request.constraints.trim()}` : "No additional constraints.",
+    "Every workout must have a schedule_date, explicit sport, and complete typed steps including repeats, targets, and intensities. Set save_to_library to false.",
+    "You MUST call draft_training_plan with the finished plan. Return a short summary only after the tool succeeds. Never call upload_training_plan."
+  ].join("\n");
+}
+
+interface StepperProps {
+  value: number;
+  min: number;
+  max: number;
+  disabled?: boolean;
+  decreaseLabel: string;
+  increaseLabel: string;
+  onChange: (value: number) => void;
+}
+
+function Stepper({ value, min, max, disabled, decreaseLabel, increaseLabel, onChange }: StepperProps) {
+  return (
+    <span className="plan-generator-stepper">
+      <button type="button" aria-label={decreaseLabel} disabled={disabled || value <= min} onClick={() => onChange(Math.max(min, value - 1))}>
+        <Minus size={13} />
+      </button>
+      <strong aria-live="polite">{value}</strong>
+      <button type="button" aria-label={increaseLabel} disabled={disabled || value >= max} onClick={() => onChange(Math.min(max, value + 1))}>
+        <Plus size={13} />
+      </button>
+    </span>
+  );
+}
+export function TrainingPlanGenerator({ api, onClose, onGenerated, onOpenCoach }: TrainingPlanGeneratorProps) {
+  const { unitSystem } = useUnitSystem();
+  const [goal, setGoal] = useState("");
+  const [sports, setSports] = useState<WorkoutSport[]>(["run"]);
+  const [difficulty, setDifficulty] = useState<TrainingPlanGenerationRequest["difficulty"]>("intermediate");
+  const [weeks, setWeeks] = useState(8);
+  const [sessionsPerWeek, setSessionsPerWeek] = useState(4);
+  const [startDate, setStartDate] = useState(nextMonday);
+  const [availableDays, setAvailableDays] = useState([0, 1, 2, 3, 4, 5, 6]);
+  const [maxSessionMinutes, setMaxSessionMinutes] = useState("");
+  const [constraints, setConstraints] = useState("");
+  const [availability, setAvailability] = useState<ProviderAvailability | null>(null);
+  const [checkingProvider, setCheckingProvider] = useState(true);
+  const [generating, setGenerating] = useState(false);
+  const [stage, setStage] = useState("Preparing Training Coach context");
+  const [failure, setFailure] = useState<string | null>(null);
+  const activeRequestId = useRef<string | null>(null);
+  const draftRef = useRef<PlanDraftPreview | null>(null);
+  const requestRef = useRef<TrainingPlanGenerationRequest | null>(null);
+
+  const request = useMemo<TrainingPlanGenerationRequest>(() => ({
+    goal: goal.trim(),
+    sports,
+    difficulty,
+    weeks,
+    sessionsPerWeek,
+    startDate,
+    availableDayIndexes: [...availableDays].sort(),
+    maxSessionMinutes: maxSessionMinutes ? Number(maxSessionMinutes) : undefined,
+    constraints: constraints.trim() || undefined
+  }), [availableDays, constraints, difficulty, goal, maxSessionMinutes, sessionsPerWeek, sports, startDate, weeks]);
+
+  const formValid = Boolean(
+    request.goal && request.sports.length && request.availableDayIndexes.length &&
+    request.weeks >= 1 && request.weeks <= 24 &&
+    request.sessionsPerWeek >= 1 && request.sessionsPerWeek <= Math.min(7, request.availableDayIndexes.length) &&
+    isMonday(request.startDate) &&
+    (request.maxSessionMinutes === undefined || request.maxSessionMinutes > 0)
+  );
+
+  /** Index into STAGE_STEPS for the progress checklist; unknown tool messages map to "reviewing". */
+  const stageIndex = (() => {
+    const exact = STAGE_STEPS.findIndex((step) => step.id === stage);
+    if (exact >= 0) return exact;
+    return stage.includes("Coach tools") ? 1 : 0;
+  })();
+
+  /** Live plan snapshot for the sidebar: total sessions and the full date range. */
+  const snapshot = useMemo(() => {
+    const start = new Date(`${startDate}T12:00:00`);
+    const validStart = !Number.isNaN(start.valueOf());
+    const end = validStart ? new Date(start) : null;
+    if (end) end.setDate(end.getDate() + Math.max(1, weeks) * 7 - 1);
+    const dayFmt = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" });
+    const fullFmt = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric", year: "numeric" });
+    const total = Number.isFinite(weeks * sessionsPerWeek) ? weeks * sessionsPerWeek : 0;
+    return {
+      total,
+      range: end ? `${dayFmt.format(start)} – ${fullFmt.format(end)}` : "Pick a Week 1 Monday"
+    };
+  }, [sessionsPerWeek, startDate, weeks]);
+
+  const daysSummary = useMemo(() => {
+    if (!availableDays.length) return "—";
+    if (availableDays.length === 7) return "Every day";
+    return [...availableDays].sort().map((day) => DAY_NAMES[day]).join(" · ");
+  }, [availableDays]);
+
+  useEffect(() => {
+    let active = true;
+    void api.getChatSettings().then(async (settings) => {
+      const label = providerName(settings.provider);
+      if (settings.provider === "chatgpt") {
+        const status = await api.getChatAuthStatus();
+        if (active) setAvailability({ provider: settings.provider, label, ready: status.signedIn, detail: status.signedIn ? "Signed in and using Coach privacy settings." : "Sign in to ChatGPT in Training Coach settings." });
+      } else if (settings.provider === "claude-code") {
+        const status = await api.getClaudeCodeStatus();
+        if (active) setAvailability({ provider: settings.provider, label, ready: status.authenticated, detail: status.authenticated ? status.message : "Connect Claude Code in Training Coach settings." });
+      } else {
+        const configured = Boolean(settings.local.baseUrl.trim() && settings.local.model.trim());
+        let ready = configured;
+        let detail = configured ? `Configured for ${settings.local.model}.` : "Choose a local endpoint and model in Training Coach settings.";
+        if (configured) {
+          const tested = await api.testLocalChatConnection(settings.local);
+          ready = tested.ok;
+          detail = tested.message;
+        }
+        if (active) setAvailability({ provider: settings.provider, label, ready, detail });
+      }
+    }).catch((cause: unknown) => {
+      if (active) setAvailability({ provider: "chatgpt", label: "Training Coach", ready: false, detail: cause instanceof Error ? cause.message : String(cause) });
+    }).finally(() => { if (active) setCheckingProvider(false); });
+    return () => { active = false; };
+  }, [api]);
+  useEffect(() => {
+    const finishWithDraft = (fullText: string) => {
+      const draft = draftRef.current;
+      const boundRequest = requestRef.current;
+      activeRequestId.current = null;
+      setGenerating(false);
+      if (!draft || !boundRequest) {
+        setFailure(fullText.trim()
+          ? "Training Coach returned guidance, but did not produce a valid structured plan draft."
+          : "Training Coach did not return a structured plan draft.");
+        return;
+      }
+      try {
+        onGenerated(trainingPlanFromDraftPreview(draft, boundRequest));
+      } catch (cause) {
+        setFailure(cause instanceof Error ? cause.message : String(cause));
+      }
+    };
+    const offStart = api.onChatStreamStart((payload) => {
+      if (payload.requestId === activeRequestId.current) setStage("Reviewing training context");
+    });
+    const offToken = api.onChatStreamToken((payload) => {
+      if (payload.requestId === activeRequestId.current) setStage("Building the plan structure");
+    });
+    const offInfo = api.onChatStreamInfo((payload) => {
+      if (payload.requestId !== activeRequestId.current) return;
+      if (payload.kind === "planDraft") {
+        draftRef.current = payload.draft;
+        setStage("Validating workouts and dates");
+      } else if (payload.kind === "mcp") {
+        setStage(payload.message ?? "Checking Training Coach tools");
+      }
+    });
+    const offDone = api.onChatStreamDone((payload) => {
+      if (payload.requestId === activeRequestId.current) finishWithDraft(payload.fullText);
+    });
+    const offError = api.onChatStreamError((payload) => {
+      if (payload.requestId !== activeRequestId.current) return;
+      activeRequestId.current = null;
+      setGenerating(false);
+      setFailure(payload.message);
+    });
+    return () => { offStart(); offToken(); offInfo(); offDone(); offError(); };
+  }, [api, onGenerated]);
+
+  useEffect(() => () => {
+    const requestId = activeRequestId.current;
+    if (requestId) void api.cancelChat(requestId);
+  }, [api]);
+
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      const requestId = activeRequestId.current;
+      if (requestId) void api.cancelChat(requestId);
+      activeRequestId.current = null;
+      onClose();
+    };
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [api, onClose]);
+
+  const close = () => {
+    const requestId = activeRequestId.current;
+    if (requestId) void api.cancelChat(requestId);
+    activeRequestId.current = null;
+    onClose();
+  };
+
+  const generate = async () => {
+    if (!formValid || !availability?.ready) return;
+    const requestId = `training-plan-${crypto.randomUUID()}`;
+    activeRequestId.current = requestId;
+    requestRef.current = structuredClone(request);
+    draftRef.current = null;
+    setFailure(null);
+    setGenerating(true);
+    setStage("Preparing Training Coach context");
+    try {
+      await api.sendChat(requestId, [{ role: "user", content: generationPrompt(request) }], unitSystem);
+    } catch (cause) {
+      if (activeRequestId.current !== requestId) return;
+      activeRequestId.current = null;
+      setGenerating(false);
+      setFailure(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+
+  const toggleSport = (sport: WorkoutSport) => {
+    setSports((current) => current.includes(sport) ? current.filter((item) => item !== sport) : [...current, sport]);
+  };
+
+  const toggleDay = (day: number) => {
+    setAvailableDays((current) => current.includes(day) ? current.filter((item) => item !== day) : [...current, day]);
+  };
+
+  const handoffPrompt = failure ? generationPrompt(request) : undefined;
+
+  /** First blocking problem, shown in the footer so the disabled Generate button explains itself. */
+  const formHint = (() => {
+    if (generating || formValid) return null;
+    if (!request.goal) return "Describe your goal to continue.";
+    if (!request.sports.length) return "Pick at least one sport.";
+    if (!request.availableDayIndexes.length) return "Pick at least one available day.";
+    if (request.sessionsPerWeek > request.availableDayIndexes.length) return `Choose at least ${request.sessionsPerWeek} available days.`;
+    if (!isMonday(request.startDate)) return "Week 1 must start on a Monday.";
+    return "Check the highlighted fields above.";
+  })();
+  return (
+    <div className="plan-generator-backdrop">
+      <section className="plan-generator" role="dialog" aria-modal="true" aria-labelledby="plan-generator-title">
+        <header>
+          <div>
+            <p className="tl-eyebrow">Training Coach</p>
+            <h2 id="plan-generator-title">
+              <span className="plan-generator-title-icon"><Sparkles size={16} /></span>
+              Generate a training plan
+            </h2>
+            <p>Build a structured draft from your current training and recovery context. Nothing is sent to COROS until you install the saved plan.</p>
+          </div>
+          <button type="button" className="icon-button" aria-label="Close plan generator" disabled={generating} onClick={close}><X size={17} /></button>
+        </header>
+
+        <div className="plan-generator-body">
+          <div className="plan-generator-form">
+            <label className="plan-generator-goal">
+              <span>What are you training for?</span>
+              <input autoFocus value={goal} maxLength={180} placeholder="Example: Finish my first trail 50K comfortably" disabled={generating} onChange={(event) => setGoal(event.target.value)} />
+            </label>
+            {!goal.trim() ? (
+              <div className="plan-generator-examples">
+                <span>Try</span>
+                {EXAMPLE_GOALS.map((example) => (
+                  <button type="button" key={example} disabled={generating} onClick={() => setGoal(example)}>{example}</button>
+                ))}
+              </div>
+            ) : null}
+
+            <fieldset>
+              <legend>Sports</legend>
+              <div className="plan-generator-sports">
+                {WORKOUT_SPORTS.map((sport) => {
+                  const meta = SPORT_META[sport];
+                  const selected = sports.includes(sport);
+                  return (
+                    <button
+                      type="button"
+                      key={sport}
+                      className={selected ? "is-selected" : ""}
+                      style={{ "--sport-accent": meta.colorVar } as CSSProperties}
+                      aria-pressed={selected}
+                      disabled={generating}
+                      onClick={() => toggleSport(sport)}
+                    >
+                      <meta.Icon size={13} />
+                      {formatWorkoutSport(sport)}
+                    </button>
+                  );
+                })}
+              </div>
+            </fieldset>
+
+            <fieldset>
+              <legend>Difficulty</legend>
+              <div className="plan-generator-segmented">
+                {DIFFICULTY_OPTIONS.map((option) => (
+                  <button
+                    type="button"
+                    key={option.value}
+                    className={difficulty === option.value ? "is-selected" : ""}
+                    aria-pressed={difficulty === option.value}
+                    disabled={generating}
+                    onClick={() => setDifficulty(option.value)}
+                  >
+                    <strong>{option.label}</strong>
+                    <small>{option.hint}</small>
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+
+            <div className="plan-generator-grid">
+              <label>
+                <span>Weeks</span>
+                <Stepper value={weeks} min={1} max={24} disabled={generating} decreaseLabel="Fewer weeks" increaseLabel="More weeks" onChange={setWeeks} />
+              </label>
+              <label>
+                <span>Sessions / week</span>
+                <Stepper value={sessionsPerWeek} min={1} max={Math.min(7, availableDays.length || 1)} disabled={generating} decreaseLabel="Fewer sessions per week" increaseLabel="More sessions per week" onChange={setSessionsPerWeek} />
+              </label>
+              <label>
+                <span>Week 1 Monday</span>
+                <span className="plan-generator-date">
+                  <CalendarDays size={14} />
+                  <input type="date" value={startDate} disabled={generating} onChange={(event) => setStartDate(event.target.value)} />
+                </span>
+              </label>
+            </div>
+
+            <fieldset>
+              <legend>Available days</legend>
+              <div className="plan-generator-days">
+                {DAY_NAMES.map((day, index) => (
+                  <button
+                    type="button"
+                    key={day}
+                    title={DAY_NAMES_FULL[index]}
+                    aria-pressed={availableDays.includes(index)}
+                    className={availableDays.includes(index) ? "is-selected" : ""}
+                    disabled={generating}
+                    onClick={() => toggleDay(index)}
+                  >
+                    {day}
+                  </button>
+                ))}
+              </div>
+            </fieldset>
+            {sessionsPerWeek > availableDays.length ? <p className="plan-generator-inline-error" role="alert">Choose at least {sessionsPerWeek} available days.</p> : null}
+            {!isMonday(startDate) ? <p className="plan-generator-inline-error" role="alert">Week 1 must start on a Monday.</p> : null}
+
+            <div className="plan-generator-grid is-bottom">
+              <label>
+                <span>Session limit <small>optional</small></span>
+                <span className="plan-generator-duration">
+                  <input type="number" min="10" max="600" value={maxSessionMinutes} placeholder="No limit" disabled={generating} onChange={(event) => setMaxSessionMinutes(event.target.value)} />
+                  <em>min</em>
+                </span>
+              </label>
+              <label className="plan-generator-constraints">
+                <span>Constraints <small>optional</small></span>
+                <textarea rows={3} value={constraints} maxLength={600} placeholder="Injuries, equipment, travel, preferred long day..." disabled={generating} onChange={(event) => setConstraints(event.target.value)} />
+              </label>
+            </div>
+          </div>
+
+          <aside className="plan-generator-status">
+            <p className="tl-eyebrow">Provider</p>
+            {checkingProvider ? (
+              <div className="plan-generator-provider">
+                <span className="plan-generator-provider-icon"><LoaderCircle className="is-spinning" size={15} /></span>
+                <span><strong>Checking Training Coach</strong><small>Using your configured provider</small></span>
+              </div>
+            ) : availability ? (
+              <div className={`plan-generator-provider${availability.ready ? " is-ready" : " is-blocked"}`}>
+                <span className="plan-generator-provider-icon">{availability.ready ? <Check size={15} /> : <AlertTriangle size={15} />}</span>
+                <span><strong>{availability.label}</strong><small>{availability.detail}</small></span>
+              </div>
+            ) : null}
+            {!checkingProvider && !availability?.ready ? <button type="button" className="ghost-button" onClick={() => onOpenCoach()}>Open Coach setup <ArrowRight size={14} /></button> : null}
+
+            <p className="tl-eyebrow plan-generator-aside-eyebrow">Plan snapshot</p>
+            <ul className="plan-generator-snapshot">
+              <li>
+                <span>Sports</span>
+                {sports.length ? (
+                  <span className="plan-generator-snapshot-sports">
+                    {sports.map((sport) => {
+                      const meta = SPORT_META[sport];
+                      return (
+                        <span key={sport} className="plan-generator-snapshot-sport" style={{ "--sport-accent": meta.colorVar } as CSSProperties} title={formatWorkoutSport(sport)}>
+                          <meta.Icon size={12} />
+                        </span>
+                      );
+                    })}
+                  </span>
+                ) : <strong>—</strong>}
+              </li>
+              <li><span>Structure</span><strong>{weeks} weeks · {sessionsPerWeek} / week</strong></li>
+              <li><span>Total sessions</span><strong>{snapshot.total}</strong></li>
+              <li><span>Dates</span><strong>{snapshot.range}</strong></li>
+              <li><span>Days</span><strong>{daysSummary}</strong></li>
+              {maxSessionMinutes ? <li><span>Session cap</span><strong>{maxSessionMinutes} min</strong></li> : null}
+            </ul>
+
+            {generating ? (
+              <div className="plan-generator-progress" aria-live="polite">
+                <span className="plan-generator-pulse"><Sparkles size={18} /></span>
+                <strong>Generating your plan</strong>
+                <ol className="plan-generator-stages">
+                  {STAGE_STEPS.map((step, index) => (
+                    <li key={step.id} className={index < stageIndex ? "is-done" : index === stageIndex ? "is-active" : ""}>
+                      <span className="plan-generator-stage-dot">{index < stageIndex ? <Check size={10} /> : null}</span>
+                      {step.label}
+                    </li>
+                  ))}
+                </ol>
+                {!STAGE_STEPS.some((step) => step.id === stage) ? <p>{stage}</p> : null}
+                <button type="button" className="ghost-button" onClick={close}>Cancel</button>
+              </div>
+            ) : null}
+            {failure ? (
+              <div className="plan-generator-failure" role="alert">
+                <AlertTriangle size={17} />
+                <strong>Draft needs another pass</strong>
+                <p>{failure}</p>
+                <div>
+                  <button type="button" className="ghost-button" disabled={!formValid || !availability?.ready} onClick={() => void generate()}><RotateCw size={14} /> Retry</button>
+                  <button type="button" className="ghost-button" onClick={() => onOpenCoach(handoffPrompt)}>Continue in Coach <ArrowRight size={14} /></button>
+                </div>
+              </div>
+            ) : null}
+            {!generating && !failure ? (
+              <div className="plan-generator-privacy">
+                <strong>Review before saving</strong>
+                <p>The result opens as an unsaved local Coach plan. You can edit every workout before saving or adding it to your calendar.</p>
+              </div>
+            ) : null}
+          </aside>
+        </div>
+
+        <footer>
+          {formHint ? <p className="plan-generator-footer-hint"><Info size={13} />{formHint}</p> : null}
+          <button type="button" className="ghost-button" disabled={generating} onClick={close}>Cancel</button>
+          <button type="button" className="primary-button" disabled={!formValid || !availability?.ready || generating} onClick={() => void generate()}>
+            {generating ? <LoaderCircle className="is-spinning" size={15} /> : <Sparkles size={15} />}
+            {generating ? "Generating..." : "Generate plan"}
+          </button>
+        </footer>
+      </section>
+    </div>
+  );
+}

--- a/src/training-library/WorkoutWorkspace.tsx
+++ b/src/training-library/WorkoutWorkspace.tsx
@@ -4,6 +4,7 @@ import {
   Download,
   Heart,
   LayoutGrid,
+  Link2,
   List,
   LoaderCircle,
   Pencil,
@@ -11,6 +12,7 @@ import {
   Search,
   Tag,
   Trash2,
+  Unlink,
   X
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -23,6 +25,7 @@ import type {
 } from "../../electron/types";
 import type { CorosLinkApi } from "../coroslink-api";
 import { formatHappenDayLabel } from "../training/formatters";
+import { sportColorCategory } from "../training/sportColors";
 import { formatWorkoutSport } from "../../electron/workoutCapabilities";
 import { workoutSportFromType } from "../../electron/trainingPlanDomain";
 import { SelectDropdown } from "../components/SelectDropdown";
@@ -63,6 +66,16 @@ const UNSETTLED_SYNC = new Set(["pending", "conflicted", "failed", "stale"]);
 /** Enough segments to read an interval comb without drawing thousands of them. */
 const SHAPE_SEGMENT_LIMIT = 96;
 
+/** Legend wording for the step kinds the shape bar can draw, in session order. */
+const STEP_KIND_LABELS: Record<string, string> = {
+  warmup: "Warm-up",
+  training: "Work",
+  rest: "Rest",
+  cooldown: "Cool-down",
+  sendOff: "Send-off"
+};
+const STEP_KIND_ORDER = Object.keys(STEP_KIND_LABELS);
+
 function metricFromVolume(volume: string | undefined, kind: "duration" | "distance"): number {
   const value = volume?.toLowerCase() ?? "";
   if (kind === "duration") {
@@ -95,6 +108,11 @@ function targetLabel(node: RunWorkoutEditorNode): string {
   if (target.type === "elevationGain") return `${target.meters} m gain`;
   if (target.type === "hrRecovery") return `${target.bpm} bpm recovery`;
   return "Open";
+}
+
+/** Repeat groups carry no kind of their own; they borrow their first child's. */
+function nodeKind(node: RunWorkoutEditorNode): string | undefined {
+  return node.nodeType === "step" ? node.kind : node.steps[0]?.kind;
 }
 
 interface ShapeSegment {
@@ -230,6 +248,11 @@ export function WorkoutWorkspace({
   const shape = useMemo(
     () => (previewDocument ? workoutShape(previewDocument.draft.nodes) : []),
     [previewDocument]
+  );
+  /** Kinds actually drawn, in session order, so the legend never lists a ghost. */
+  const shapeKinds = useMemo(
+    () => STEP_KIND_ORDER.filter((kind) => shape.some((segment) => segment.kind === kind)),
+    [shape]
   );
 
   useEffect(() => {
@@ -626,7 +649,10 @@ export function WorkoutWorkspace({
         ) : (
           <>
             <header>
-              <p className="tl-eyebrow">
+              <p
+                className="tl-eyebrow tl-reader-sport"
+                data-sport={sportColorCategory(active.sportType)}
+              >
                 {formatWorkoutSport(workoutSportFromType(active.sportType) ?? "run")}
               </p>
               <h2>{active.name}</h2>
@@ -643,7 +669,7 @@ export function WorkoutWorkspace({
             <dl className="tl-reader-metrics">
               <div>
                 <dt>Time</dt>
-                <dd>
+                <dd className={previewMetrics?.durationSeconds ? "" : "is-nil"}>
                   {previewMetrics?.durationSeconds
                     ? `${Math.round(previewMetrics.durationSeconds / 60)}m`
                     : "—"}
@@ -651,7 +677,7 @@ export function WorkoutWorkspace({
               </div>
               <div>
                 <dt>Distance</dt>
-                <dd>
+                <dd className={previewMetrics?.distanceMeters || active.volume ? "" : "is-nil"}>
                   {previewMetrics?.distanceMeters
                     ? `${(previewMetrics.distanceMeters / 1000).toFixed(1)} km`
                     : (active.volume ?? "—")}
@@ -659,7 +685,7 @@ export function WorkoutWorkspace({
               </div>
               <div>
                 <dt>Load</dt>
-                <dd>
+                <dd className={previewMetrics?.trainingLoad || active.trainingLoad ? "" : "is-nil"}>
                   {previewMetrics?.trainingLoad
                     ? Math.round(previewMetrics.trainingLoad)
                     : active.trainingLoad
@@ -669,7 +695,9 @@ export function WorkoutWorkspace({
               </div>
               <div>
                 <dt>Steps</dt>
-                <dd>{previewDocument?.draft.nodes.length ?? "—"}</dd>
+                <dd className={previewDocument?.draft.nodes.length ? "" : "is-nil"}>
+                  {previewDocument?.draft.nodes.length ?? "—"}
+                </dd>
               </div>
             </dl>
 
@@ -685,7 +713,19 @@ export function WorkoutWorkspace({
                     />
                   ))}
                 </div>
-                <figcaption>Step structure, by share of the session</figcaption>
+                <figcaption>
+                  <span>Step structure, by share of the session</span>
+                  {shapeKinds.length ? (
+                    <span className="tl-shape-legend" aria-hidden="true">
+                      {shapeKinds.map((kind) => (
+                        <span key={kind}>
+                          <em className={`is-${kind}`} />
+                          {STEP_KIND_LABELS[kind]}
+                        </span>
+                      ))}
+                    </span>
+                  ) : null}
+                </figcaption>
               </figure>
             ) : null}
 
@@ -696,10 +736,12 @@ export function WorkoutWorkspace({
             ) : previewDocument ? (
               <ol className="tl-steps">
                 {previewDocument.draft.nodes.map((node) => (
-                  <li key={node.id}>
+                  <li key={node.id} data-kind={nodeKind(node)}>
                     <span className="tl-step-head">
                       <b>{node.name}</b>
-                      <small>{targetLabel(node)}</small>
+                      <small className={node.nodeType === "repeat" ? "is-rounds" : ""}>
+                        {targetLabel(node)}
+                      </small>
                     </span>
                     {node.nodeType === "repeat" ? (
                       <span className="tl-step-children">
@@ -720,13 +762,46 @@ export function WorkoutWorkspace({
               </ol>
             ) : null}
 
-            <p className="tl-reader-references">
-              {active.usedByPlanIds.length || active.scheduledCount
-                ? `Used by ${active.usedByPlanIds.length} plan${
+            <p
+              className={`tl-reader-references${
+                active.usedByPlanIds.length || active.scheduledCount ? " is-linked" : ""
+              }`}
+            >
+              {active.usedByPlanIds.length || active.scheduledCount ? (
+                <>
+                  <Link2 size={13} />
+                  {`Used by ${active.usedByPlanIds.length} plan${
                     active.usedByPlanIds.length === 1 ? "" : "s"
-                  } and scheduled ${active.scheduledCount} time${active.scheduledCount === 1 ? "" : "s"}.`
-                : "Not referenced by a plan or a calendar day."}
+                  } and scheduled ${active.scheduledCount} time${active.scheduledCount === 1 ? "" : "s"}.`}
+                </>
+              ) : (
+                <>
+                  <Unlink size={13} />
+                  Not referenced by a plan or a calendar day.
+                </>
+              )}
             </p>
+
+            <form
+              className="tl-reader-schedule"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void schedule();
+              }}
+            >
+              <label>
+                <span>Put it on the calendar</span>
+                <input
+                  type="date"
+                  value={scheduleDate}
+                  min={tomorrow()}
+                  onChange={(event) => setScheduleDate(event.target.value)}
+                />
+              </label>
+              <button type="submit" className="primary-button" disabled={!scheduleDate || busy === "schedule"}>
+                <CalendarPlus size={14} /> {busy === "schedule" ? "Scheduling" : "Schedule"}
+              </button>
+            </form>
 
             <div className="tl-reader-actions">
               <button
@@ -766,27 +841,6 @@ export function WorkoutWorkspace({
                 <Trash2 size={14} /> Delete
               </button>
             </div>
-
-            <form
-              className="tl-reader-schedule"
-              onSubmit={(event) => {
-                event.preventDefault();
-                void schedule();
-              }}
-            >
-              <label>
-                <span>Put it on the calendar</span>
-                <input
-                  type="date"
-                  value={scheduleDate}
-                  min={tomorrow()}
-                  onChange={(event) => setScheduleDate(event.target.value)}
-                />
-              </label>
-              <button type="submit" className="primary-button" disabled={!scheduleDate || busy === "schedule"}>
-                <CalendarPlus size={14} /> {busy === "schedule" ? "Scheduling" : "Schedule"}
-              </button>
-            </form>
           </>
         )}
       </aside>

--- a/src/training-library/WorkoutWorkspace.tsx
+++ b/src/training-library/WorkoutWorkspace.tsx
@@ -401,6 +401,20 @@ export function WorkoutWorkspace({
       ? [active]
       : [];
 
+  /*
+   * Reader figures resolve once, so a cell the strip has to ellipsize can
+   * still carry its full string on the title attribute.
+   */
+  const readerTime = previewMetrics?.durationSeconds
+    ? `${Math.round(previewMetrics.durationSeconds / 60)}m`
+    : null;
+  const readerDistance = previewMetrics?.distanceMeters
+    ? `${(previewMetrics.distanceMeters / 1000).toFixed(1)} km`
+    : (active?.volume ?? null);
+  const readerLoadSource = previewMetrics?.trainingLoad || active?.trainingLoad;
+  const readerLoad = readerLoadSource ? Math.round(readerLoadSource) : null;
+  const readerSteps = previewDocument?.draft.nodes.length ?? null;
+
   return (
     <div className="tl-panel tl-split">
       <section className="tl-catalog" aria-label={`${filtered.length} workouts`}>
@@ -648,56 +662,55 @@ export function WorkoutWorkspace({
           </div>
         ) : (
           <>
-            <header>
-              <p
-                className="tl-eyebrow tl-reader-sport"
-                data-sport={sportColorCategory(active.sportType)}
-              >
-                {formatWorkoutSport(workoutSportFromType(active.sportType) ?? "run")}
-              </p>
-              <h2>{active.name}</h2>
-              <button
-                type="button"
-                className={`tl-reader-favorite${active.favorite ? " is-active" : ""}`}
-                aria-label={active.favorite ? "Remove from favorites" : "Add to favorites"}
-                onClick={() => void updateMetadata([active.id], { favorite: !active.favorite })}
-              >
-                <Heart size={16} fill={active.favorite ? "currentColor" : "none"} />
-              </button>
-            </header>
+            <div className="tl-reader-scroll">
+              <header>
+                <p
+                  className="tl-eyebrow tl-reader-sport"
+                  data-sport={sportColorCategory(active.sportType)}
+                >
+                  {formatWorkoutSport(workoutSportFromType(active.sportType) ?? "run")}
+                </p>
+                <h2>{active.name}</h2>
+                {active.tags.length ? (
+                  <ul className="tl-reader-tags" aria-label="Workout tags">
+                    {active.tags.slice(0, 8).map((tag) => (
+                      <li key={tag}>{tag}</li>
+                    ))}
+                    {active.tags.length > 8 ? <li>+{active.tags.length - 8} more</li> : null}
+                  </ul>
+                ) : null}
+                <button
+                  type="button"
+                  className={`tl-reader-favorite${active.favorite ? " is-active" : ""}`}
+                  aria-label={active.favorite ? "Remove from favorites" : "Add to favorites"}
+                  onClick={() => void updateMetadata([active.id], { favorite: !active.favorite })}
+                >
+                  <Heart size={16} fill={active.favorite ? "currentColor" : "none"} />
+                </button>
+              </header>
 
-            <dl className="tl-reader-metrics">
+              <dl className="tl-reader-metrics">
               <div>
                 <dt>Time</dt>
-                <dd className={previewMetrics?.durationSeconds ? "" : "is-nil"}>
-                  {previewMetrics?.durationSeconds
-                    ? `${Math.round(previewMetrics.durationSeconds / 60)}m`
-                    : "—"}
+                <dd className={readerTime ? "" : "is-nil"} title={readerTime ?? undefined}>
+                  {readerTime ?? "—"}
                 </dd>
               </div>
               <div>
                 <dt>Distance</dt>
-                <dd className={previewMetrics?.distanceMeters || active.volume ? "" : "is-nil"}>
-                  {previewMetrics?.distanceMeters
-                    ? `${(previewMetrics.distanceMeters / 1000).toFixed(1)} km`
-                    : (active.volume ?? "—")}
+                <dd className={readerDistance ? "" : "is-nil"} title={readerDistance ?? undefined}>
+                  {readerDistance ?? "—"}
                 </dd>
               </div>
               <div>
                 <dt>Load</dt>
-                <dd className={previewMetrics?.trainingLoad || active.trainingLoad ? "" : "is-nil"}>
-                  {previewMetrics?.trainingLoad
-                    ? Math.round(previewMetrics.trainingLoad)
-                    : active.trainingLoad
-                      ? Math.round(active.trainingLoad)
-                      : "—"}
+                <dd className={readerLoad ? "" : "is-nil"} title={readerLoad ? String(readerLoad) : undefined}>
+                  {readerLoad ?? "—"}
                 </dd>
               </div>
               <div>
                 <dt>Steps</dt>
-                <dd className={previewDocument?.draft.nodes.length ? "" : "is-nil"}>
-                  {previewDocument?.draft.nodes.length ?? "—"}
-                </dd>
+                <dd className={readerSteps ? "" : "is-nil"}>{readerSteps ?? "—"}</dd>
               </div>
             </dl>
 
@@ -734,32 +747,37 @@ export function WorkoutWorkspace({
                 <LoaderCircle className="is-spinning" size={16} /> Loading the full structure
               </p>
             ) : previewDocument ? (
-              <ol className="tl-steps">
-                {previewDocument.draft.nodes.map((node) => (
-                  <li key={node.id} data-kind={nodeKind(node)}>
-                    <span className="tl-step-head">
-                      <b>{node.name}</b>
-                      <small className={node.nodeType === "repeat" ? "is-rounds" : ""}>
-                        {targetLabel(node)}
-                      </small>
-                    </span>
-                    {node.nodeType === "repeat" ? (
-                      <span className="tl-step-children">
-                        {node.steps.map((step) => (
-                          <em key={step.id}>
-                            {step.name} <small>{targetLabel(step)}</small>
-                          </em>
-                        ))}
+              <div className="tl-steps-block">
+                <p className="tl-steps-label">
+                  Session steps <span>{previewDocument.draft.nodes.length}</span>
+                </p>
+                <ol className="tl-steps">
+                  {previewDocument.draft.nodes.map((node) => (
+                    <li key={node.id} data-kind={nodeKind(node)}>
+                      <span className="tl-step-head">
+                        <b>{node.name}</b>
+                        <small className={node.nodeType === "repeat" ? "is-rounds" : ""}>
+                          {targetLabel(node)}
+                        </small>
                       </span>
-                    ) : null}
-                    {!node.editable ? (
-                      <i className="tl-flag" title={node.unsupportedReason}>
-                        read only
-                      </i>
-                    ) : null}
-                  </li>
-                ))}
-              </ol>
+                      {node.nodeType === "repeat" ? (
+                        <span className="tl-step-children">
+                          {node.steps.map((step) => (
+                            <em key={step.id}>
+                              {step.name} <small>{targetLabel(step)}</small>
+                            </em>
+                          ))}
+                        </span>
+                      ) : null}
+                      {!node.editable ? (
+                        <i className="tl-flag" title={node.unsupportedReason}>
+                          read only
+                        </i>
+                      ) : null}
+                    </li>
+                  ))}
+                </ol>
+              </div>
             ) : null}
 
             <p
@@ -781,66 +799,90 @@ export function WorkoutWorkspace({
                 </>
               )}
             </p>
-
-            <form
-              className="tl-reader-schedule"
-              onSubmit={(event) => {
-                event.preventDefault();
-                void schedule();
-              }}
-            >
-              <label>
-                <span>Put it on the calendar</span>
-                <input
-                  type="date"
-                  value={scheduleDate}
-                  min={tomorrow()}
-                  onChange={(event) => setScheduleDate(event.target.value)}
-                />
-              </label>
-              <button type="submit" className="primary-button" disabled={!scheduleDate || busy === "schedule"}>
-                <CalendarPlus size={14} /> {busy === "schedule" ? "Scheduling" : "Schedule"}
-              </button>
-            </form>
-
-            <div className="tl-reader-actions">
-              <button
-                type="button"
-                className="primary-button"
-                disabled={!previewDocument?.canEdit}
-                onClick={() => setEditId(active.id)}
-              >
-                <Pencil size={14} /> Edit
-              </button>
-              <button
-                type="button"
-                className="ghost-button"
-                disabled={busy === "duplicate"}
-                onClick={() => void duplicate()}
-              >
-                <Copy size={14} /> Duplicate as
-              </button>
-              <SelectDropdown
-                className="tl-quiet-select"
-                label="Sport for the duplicate"
-                value={String(duplicateSport ?? active.sportType ?? 1)}
-                options={Array.from({ length: 9 }, (_, index) => ({
-                  value: String(index + 1),
-                  label: formatWorkoutSport(workoutSportFromType(index + 1) ?? "run")
-                }))}
-                onChange={(value) => setDuplicateSport(Number(value))}
-              />
-              <button type="button" className="ghost-button" onClick={applyTags}>
-                <Tag size={14} /> Tags
-              </button>
-              <button
-                type="button"
-                className="ghost-button danger"
-                onClick={() => setPendingDelete([active.id])}
-              >
-                <Trash2 size={14} /> Delete
-              </button>
             </div>
+
+            <footer className="tl-reader-dock">
+              <form
+                className="tl-reader-schedule"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  void schedule();
+                }}
+              >
+                <div className="tl-reader-schedule-heading">
+                  <span className="tl-reader-schedule-icon" aria-hidden="true">
+                    <CalendarPlus size={15} />
+                  </span>
+                  <span>
+                    <strong>Schedule workout</strong>
+                    <small>Add it to your COROS calendar</small>
+                  </span>
+                </div>
+                <div className="tl-reader-schedule-controls">
+                  <label>
+                    <span className="sr-only">Schedule date</span>
+                    <input
+                      type="date"
+                      value={scheduleDate}
+                      min={tomorrow()}
+                      onChange={(event) => setScheduleDate(event.target.value)}
+                    />
+                  </label>
+                  <button
+                    type="submit"
+                    className="primary-button"
+                    disabled={!scheduleDate || busy === "schedule"}
+                  >
+                    {busy === "schedule" ? "Scheduling" : "Schedule"}
+                  </button>
+                </div>
+              </form>
+
+              <div className="tl-reader-actions">
+                <div className="tl-reader-actions-main">
+                  <button
+                    type="button"
+                    className="primary-button"
+                    disabled={!previewDocument?.canEdit}
+                    onClick={() => setEditId(active.id)}
+                  >
+                    <Pencil size={14} /> Edit
+                  </button>
+                  <div className="tl-reader-duplicate">
+                    <button
+                      type="button"
+                      className="ghost-button"
+                      disabled={busy === "duplicate"}
+                      onClick={() => void duplicate()}
+                    >
+                      <Copy size={14} /> Duplicate as
+                    </button>
+                    <SelectDropdown
+                      className="tl-quiet-select"
+                      label="Sport for the duplicate"
+                      value={String(duplicateSport ?? active.sportType ?? 1)}
+                      options={Array.from({ length: 9 }, (_, index) => ({
+                        value: String(index + 1),
+                        label: formatWorkoutSport(workoutSportFromType(index + 1) ?? "run")
+                      }))}
+                      onChange={(value) => setDuplicateSport(Number(value))}
+                    />
+                  </div>
+                </div>
+                <div className="tl-reader-actions-meta">
+                  <button type="button" className="ghost-button" onClick={applyTags}>
+                    <Tag size={14} /> Tags
+                  </button>
+                  <button
+                    type="button"
+                    className="ghost-button danger"
+                    onClick={() => setPendingDelete([active.id])}
+                  >
+                    <Trash2 size={14} /> Delete
+                  </button>
+                </div>
+              </div>
+            </footer>
           </>
         )}
       </aside>

--- a/src/training-library/WorkoutWorkspace.tsx
+++ b/src/training-library/WorkoutWorkspace.tsx
@@ -1,0 +1,873 @@
+import {
+  CalendarPlus,
+  Copy,
+  Download,
+  Heart,
+  LayoutGrid,
+  List,
+  LoaderCircle,
+  Pencil,
+  Plus,
+  Search,
+  Tag,
+  Trash2,
+  X
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import type {
+  RunWorkoutEditorNode,
+  TrainingCollection,
+  TrainingLibraryWorkout,
+  WorkoutEditPreview,
+  WorkoutEditorDocument
+} from "../../electron/types";
+import type { CorosLinkApi } from "../coroslink-api";
+import { formatHappenDayLabel } from "../training/formatters";
+import { formatWorkoutSport } from "../../electron/workoutCapabilities";
+import { workoutSportFromType } from "../../electron/trainingPlanDomain";
+import { SelectDropdown } from "../components/SelectDropdown";
+import { WorkoutEditorModal } from "../calendar/WorkoutEditorModal";
+import { AddWorkoutModal } from "../calendar/AddWorkoutModal";
+
+interface WorkoutWorkspaceProps {
+  api: CorosLinkApi;
+  workouts: TrainingLibraryWorkout[];
+  collections: TrainingCollection[];
+  onRefresh: () => Promise<void>;
+  onMessage: (message: string) => void;
+  onError: (message: string) => void;
+}
+
+type WorkoutColumn = "name" | "total" | "load" | "used";
+
+interface WorkoutSort {
+  column: WorkoutColumn;
+  descending: boolean;
+}
+
+const WORKOUT_COLUMNS: Array<{ id: WorkoutColumn; label: string }> = [
+  { id: "total", label: "Total" },
+  { id: "load", label: "Load" },
+  { id: "used", label: "Used" }
+];
+
+/** Tiles have no column headings to click, so sorting gets its own control. */
+const WORKOUT_SORT_OPTIONS: Array<{ value: WorkoutColumn; label: string }> = [
+  { value: "name", label: "Name" },
+  { value: "total", label: "Duration" },
+  { value: "load", label: "Training load" },
+  { value: "used", label: "Most used" }
+];
+
+const UNSETTLED_SYNC = new Set(["pending", "conflicted", "failed", "stale"]);
+/** Enough segments to read an interval comb without drawing thousands of them. */
+const SHAPE_SEGMENT_LIMIT = 96;
+
+function metricFromVolume(volume: string | undefined, kind: "duration" | "distance"): number {
+  const value = volume?.toLowerCase() ?? "";
+  if (kind === "duration") {
+    const hours = Number(value.match(/([\d.]+)\s*h/)?.[1] ?? 0);
+    const minutes = Number(value.match(/([\d.]+)\s*m(?:in)?/)?.[1] ?? 0);
+    return hours * 3600 + minutes * 60;
+  }
+  const distance = Number(value.match(/([\d.]+)\s*(km|mi|m)\b/)?.[1] ?? 0);
+  if (value.includes(" km")) return distance * 1000;
+  if (value.includes(" mi")) return distance * 1609.344;
+  return distance;
+}
+
+function tomorrow(): string {
+  const date = new Date();
+  date.setDate(date.getDate() + 1);
+  return date.toISOString().slice(0, 10);
+}
+
+function targetLabel(node: RunWorkoutEditorNode): string {
+  if (node.nodeType === "repeat") return `${node.repeat} rounds`;
+  const target = node.target;
+  if (target.type === "time") return `${Math.round(target.seconds / 60)} min`;
+  if (target.type === "distance") {
+    return target.meters >= 1000 ? `${(target.meters / 1000).toFixed(1)} km` : `${target.meters} m`;
+  }
+  if (target.type === "load") return `${target.load} load`;
+  if (target.type === "reps") return `${target.count} reps`;
+  if (target.type === "routes") return `${target.count} routes`;
+  if (target.type === "elevationGain") return `${target.meters} m gain`;
+  if (target.type === "hrRecovery") return `${target.bpm} bpm recovery`;
+  return "Open";
+}
+
+interface ShapeSegment {
+  kind: string;
+  share: number;
+  label: string;
+}
+
+/**
+ * The reader's counterpart to the plan ridge: one segment per step, width
+ * proportional to how long the step runs, shaded by the step's declared kind.
+ * Repeats expand, so an interval set reads as a comb.
+ */
+function workoutShape(nodes: RunWorkoutEditorNode[]): ShapeSegment[] {
+  const segments: ShapeSegment[] = [];
+
+  const push = (node: RunWorkoutEditorNode) => {
+    if (segments.length >= SHAPE_SEGMENT_LIMIT || node.nodeType === "repeat") return;
+    const target = node.target;
+    const weight =
+      target.type === "time"
+        ? target.seconds
+        : target.type === "distance"
+          ? target.meters / 3
+          : target.type === "reps"
+            ? target.count * 4
+            : 120;
+    segments.push({ kind: node.kind, share: Math.max(weight, 1), label: `${node.name} · ${targetLabel(node)}` });
+  };
+
+  for (const node of nodes) {
+    if (node.nodeType === "repeat") {
+      for (let round = 0; round < node.repeat; round += 1) {
+        for (const step of node.steps) push(step);
+      }
+    } else {
+      push(node);
+    }
+  }
+
+  const total = segments.reduce((sum, segment) => sum + segment.share, 0) || 1;
+  return segments.map((segment) => ({ ...segment, share: (segment.share / total) * 100 }));
+}
+
+function downloadSelection(workouts: TrainingLibraryWorkout[]) {
+  const blob = new Blob([JSON.stringify({ exportedAt: new Date().toISOString(), workouts }, null, 2)], {
+    type: "application/json"
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `coroslink-workouts-${new Date().toISOString().slice(0, 10)}.json`;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+export function WorkoutWorkspace({
+  api,
+  workouts,
+  collections,
+  onRefresh,
+  onMessage,
+  onError
+}: WorkoutWorkspaceProps) {
+  const [query, setQuery] = useState("");
+  const [scope, setScope] = useState("all");
+  const [sort, setSort] = useState<WorkoutSort>({ column: "name", descending: false });
+  const [layout, setLayout] = useState<"grid" | "list">("grid");
+  const [selected, setSelected] = useState<string[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(workouts[0]?.id ?? null);
+  const [visibleCount, setVisibleCount] = useState(60);
+  const [previewDocument, setPreviewDocument] = useState<WorkoutEditorDocument | null>(null);
+  const [previewMetrics, setPreviewMetrics] = useState<WorkoutEditPreview | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [editId, setEditId] = useState<string | null>(null);
+  const [scheduleDate, setScheduleDate] = useState(tomorrow);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<string[]>([]);
+  const [duplicateSport, setDuplicateSport] = useState<number | undefined>();
+  const [creating, setCreating] = useState(false);
+
+  const scopes = useMemo(() => {
+    const options = [{ id: "all", label: "All" }];
+    if (workouts.some((workout) => workout.favorite)) {
+      options.push({ id: "favorite", label: "Favorites" });
+    }
+    const sports = [...new Set(workouts.map((workout) => workout.sportType))]
+      .filter((value): value is number => value !== undefined)
+      .sort((left, right) => left - right);
+    for (const sportType of sports) {
+      options.push({
+        id: `sport:${sportType}`,
+        label: formatWorkoutSport(workoutSportFromType(sportType) ?? "run")
+      });
+    }
+    if (workouts.some((workout) => UNSETTLED_SYNC.has(workout.syncState))) {
+      options.push({ id: "unsettled", label: "Needs attention" });
+    }
+    return options;
+  }, [workouts]);
+
+  const filtered = useMemo(() => {
+    const needle = query.trim().toLowerCase();
+    const matching = workouts.filter((workout) => {
+      if (needle && !`${workout.name} ${workout.tags.join(" ")}`.toLowerCase().includes(needle)) {
+        return false;
+      }
+      if (scope === "favorite") return workout.favorite;
+      if (scope === "unsettled") return UNSETTLED_SYNC.has(workout.syncState);
+      if (scope.startsWith("sport:")) return String(workout.sportType) === scope.slice(6);
+      return true;
+    });
+
+    const direction = sort.descending ? -1 : 1;
+    return matching.sort((left, right) => {
+      if (sort.column === "name") return left.name.localeCompare(right.name) * direction;
+      if (sort.column === "load") {
+        return ((left.trainingLoad ?? 0) - (right.trainingLoad ?? 0)) * direction;
+      }
+      if (sort.column === "used") {
+        return (
+          (left.usedByPlanIds.length + left.scheduledCount - right.usedByPlanIds.length - right.scheduledCount) *
+          direction
+        );
+      }
+      return (
+        (metricFromVolume(left.volume, "duration") - metricFromVolume(right.volume, "duration")) * direction
+      );
+    });
+  }, [workouts, query, scope, sort]);
+
+  const active = workouts.find((workout) => workout.id === activeId);
+  const shape = useMemo(
+    () => (previewDocument ? workoutShape(previewDocument.draft.nodes) : []),
+    [previewDocument]
+  );
+
+  useEffect(() => {
+    if (!activeId) {
+      setPreviewDocument(null);
+      setPreviewMetrics(null);
+      return;
+    }
+    let cancelled = false;
+    setPreviewLoading(true);
+    setPreviewDocument(null);
+    setPreviewMetrics(null);
+    void api
+      .getWorkoutForEdit({ kind: "library", programId: activeId }, "metric")
+      .then(async (document) => {
+        if (cancelled) return;
+        setPreviewDocument(document);
+        try {
+          const metrics = await api.previewWorkoutEdit(
+            document.ref,
+            document.revision,
+            document.draft,
+            "metric"
+          );
+          if (!cancelled) setPreviewMetrics(metrics);
+        } catch {
+          // The complete step structure is still useful when the estimate is unavailable.
+        }
+      })
+      .catch((cause: unknown) => {
+        if (!cancelled) onError(cause instanceof Error ? cause.message : String(cause));
+      })
+      .finally(() => {
+        if (!cancelled) setPreviewLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api, activeId, onError]);
+
+  const updateMetadata = async (ids: string[], patch: Parameters<CorosLinkApi["updateWorkoutMetadata"]>[1]) => {
+    setBusy("metadata");
+    try {
+      await api.updateWorkoutMetadata(ids, patch);
+      await onRefresh();
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const schedule = async () => {
+    if (!active || !scheduleDate) return;
+    setBusy("schedule");
+    try {
+      const happenDay = scheduleDate.replace(/-/g, "");
+      await api.scheduleLibraryWorkout(active.id, happenDay);
+      await api.updateWorkoutMetadata([active.id], { lastUsedAt: new Date().toISOString() });
+      onMessage(`Scheduled "${active.name}" on ${formatHappenDayLabel(happenDay)}.`);
+      await onRefresh();
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const duplicate = async () => {
+    if (!active) return;
+    const name = window.prompt("Name for the duplicate", `${active.name} Copy`);
+    if (!name?.trim()) return;
+    setBusy("duplicate");
+    try {
+      const result = await api.duplicateLibraryWorkout(
+        active.id,
+        name.trim(),
+        duplicateSport ?? active.sportType
+      );
+      onMessage(`Created "${result.name}" in the workout library.`);
+      await onRefresh();
+      setActiveId(result.id);
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const applyTags = () => {
+    const targets = selected.length ? selected : activeId ? [activeId] : [];
+    if (!targets.length) return;
+    const existing = workouts.find((workout) => targets.includes(workout.id))?.tags.join(", ") ?? "";
+    const value = window.prompt("Tags, separated by commas", existing);
+    if (value === null) return;
+    void updateMetadata(targets, {
+      tags: [...new Set(value.split(",").map((item) => item.trim()).filter(Boolean))]
+    });
+  };
+
+  const deleteConfirmed = async () => {
+    setBusy("delete");
+    try {
+      await api.deleteTrainingLibraryWorkouts({ programIds: pendingDelete, confirmed: true });
+      onMessage(`Deleted ${pendingDelete.length} workout${pendingDelete.length === 1 ? "" : "s"} from COROS.`);
+      setSelected([]);
+      setPendingDelete([]);
+      setActiveId(null);
+      await onRefresh();
+    } catch (cause) {
+      onError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  /** Shared by the tile and the row so selection behaves identically. */
+  const workoutMark = (id: string, name: string, isSelected: boolean) => (
+    <button
+      type="button"
+      className="tl-mark"
+      role="checkbox"
+      aria-checked={isSelected}
+      aria-label={`Select ${name}`}
+      onClick={() =>
+        setSelected((current) =>
+          current.includes(id) ? current.filter((value) => value !== id) : [...current, id]
+        )
+      }
+    />
+  );
+
+  const toggleSort = (column: WorkoutColumn) =>
+    setSort((current) =>
+      current.column === column
+        ? { column, descending: !current.descending }
+        : { column, descending: column !== "name" }
+    );
+
+  const sortIndicator = (column: WorkoutColumn) =>
+    sort.column === column ? (sort.descending ? " ↓" : " ↑") : "";
+
+  const exportTargets = selected.length
+    ? workouts.filter((workout) => selected.includes(workout.id))
+    : active
+      ? [active]
+      : [];
+
+  return (
+    <div className="tl-panel tl-split">
+      <section className="tl-catalog" aria-label={`${filtered.length} workouts`}>
+        <div className="tl-filters">
+          <label className="tl-search">
+            <Search size={15} />
+            <span className="sr-only">Search workouts</span>
+            <input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search workouts and tags"
+            />
+          </label>
+          <div className="tl-chips" role="group" aria-label="Filter workouts">
+            {scopes.map((option) => (
+              <button
+                type="button"
+                key={option.id}
+                aria-pressed={scope === option.id}
+                onClick={() => setScope(option.id)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+          <div className="tl-filters-tail">
+            <SelectDropdown
+              className="tl-quiet-select"
+              label="Sort workouts"
+              value={sort.column}
+              options={WORKOUT_SORT_OPTIONS}
+              onChange={(value) => setSort({ column: value, descending: value !== "name" })}
+            />
+            <div className="tl-layout-switch" role="group" aria-label="Workout layout">
+              <button
+                type="button"
+                aria-pressed={layout === "grid"}
+                aria-label="Show tiles"
+                onClick={() => setLayout("grid")}
+              >
+                <LayoutGrid size={14} />
+              </button>
+              <button
+                type="button"
+                aria-pressed={layout === "list"}
+                aria-label="Show list"
+                onClick={() => setLayout("list")}
+              >
+                <List size={14} />
+              </button>
+            </div>
+            <button type="button" className="primary-button" onClick={() => setCreating(true)}>
+              <Plus size={14} /> New workout
+            </button>
+          </div>
+        </div>
+
+        {selected.length ? (
+          <div className="tl-bulk" role="toolbar" aria-label="Actions for selected workouts">
+            <strong>{selected.length} selected</strong>
+            <button type="button" onClick={applyTags}>
+              <Tag size={13} /> Tag
+            </button>
+            {collections.length ? (
+              <SelectDropdown
+                className="tl-quiet-select"
+                label="Move selected workouts to a collection"
+                value=""
+                options={[
+                  { value: "", label: "Move to collection" },
+                  ...collections.map((collection) => ({ value: collection.id, label: collection.name }))
+                ]}
+                onChange={(value) => {
+                  if (value) void updateMetadata(selected, { collectionId: value });
+                }}
+              />
+            ) : null}
+            <button type="button" onClick={() => downloadSelection(exportTargets)}>
+              <Download size={13} /> Export
+            </button>
+            <button type="button" className="danger" onClick={() => setPendingDelete(selected)}>
+              <Trash2 size={13} /> Delete
+            </button>
+            <button type="button" aria-label="Clear selection" onClick={() => setSelected([])}>
+              <X size={13} />
+            </button>
+          </div>
+        ) : null}
+
+        {filtered.length === 0 ? (
+          <div className="tl-empty">
+            <h3>No workouts match</h3>
+            <p>Clear the search or choose another filter.</p>
+          </div>
+        ) : layout === "grid" ? (
+          <ul className="tl-grid" role="list">
+            {filtered.slice(0, visibleCount).map((workout) => {
+              const isSelected = selected.includes(workout.id);
+              const references = workout.usedByPlanIds.length + workout.scheduledCount;
+
+              return (
+                <li
+                  className={`tl-card${activeId === workout.id ? " is-active" : ""}${
+                    isSelected ? " is-selected" : ""
+                  }`}
+                  key={workout.id}
+                >
+                  {workoutMark(workout.id, workout.name, isSelected)}
+                  <button
+                    type="button"
+                    className="tl-card-open"
+                    onClick={() => setActiveId(workout.id)}
+                  >
+                    <span className="tl-card-top">
+                      {workout.favorite ? (
+                        <Heart size={11} fill="currentColor" strokeWidth={0} aria-label="Favorite" />
+                      ) : null}
+                      <em>{formatWorkoutSport(workoutSportFromType(workout.sportType) ?? "run")}</em>
+                      {UNSETTLED_SYNC.has(workout.syncState) ? (
+                        <i className="tl-flag">{workout.syncState}</i>
+                      ) : null}
+                    </span>
+                    <span className="tl-card-name">{workout.name}</span>
+                    <span className="tl-card-figs">
+                      <span>
+                        <b className={workout.volume ? "" : "is-nil"}>{workout.volume ?? "—"}</b>
+                        <small>total</small>
+                      </span>
+                      <span>
+                        <b className={workout.trainingLoad ? "" : "is-nil"}>
+                          {workout.trainingLoad ? Math.round(workout.trainingLoad) : "—"}
+                        </b>
+                        <small>load</small>
+                      </span>
+                      <span>
+                        <b className={references ? "" : "is-nil"}>{references || "—"}</b>
+                        <small>used</small>
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+            {visibleCount < filtered.length ? (
+              <li>
+                <button
+                  type="button"
+                  className="tl-load-more"
+                  onClick={() => setVisibleCount((value) => value + 60)}
+                >
+                  Show 60 more of {filtered.length}
+                </button>
+              </li>
+            ) : null}
+          </ul>
+        ) : (
+          <div className="tl-index">
+            <div className="tl-index-head tl-workout-row">
+              <span />
+              <button
+                type="button"
+                className="tl-sortable"
+                aria-pressed={sort.column === "name"}
+                onClick={() => toggleSort("name")}
+              >
+                workout{sortIndicator("name")}
+              </button>
+              {WORKOUT_COLUMNS.map((column) => (
+                <button
+                  type="button"
+                  key={column.id}
+                  className="tl-sortable is-numeric"
+                  aria-pressed={sort.column === column.id}
+                  onClick={() => toggleSort(column.id)}
+                >
+                  {column.label}
+                  {sortIndicator(column.id)}
+                </button>
+              ))}
+            </div>
+
+            <ul role="list">
+              {filtered.slice(0, visibleCount).map((workout) => {
+                const isSelected = selected.includes(workout.id);
+                const references = workout.usedByPlanIds.length + workout.scheduledCount;
+                const details = [
+                  formatWorkoutSport(workoutSportFromType(workout.sportType) ?? "run"),
+                  ...workout.tags.slice(0, 2)
+                ];
+
+                return (
+                  <li
+                    className={`tl-workout-row tl-row${activeId === workout.id ? " is-active" : ""}${
+                      isSelected ? " is-selected" : ""
+                    }`}
+                    key={workout.id}
+                  >
+                    {workoutMark(workout.id, workout.name, isSelected)}
+                    <button type="button" className="tl-row-open" onClick={() => setActiveId(workout.id)}>
+                      <span className="tl-row-name">
+                        {workout.favorite ? (
+                          <Heart size={12} fill="currentColor" strokeWidth={0} aria-label="Favorite" />
+                        ) : null}
+                        {workout.name}
+                      </span>
+                      <span className="tl-row-sub">
+                        {details.map((detail, index) => (
+                          <em key={index}>{detail}</em>
+                        ))}
+                        {UNSETTLED_SYNC.has(workout.syncState) ? (
+                          <i className="tl-flag">{workout.syncState}</i>
+                        ) : null}
+                      </span>
+                    </button>
+                    <span className={`tl-fig${workout.volume ? "" : " is-nil"}`}>
+                      {workout.volume ?? "—"}
+                    </span>
+                    <span className={`tl-fig${workout.trainingLoad ? "" : " is-nil"}`}>
+                      {workout.trainingLoad ? Math.round(workout.trainingLoad) : "—"}
+                    </span>
+                    <span className={`tl-fig${references ? "" : " is-nil"}`}>{references || "—"}</span>
+                  </li>
+                );
+              })}
+            </ul>
+
+            {visibleCount < filtered.length ? (
+              <button
+                type="button"
+                className="tl-load-more"
+                onClick={() => setVisibleCount((value) => value + 60)}
+              >
+                Show 60 more of {filtered.length}
+              </button>
+            ) : null}
+          </div>
+        )}
+      </section>
+
+      <aside className="tl-reader" aria-live="polite">
+        {!active ? (
+          <div className="tl-empty">
+            <h3>Pick a workout</h3>
+            <p>Its full step structure and references appear here.</p>
+          </div>
+        ) : (
+          <>
+            <header>
+              <p className="tl-eyebrow">
+                {formatWorkoutSport(workoutSportFromType(active.sportType) ?? "run")}
+              </p>
+              <h2>{active.name}</h2>
+              <button
+                type="button"
+                className={`tl-reader-favorite${active.favorite ? " is-active" : ""}`}
+                aria-label={active.favorite ? "Remove from favorites" : "Add to favorites"}
+                onClick={() => void updateMetadata([active.id], { favorite: !active.favorite })}
+              >
+                <Heart size={16} fill={active.favorite ? "currentColor" : "none"} />
+              </button>
+            </header>
+
+            <dl className="tl-reader-metrics">
+              <div>
+                <dt>Time</dt>
+                <dd>
+                  {previewMetrics?.durationSeconds
+                    ? `${Math.round(previewMetrics.durationSeconds / 60)}m`
+                    : "—"}
+                </dd>
+              </div>
+              <div>
+                <dt>Distance</dt>
+                <dd>
+                  {previewMetrics?.distanceMeters
+                    ? `${(previewMetrics.distanceMeters / 1000).toFixed(1)} km`
+                    : (active.volume ?? "—")}
+                </dd>
+              </div>
+              <div>
+                <dt>Load</dt>
+                <dd>
+                  {previewMetrics?.trainingLoad
+                    ? Math.round(previewMetrics.trainingLoad)
+                    : active.trainingLoad
+                      ? Math.round(active.trainingLoad)
+                      : "—"}
+                </dd>
+              </div>
+              <div>
+                <dt>Steps</dt>
+                <dd>{previewDocument?.draft.nodes.length ?? "—"}</dd>
+              </div>
+            </dl>
+
+            {shape.length ? (
+              <figure className="tl-shape">
+                <div role="img" aria-label={`Step structure of ${active.name}, ${shape.length} steps`}>
+                  {shape.map((segment, index) => (
+                    <span
+                      key={index}
+                      className={`is-${segment.kind}`}
+                      style={{ width: `${segment.share}%` }}
+                      title={segment.label}
+                    />
+                  ))}
+                </div>
+                <figcaption>Step structure, by share of the session</figcaption>
+              </figure>
+            ) : null}
+
+            {previewLoading ? (
+              <p className="tl-reader-loading">
+                <LoaderCircle className="is-spinning" size={16} /> Loading the full structure
+              </p>
+            ) : previewDocument ? (
+              <ol className="tl-steps">
+                {previewDocument.draft.nodes.map((node) => (
+                  <li key={node.id}>
+                    <span className="tl-step-head">
+                      <b>{node.name}</b>
+                      <small>{targetLabel(node)}</small>
+                    </span>
+                    {node.nodeType === "repeat" ? (
+                      <span className="tl-step-children">
+                        {node.steps.map((step) => (
+                          <em key={step.id}>
+                            {step.name} <small>{targetLabel(step)}</small>
+                          </em>
+                        ))}
+                      </span>
+                    ) : null}
+                    {!node.editable ? (
+                      <i className="tl-flag" title={node.unsupportedReason}>
+                        read only
+                      </i>
+                    ) : null}
+                  </li>
+                ))}
+              </ol>
+            ) : null}
+
+            <p className="tl-reader-references">
+              {active.usedByPlanIds.length || active.scheduledCount
+                ? `Used by ${active.usedByPlanIds.length} plan${
+                    active.usedByPlanIds.length === 1 ? "" : "s"
+                  } and scheduled ${active.scheduledCount} time${active.scheduledCount === 1 ? "" : "s"}.`
+                : "Not referenced by a plan or a calendar day."}
+            </p>
+
+            <div className="tl-reader-actions">
+              <button
+                type="button"
+                className="primary-button"
+                disabled={!previewDocument?.canEdit}
+                onClick={() => setEditId(active.id)}
+              >
+                <Pencil size={14} /> Edit
+              </button>
+              <button
+                type="button"
+                className="ghost-button"
+                disabled={busy === "duplicate"}
+                onClick={() => void duplicate()}
+              >
+                <Copy size={14} /> Duplicate as
+              </button>
+              <SelectDropdown
+                className="tl-quiet-select"
+                label="Sport for the duplicate"
+                value={String(duplicateSport ?? active.sportType ?? 1)}
+                options={Array.from({ length: 9 }, (_, index) => ({
+                  value: String(index + 1),
+                  label: formatWorkoutSport(workoutSportFromType(index + 1) ?? "run")
+                }))}
+                onChange={(value) => setDuplicateSport(Number(value))}
+              />
+              <button type="button" className="ghost-button" onClick={applyTags}>
+                <Tag size={14} /> Tags
+              </button>
+              <button
+                type="button"
+                className="ghost-button danger"
+                onClick={() => setPendingDelete([active.id])}
+              >
+                <Trash2 size={14} /> Delete
+              </button>
+            </div>
+
+            <form
+              className="tl-reader-schedule"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void schedule();
+              }}
+            >
+              <label>
+                <span>Put it on the calendar</span>
+                <input
+                  type="date"
+                  value={scheduleDate}
+                  min={tomorrow()}
+                  onChange={(event) => setScheduleDate(event.target.value)}
+                />
+              </label>
+              <button type="submit" className="primary-button" disabled={!scheduleDate || busy === "schedule"}>
+                <CalendarPlus size={14} /> {busy === "schedule" ? "Scheduling" : "Schedule"}
+              </button>
+            </form>
+          </>
+        )}
+      </aside>
+
+      {pendingDelete.length ? (
+        <div className="tl-dialog-backdrop">
+          <section
+            className="tl-dialog"
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="workout-delete-title"
+          >
+            <h2 id="workout-delete-title">
+              Delete {pendingDelete.length} workout{pendingDelete.length === 1 ? "" : "s"} from COROS?
+            </h2>
+            <p>
+              This cannot be undone. Calendar copies stay in place, and plan references will remain but
+              point at nothing.
+            </p>
+            <ul>
+              {workouts
+                .filter((workout) => pendingDelete.includes(workout.id))
+                .map((workout) => (
+                  <li key={workout.id}>
+                    <strong>{workout.name}</strong>
+                    <span>
+                      {workout.usedByPlanIds.length} plan references · {workout.scheduledCount} scheduled
+                    </span>
+                  </li>
+                ))}
+            </ul>
+            <footer>
+              <button type="button" className="ghost-button" onClick={() => setPendingDelete([])}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="primary-button danger"
+                disabled={busy === "delete"}
+                onClick={() => void deleteConfirmed()}
+              >
+                {busy === "delete" ? "Deleting" : "Delete"}
+              </button>
+            </footer>
+          </section>
+        </div>
+      ) : null}
+
+      {editId ? (
+        <WorkoutEditorModal
+          api={api}
+          editRef={{ kind: "library", programId: editId }}
+          onClose={() => setEditId(null)}
+          onSaved={(result) => {
+            setEditId(null);
+            onMessage(result.verified ? "Workout saved and verified." : (result.warning ?? "Workout saved."));
+            void onRefresh();
+          }}
+          onError={(message) => message && onError(message)}
+        />
+      ) : null}
+
+      {creating ? (
+        <AddWorkoutModal
+          api={api}
+          dateKey={tomorrow().replace(/-/g, "")}
+          sportTypes={[]}
+          libraryOnly
+          onClose={() => setCreating(false)}
+          onScheduled={(message) => {
+            setCreating(false);
+            onMessage(message);
+            void onRefresh();
+          }}
+          onError={(message) => message && onError(message)}
+          onEditLibrary={(programId) => {
+            setCreating(false);
+            setEditId(programId);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/training-library/trainingLibrary.css
+++ b/src/training-library/trainingLibrary.css
@@ -1,0 +1,2708 @@
+/*
+ * Training Library
+ *
+ * A library is a record, so this surface is set as a ledger: one calm glass
+ * panel per section, and inside it nothing but hairlines, generous leading, and
+ * figures that align into columns so they can be compared by eye.
+ *
+ * Only one thing is ever drawn — the ridge of weekly training load (Ridge.tsx),
+ * small on an index row and at reading size on the adherence lede. It keeps to
+ * the accent hue alone; height carries the number.
+ *
+ * Values derive from the app tokens in styles.css, so both themes reskin this
+ * file by overriding tokens rather than restyling rules. Two small token blocks
+ * follow the root: charcoal for the dark theme, and tile colours for paper.
+ */
+
+.training-library-view {
+  /*
+   * Hairlines derive from the text colour rather than --glass-border, which is
+   * a 0.1-alpha dark on the paper theme and disappears against a white panel.
+   * --text-muted inverts with the theme, so one value reads in both.
+   */
+  --tl-rule: color-mix(in srgb, var(--text-muted) 32%, transparent);
+  --tl-rule-soft: color-mix(in srgb, var(--text-muted) 17%, transparent);
+  --tl-panel-bg: color-mix(in srgb, var(--surface) 58%, transparent);
+  --tl-row-hover: color-mix(in srgb, var(--accent) 6%, transparent);
+  --tl-figure: 15px;
+  --tl-column: 58px;
+
+  min-width: 0;
+  min-height: 100%;
+  padding: 30px 34px 56px;
+  color: var(--text-primary);
+  background: var(--tl-ground, var(--bg-base));
+}
+
+/*
+ * Charcoal, dark theme only. The dark theme is the *absence* of a data-theme
+ * attribute (see theme.ts applyTheme), so this cannot leak into paper.
+ *
+ * It works by overriding the app tokens rather than inventing new ones, which
+ * is how the paper theme reskins too: everything downstream — this file, plus
+ * shared pieces like .app-select and .primary-button — follows for free.
+ */
+:root:not([data-theme]) .training-library-view {
+  --tl-ground: #1b1d20;
+  --tl-panel-bg: #212429;
+  --tl-card: #262a2f;
+  --tl-card-hover: #2d3239;
+  --tl-reader-bg: #1d2023;
+
+  --surface: #262a2f;
+  --glass-bg: rgba(255, 255, 255, 0.04);
+  --glass-bg-hover: rgba(255, 255, 255, 0.07);
+  --glass-bg-elevated: rgba(255, 255, 255, 0.09);
+  --glass-border: rgba(255, 255, 255, 0.1);
+
+  --text-primary: #edeef0;
+  --text-secondary: #a9adb2;
+  --text-muted: #7b8085;
+
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.28), 0 14px 32px rgba(0, 0, 0, 0.26);
+  --shadow-elevated: 0 20px 44px rgba(0, 0, 0, 0.42);
+
+  /* Charcoal sits lighter than the old near-black, so the ridge needs more
+     accent to hold the same presence. */
+  --tl-ridge-fill: color-mix(in srgb, var(--accent) 58%, transparent);
+  --tl-ridge-fill-hover: color-mix(in srgb, var(--accent) 82%, transparent);
+}
+
+/* Crisp white tiles read better than translucent ones on the warm paper panel. */
+:root[data-theme="paper"] .training-library-view {
+  --tl-card: #ffffff;
+  --tl-card-hover: #fffdf9;
+}
+
+.training-library-view :is(button, input, select, textarea) {
+  font: inherit;
+  font-family: inherit;
+}
+
+.training-library-view :is(button, input, select, textarea, [role="checkbox"]):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/*
+ * `.ghost-button` has no global base — each view sets its own — and the global
+ * `.primary-button` is a 44px marketing button. Both are quieted here to sit on
+ * a hairline row without shouting.
+ */
+.training-library-view :is(.primary-button, .ghost-button) {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 0 13px;
+  border-radius: var(--radius-sm);
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.training-library-view .primary-button {
+  border: 0;
+  color: #fff;
+  background: var(--accent);
+  box-shadow: none;
+  transition: background 150ms ease;
+}
+
+.training-library-view .primary-button:hover:not(:disabled) {
+  background: var(--accent-hover);
+  box-shadow: none;
+  transform: none;
+}
+
+.training-library-view .ghost-button {
+  border: 1px solid var(--glass-border);
+  color: var(--text-secondary);
+  background: var(--glass-bg);
+  transition: color 150ms ease, background 150ms ease, border-color 150ms ease;
+}
+
+.training-library-view .ghost-button:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--glass-bg-hover);
+}
+
+.training-library-view .ghost-button.danger:hover:not(:disabled) {
+  color: var(--error-text);
+  border-color: var(--error-border);
+}
+
+.training-library-view :is(.primary-button, .ghost-button):disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.training-library-view .icon-button {
+  display: inline-flex;
+  width: 30px;
+  height: 30px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  background: none;
+  cursor: pointer;
+  transition: color 150ms ease, background 150ms ease;
+}
+
+.training-library-view .icon-button:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--glass-bg-hover);
+}
+
+.training-library-view .icon-button.danger:hover:not(:disabled) {
+  color: var(--error-text);
+}
+
+.training-library-view .icon-button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* ---------------------------------------------------------------- Masthead */
+
+.tl-masthead {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  padding-bottom: 22px;
+}
+
+.tl-masthead h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 30px;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+}
+
+/* The census replaces a tagline: what is actually in the library. */
+.tl-census {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+  margin: 9px 0 0;
+  color: var(--text-muted);
+  font-size: 12.5px;
+}
+
+.tl-census b {
+  margin-right: 4px;
+  color: var(--text-secondary);
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.tl-masthead-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.tl-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.tl-state::before {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--success-dot);
+  content: "";
+}
+
+.tl-state.is-stale::before {
+  background: var(--warning-text);
+}
+
+.tl-notice {
+  margin-bottom: 18px;
+  padding: 11px 14px;
+  border: 1px solid var(--warning-border);
+  border-radius: var(--radius-md);
+  color: var(--warning-text);
+  background: var(--warning-bg);
+  font-size: 12.5px;
+}
+
+.tl-notice summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.tl-notice p {
+  margin: 8px 0 0 22px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+/* -------------------------------------------------------------- Section nav */
+
+.tl-sections {
+  display: flex;
+  gap: 26px;
+  margin-bottom: 18px;
+  border-bottom: 1px solid var(--tl-rule);
+}
+
+.tl-sections button {
+  position: relative;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 7px;
+  padding: 0 1px 13px;
+  border: 0;
+  color: var(--text-muted);
+  background: none;
+  font-family: var(--font-display);
+  font-size: 13.5px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  cursor: pointer;
+  transition: color 160ms ease;
+}
+
+.tl-sections button:hover {
+  color: var(--text-secondary);
+}
+
+.tl-sections button span {
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+
+.tl-sections button[aria-current="page"] {
+  color: var(--text-primary);
+}
+
+.tl-sections button[aria-current="page"]::after {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 1.5px;
+  background: var(--accent);
+  content: "";
+}
+
+.tl-sections button[aria-current="page"] span {
+  color: var(--accent);
+}
+
+/* ------------------------------------------------------------------- Panels */
+
+.tl-panel {
+  min-width: 0;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  background: var(--tl-panel-bg);
+  box-shadow: var(--shadow-card);
+  backdrop-filter: blur(var(--glass-blur));
+  overflow: hidden;
+}
+
+.tl-panel > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 18px 20px 15px;
+}
+
+.tl-panel > header h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+
+.tl-panel > header p {
+  margin: 5px 0 0;
+  max-width: 52ch;
+  color: var(--text-muted);
+  font-size: 12.5px;
+}
+
+.tl-eyebrow {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+/* ------------------------------------------------------------------ Filters */
+
+.tl-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 14px;
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--tl-rule);
+}
+
+/* Sort, layout and the create action group at the right of the filter line. */
+.tl-filters-tail {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.tl-search {
+  display: inline-flex;
+  min-width: 0;
+  flex: 0 1 300px;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+}
+
+.tl-search input {
+  min-width: 0;
+  width: 100%;
+  padding: 5px 0;
+  border: 0;
+  color: var(--text-primary);
+  background: none;
+  font-size: 13px;
+}
+
+.tl-search input::placeholder {
+  color: var(--text-muted);
+}
+
+.tl-search input:focus-visible {
+  outline: 0;
+}
+
+.tl-search:focus-within {
+  color: var(--accent);
+}
+
+.tl-chips {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.tl-chips button {
+  padding: 4px 11px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  color: var(--text-muted);
+  background: none;
+  font-size: 12px;
+  cursor: pointer;
+  transition: color 140ms ease, background 140ms ease, border-color 140ms ease;
+}
+
+.tl-chips button:hover {
+  color: var(--text-secondary);
+  background: var(--glass-bg);
+}
+
+.tl-chips button[aria-pressed="true"] {
+  color: var(--accent-strong);
+  border-color: color-mix(in srgb, var(--accent) 34%, transparent);
+  background: var(--accent-soft);
+}
+
+/* The "show more" control spans the whole tile grid rather than one cell. */
+.tl-grid > li:has(> .tl-load-more) {
+  grid-column: 1 / -1;
+}
+
+.tl-grid .tl-load-more {
+  border-top: 0;
+}
+
+.tl-inline-note {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--tl-rule);
+  color: var(--warning-text);
+  background: color-mix(in srgb, var(--warning-bg) 60%, transparent);
+  font-size: 12px;
+}
+
+.tl-inline-note svg {
+  flex: none;
+}
+
+.tl-bulk {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 16px;
+  border-bottom: 1px solid var(--tl-rule);
+  background: var(--accent-soft);
+  font-size: 12px;
+}
+
+.tl-bulk strong {
+  margin-right: 6px;
+  color: var(--accent-strong);
+  font-family: var(--font-display);
+  font-weight: 600;
+}
+
+.tl-bulk button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+  background: var(--glass-bg);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.tl-bulk button:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--glass-bg-hover);
+}
+
+.tl-bulk button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.tl-bulk button.danger:hover {
+  color: var(--error-text);
+  border-color: var(--error-border);
+}
+
+/* -------------------------------------------------------------- Ledger index */
+
+.tl-index {
+  min-width: 0;
+}
+
+.tl-index ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* Column labels are stated once, so the rows can be pure data. */
+.tl-index-head {
+  padding: 9px 16px;
+  border-bottom: 1px solid var(--tl-rule);
+  color: var(--text-muted);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.tl-index-head .tl-column-label,
+.tl-index-head .tl-sortable {
+  padding: 0;
+  border: 0;
+  color: inherit;
+  background: none;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.tl-index-head .tl-sortable {
+  cursor: pointer;
+  transition: color 140ms ease;
+}
+
+.tl-index-head .tl-sortable:hover {
+  color: var(--text-secondary);
+}
+
+.tl-index-head .tl-sortable[aria-pressed="true"] {
+  color: var(--accent-strong);
+}
+
+.tl-index-head .is-numeric {
+  text-align: right;
+}
+
+.tl-row {
+  align-items: center;
+  border-bottom: 1px solid var(--tl-rule-soft);
+  transition: background 140ms ease;
+}
+
+.tl-row:last-child {
+  border-bottom: 0;
+}
+
+.tl-row:hover {
+  background: var(--tl-row-hover);
+}
+
+.tl-row.is-selected {
+  background: var(--accent-soft);
+}
+
+.tl-plan-row,
+.tl-workout-row,
+.tl-match-row,
+.tl-activity-row {
+  display: grid;
+  gap: 0 14px;
+  padding-right: 16px;
+  padding-left: 16px;
+}
+
+.tl-plan-row {
+  grid-template-columns:
+    16px minmax(0, 1fr)
+    var(--tl-column) var(--tl-column) var(--tl-column) 62px
+    132px 92px;
+}
+
+.tl-workout-row {
+  grid-template-columns: 16px minmax(0, 1fr) 88px 50px 44px;
+}
+
+/* The row's own body is the primary target; it stays a plain block of text. */
+.tl-row-open {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+  padding: 15px 0;
+  border: 0;
+  color: inherit;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.tl-row-open.is-static {
+  cursor: default;
+}
+
+.tl-row-name {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: 14.5px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tl-row-name svg {
+  flex: none;
+  color: var(--accent);
+}
+
+.tl-row-sub {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  white-space: nowrap;
+}
+
+.tl-row-sub em {
+  overflow: hidden;
+  font-style: normal;
+  text-overflow: ellipsis;
+}
+
+.tl-row-sub em + em::before {
+  margin-right: 7px;
+  content: "·";
+}
+
+/* Sync state is shown only when it needs attention. */
+.tl-flag {
+  flex: none;
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  color: var(--warning-text);
+  background: var(--warning-bg);
+  font-size: 9.5px;
+  font-style: normal;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.tl-fig {
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: var(--tl-figure);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+  text-align: right;
+}
+
+.tl-fig.is-nil {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.tl-fig.is-quiet {
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.tl-mark {
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--text-muted) 52%, transparent);
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+  transition: border-color 140ms ease, background 140ms ease;
+}
+
+.tl-mark:hover {
+  border-color: var(--accent);
+}
+
+.tl-mark[aria-checked="true"] {
+  border-color: var(--accent);
+  background: var(--accent);
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--surface) 80%, transparent);
+}
+
+/* Secondary actions stay out of the way until the row is reached. */
+.tl-row-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 140ms ease;
+}
+
+.tl-row:hover .tl-row-actions,
+.tl-row:focus-within .tl-row-actions,
+.tl-row.is-selected .tl-row-actions {
+  opacity: 1;
+}
+
+/* Without a pointer there is no hover to reveal them, so they stay put. */
+@media (hover: none) {
+  .tl-row-actions {
+    opacity: 1;
+  }
+}
+
+.tl-row-actions button {
+  display: inline-flex;
+  width: 26px;
+  height: 26px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 6px;
+  color: var(--text-muted);
+  background: none;
+  cursor: pointer;
+  transition: color 140ms ease, background 140ms ease;
+}
+
+.tl-row-actions button:hover {
+  color: var(--text-primary);
+  background: var(--glass-bg-hover);
+}
+
+.tl-row-actions button.danger:hover {
+  color: var(--error-text);
+}
+
+.tl-load-more {
+  width: 100%;
+  padding: 13px;
+  border: 0;
+  border-top: 1px solid var(--tl-rule);
+  color: var(--text-secondary);
+  background: none;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.tl-load-more:hover {
+  color: var(--text-primary);
+  background: var(--glass-bg);
+}
+
+/* ------------------------------------------------------------- Card tiles */
+
+/*
+ * One tile per training. The tile is where the ridge belongs: it gets the full
+ * width and twice the height it can have on a row, so the shape of a block is
+ * readable at a glance while browsing.
+ */
+.tl-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(258px, 1fr));
+  gap: 12px;
+  margin: 0;
+  padding: 16px;
+  list-style: none;
+}
+
+.tl-card {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  min-height: 198px;
+  flex-direction: column;
+  /* --tl-rule, not --glass-border: a tile needs a defined edge, and the glass
+     border is a 0.1-alpha dark that disappears on a white paper tile. */
+  border: 1px solid var(--tl-rule);
+  border-radius: var(--radius-md);
+  background: var(--tl-card, var(--glass-bg));
+  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.tl-card:hover {
+  border-color: color-mix(in srgb, var(--accent) 30%, var(--glass-border));
+  background: var(--tl-card-hover, var(--glass-bg-hover));
+  transform: translateY(-1px);
+}
+
+.tl-card.is-selected {
+  border-color: var(--accent);
+}
+
+.tl-card.is-active {
+  border-color: color-mix(in srgb, var(--accent) 58%, var(--glass-border));
+  background: var(--tl-card-hover, var(--glass-bg-hover));
+}
+
+.tl-card-open {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px 15px 13px;
+  border: 0;
+  color: inherit;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.tl-card-top {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding-right: 24px;
+  color: var(--text-muted);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.tl-card-top em {
+  font-style: normal;
+}
+
+.tl-card-top svg {
+  color: var(--accent);
+}
+
+.tl-card-name {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.28;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.tl-card-note {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/*
+ * Pushes the ridge and figures to the tile floor so tiles align across a row.
+ * A week gets a wider slot here than on a list row — a typical block then fills
+ * most of the tile, and a short plan visibly draws a shorter ridge.
+ */
+.tl-card-open .tl-ridge {
+  height: 42px;
+  margin-top: auto;
+  gap: 2px;
+}
+
+.tl-card-open .tl-ridge-bar {
+  flex-basis: 10px;
+  border-radius: 1.5px;
+}
+
+.tl-card-figs {
+  display: flex;
+  gap: 16px;
+  padding-top: 11px;
+  border-top: 1px solid var(--tl-rule-soft);
+}
+
+.tl-card-figs span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.tl-card-figs b {
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+
+.tl-card-figs b.is-nil {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.tl-card-figs small {
+  color: var(--text-muted);
+  font-size: 9.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.tl-card > .tl-mark {
+  position: absolute;
+  top: 13px;
+  right: 13px;
+  z-index: 1;
+}
+
+.tl-card-actions {
+  position: absolute;
+  right: 9px;
+  bottom: 9px;
+  display: flex;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 140ms ease;
+}
+
+.tl-card:hover .tl-card-actions,
+.tl-card:focus-within .tl-card-actions,
+.tl-card.is-selected .tl-card-actions {
+  opacity: 1;
+}
+
+.tl-card-actions button {
+  display: inline-flex;
+  width: 26px;
+  height: 26px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 6px;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--tl-card, var(--surface)) 88%, transparent);
+  cursor: pointer;
+  transition: color 140ms ease, background 140ms ease;
+}
+
+.tl-card-actions button:hover {
+  color: var(--text-primary);
+  background: var(--glass-bg-hover);
+}
+
+.tl-card-actions button.danger:hover {
+  color: var(--error-text);
+}
+
+@media (hover: none) {
+  .tl-card-actions {
+    opacity: 1;
+  }
+}
+
+/* Workout tiles carry no weekly data, so they stay shorter and text-only. */
+.tl-catalog .tl-grid {
+  grid-template-columns: repeat(auto-fill, minmax(196px, 1fr));
+}
+
+.tl-catalog .tl-card {
+  min-height: 120px;
+}
+
+/* With no ridge to push them down, the figures take the auto margin instead so
+   they still land on the tile floor when a name wraps to two lines. */
+.tl-catalog .tl-card-figs {
+  gap: 14px;
+  margin-top: auto;
+}
+
+/* -------------------------------------------------------- Layout switch */
+
+.tl-layout-switch {
+  display: inline-flex;
+  flex: none;
+  gap: 1px;
+  padding: 2px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+}
+
+.tl-layout-switch button {
+  display: inline-flex;
+  width: 26px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 5px;
+  color: var(--text-muted);
+  background: none;
+  cursor: pointer;
+  transition: color 140ms ease, background 140ms ease;
+}
+
+.tl-layout-switch button:hover {
+  color: var(--text-secondary);
+}
+
+.tl-layout-switch button[aria-pressed="true"] {
+  color: var(--text-primary);
+  background: var(--glass-bg-hover);
+}
+
+/* ------------------------------------------------- The ridge (the signature) */
+
+/*
+ * One week is always the same width, and every ridge starts at week 1, so the
+ * bars stay comparable between rows and a longer plan simply draws a longer
+ * ridge. Only a plan past ~22 weeks compresses to fit its column.
+ */
+.tl-ridge {
+  display: flex;
+  height: 26px;
+  align-items: flex-end;
+  justify-content: flex-start;
+  gap: 1.5px;
+}
+
+.tl-ridge.is-blank {
+  align-items: center;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.tl-ridge-bar {
+  position: relative;
+  min-width: 1px;
+  flex: 0 1 4px;
+  height: var(--tl-bar-height);
+  border-radius: 1px;
+  background: var(--tl-ridge-fill, color-mix(in srgb, var(--accent) 46%, transparent));
+  transform-origin: bottom;
+}
+
+.tl-ridge-bar.is-empty {
+  background: color-mix(in srgb, var(--text-muted) 40%, transparent);
+}
+
+/* Session counts, not load: grey, so the accent keeps meaning one thing. */
+.tl-ridge.is-count .tl-ridge-bar {
+  background: color-mix(in srgb, var(--text-secondary) 34%, transparent);
+}
+
+.tl-row:hover .tl-ridge.is-count .tl-ridge-bar {
+  background: color-mix(in srgb, var(--text-secondary) 52%, transparent);
+}
+
+.tl-ridge-bar.is-peak {
+  background: var(--accent-strong);
+}
+
+.tl-row:hover .tl-ridge-bar:not(.is-empty),
+.tl-card:hover .tl-ridge-bar:not(.is-empty) {
+  background: var(--tl-ridge-fill-hover, color-mix(in srgb, var(--accent) 72%, transparent));
+}
+
+.tl-row:hover .tl-ridge-bar.is-peak {
+  background: var(--accent-strong);
+}
+
+/* The same axis at reading size: planned load pale, completed load solid. */
+.tl-bullets {
+  display: flex;
+  height: 78px;
+  align-items: flex-end;
+  gap: 3px;
+}
+
+.tl-bullet {
+  position: relative;
+  min-width: 3px;
+  flex: 1 1 0;
+  height: 100%;
+}
+
+.tl-bullet b,
+.tl-bullet i {
+  position: absolute;
+  bottom: 0;
+  height: var(--tl-bar-height);
+  border-radius: 1.5px;
+  transform-origin: bottom;
+}
+
+.tl-bullet b {
+  right: 0;
+  left: 0;
+  background: color-mix(in srgb, var(--text-muted) 24%, transparent);
+}
+
+.tl-bullet i {
+  right: 30%;
+  left: 30%;
+  background: color-mix(in srgb, var(--accent) 82%, transparent);
+}
+
+.tl-bullet:hover b {
+  background: color-mix(in srgb, var(--text-muted) 42%, transparent);
+}
+
+/* ------------------------------------------------- Workouts: catalog + reader */
+
+.tl-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 372px;
+}
+
+.tl-catalog {
+  min-width: 0;
+  border-right: 1px solid var(--tl-rule);
+}
+
+/* Sits a step below the catalog so the tiles read as the raised layer. */
+.tl-reader {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 18px;
+  padding: 18px 20px 22px;
+  background: var(--tl-reader-bg, color-mix(in srgb, var(--surface) 34%, transparent));
+}
+
+.tl-reader > header {
+  position: relative;
+  padding-right: 34px;
+}
+
+.tl-reader > header h2 {
+  margin: 5px 0 0;
+  font-family: var(--font-display);
+  font-size: 21px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.tl-reader-favorite {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: inline-flex;
+  width: 30px;
+  height: 30px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 8px;
+  color: var(--text-muted);
+  background: none;
+  cursor: pointer;
+}
+
+.tl-reader-favorite:hover,
+.tl-reader-favorite.is-active {
+  color: var(--accent);
+}
+
+.tl-reader-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+  padding: 14px 0;
+  border-top: 1px solid var(--tl-rule);
+  border-bottom: 1px solid var(--tl-rule);
+}
+
+.tl-reader-metrics dt {
+  color: var(--text-muted);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.tl-reader-metrics dd {
+  margin: 5px 0 0;
+  font-family: var(--font-display);
+  font-size: 17px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+
+/* Step structure by share of the session: repeats expand into a comb. */
+.tl-shape {
+  margin: 0;
+}
+
+/* Time is continuous, so the segments abut: only the fill marks a boundary. */
+.tl-shape > div {
+  display: flex;
+  height: 34px;
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.tl-shape span {
+  min-width: 1px;
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.tl-shape span.is-training {
+  background: var(--accent);
+}
+
+.tl-shape span.is-warmup,
+.tl-shape span.is-cooldown {
+  background: color-mix(in srgb, var(--accent) 26%, transparent);
+}
+
+.tl-shape span.is-rest,
+.tl-shape span.is-sendOff {
+  background: color-mix(in srgb, var(--text-secondary) 20%, transparent);
+}
+
+.tl-shape figcaption,
+.tl-adherence-chart figcaption {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 8px;
+  color: var(--text-muted);
+  font-size: 10.5px;
+}
+
+.tl-steps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: tl-step;
+}
+
+.tl-steps li {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 10px;
+  padding: 9px 0 9px 26px;
+  border-bottom: 1px solid var(--tl-rule-soft);
+  counter-increment: tl-step;
+}
+
+.tl-steps li::before {
+  position: absolute;
+  top: 11px;
+  left: 0;
+  color: var(--text-muted);
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  content: counter(tl-step, decimal-leading-zero);
+}
+
+.tl-step-head {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.tl-step-head b {
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tl-step-head small {
+  flex: none;
+  color: var(--text-secondary);
+  font-family: var(--font-display);
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+}
+
+.tl-step-children {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 3px;
+  padding-left: 10px;
+  border-left: 1px solid var(--tl-rule);
+}
+
+.tl-step-children em {
+  color: var(--text-muted);
+  font-size: 11.5px;
+  font-style: normal;
+}
+
+.tl-reader-references {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.tl-reader-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  padding-top: 16px;
+  border-top: 1px solid var(--tl-rule);
+}
+
+.tl-reader-schedule {
+  display: flex;
+  align-items: flex-end;
+  gap: 9px;
+}
+
+.tl-reader-schedule label {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.tl-reader-schedule label span {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.tl-reader-schedule input {
+  min-height: 34px;
+  padding: 0 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  background: var(--glass-bg);
+  font-size: 12.5px;
+}
+
+.tl-reader-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+/* ---------------------------------------------------- Templates: collections */
+
+.tl-template-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 292px;
+  align-items: start;
+  gap: 16px;
+}
+
+.tl-collections > header {
+  display: block;
+  padding-bottom: 12px;
+}
+
+.tl-collection-create {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 7px;
+  padding: 0 20px 14px;
+}
+
+.tl-collection-create input {
+  min-width: 0;
+  min-height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  background: var(--glass-bg);
+  font-size: 12.5px;
+}
+
+.tl-collections ul {
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--tl-rule);
+  list-style: none;
+}
+
+.tl-collections li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 11px 16px 11px 20px;
+  border-bottom: 1px solid var(--tl-rule-soft);
+}
+
+.tl-collections li:last-child {
+  border-bottom: 0;
+}
+
+.tl-collections li span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tl-collections li strong {
+  overflow: hidden;
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tl-collections li small {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.tl-collections li button {
+  display: inline-flex;
+  width: 26px;
+  height: 26px;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 6px;
+  color: var(--text-muted);
+  background: none;
+  cursor: pointer;
+}
+
+.tl-collections li button:hover {
+  color: var(--error-text);
+  background: var(--glass-bg-hover);
+}
+
+.tl-collections-empty {
+  margin: 0;
+  padding: 0 20px 20px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+/* ---------------------------------------------------------------- Adherence */
+
+.tl-adherence {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.tl-adherence-lede > header {
+  align-items: center;
+}
+
+.tl-adherence-chart {
+  margin: 0;
+  padding: 4px 20px 0;
+}
+
+.tl-legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tl-legend em {
+  width: 9px;
+  height: 9px;
+  border-radius: 2px;
+}
+
+.tl-legend em:not(:first-child) {
+  margin-left: 8px;
+}
+
+.tl-legend .is-planned {
+  background: color-mix(in srgb, var(--text-muted) 34%, transparent);
+}
+
+.tl-legend .is-done {
+  background: color-mix(in srgb, var(--accent) 82%, transparent);
+}
+
+.tl-tally {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1px;
+  margin: 18px 0 0;
+  border-top: 1px solid var(--tl-rule);
+  background: var(--tl-rule);
+}
+
+.tl-tally div {
+  padding: 13px 20px;
+  background: var(--tl-panel-bg);
+}
+
+.tl-tally dt {
+  color: var(--text-muted);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.tl-tally dd {
+  margin: 5px 0 0;
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+
+.tl-match-row {
+  grid-template-columns: 92px minmax(0, 1fr) minmax(0, 1.05fr) 60px 88px;
+}
+
+.tl-match-row.tl-row {
+  padding-top: 11px;
+  padding-bottom: 11px;
+}
+
+.tl-match-day,
+.tl-match-planned,
+.tl-match-done {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tl-match-day b {
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.tl-match-day small,
+.tl-match-planned small,
+.tl-match-done small {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.tl-match-planned b {
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* A status is a state, not a label: the day carries a hairline of its colour. */
+.tl-match-row {
+  border-left: 2px solid transparent;
+  padding-left: 14px;
+}
+
+.tl-match-row.is-completed {
+  border-left-color: var(--success-text);
+}
+
+.tl-match-row.is-partial,
+.tl-match-row.is-rescheduled {
+  border-left-color: var(--warning-text);
+}
+
+.tl-match-row.is-missed {
+  border-left-color: var(--error-text);
+}
+
+.tl-match-row.is-upcoming {
+  border-left-color: color-mix(in srgb, var(--accent) 55%, transparent);
+}
+
+.tl-activity-row {
+  grid-template-columns: minmax(0, 1fr) 64px 70px 52px 34px;
+}
+
+.tl-recent .tl-index-head,
+.tl-recent .tl-row {
+  padding-left: 20px;
+}
+
+/* --------------------------------------------------------- Quiet dropdowns */
+
+.training-library-view .tl-quiet-select {
+  min-width: 0;
+}
+
+.training-library-view .tl-quiet-select .app-select-trigger {
+  min-height: 28px;
+  padding: 0 6px 0 9px;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+}
+
+.training-library-view .tl-quiet-select.is-wide {
+  max-width: 100%;
+}
+
+/*
+ * The activity picker doubles as the value it edits, so it is set as text with
+ * the chevron tucked against it rather than a field spanning the whole cell.
+ */
+.training-library-view .tl-quiet-select.is-wide .app-select-trigger {
+  width: auto;
+  max-width: 100%;
+  justify-content: flex-start;
+  gap: 3px;
+  padding: 0 2px 0 0;
+  border-color: transparent;
+  background: none;
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.training-library-view .tl-quiet-select.is-wide .app-select-value {
+  flex: 0 1 auto;
+}
+
+.training-library-view .tl-quiet-select.is-wide .app-select-icon {
+  color: var(--text-muted);
+}
+
+.training-library-view .tl-quiet-select.is-wide .app-select-trigger:hover,
+.training-library-view .tl-quiet-select.is-wide .app-select-trigger[aria-expanded="true"] {
+  padding: 0 4px 0 7px;
+  border-color: var(--glass-border);
+  background: var(--glass-bg);
+}
+
+/* --------------------------------------------------- Empty, gate, and dialog */
+
+.tl-empty {
+  padding: 54px 20px 58px;
+  text-align: center;
+}
+
+.tl-empty h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.tl-empty p {
+  margin: 7px auto 0;
+  max-width: 38ch;
+  color: var(--text-muted);
+  font-size: 12.5px;
+}
+
+.training-library-gate {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 60px 30px;
+  color: var(--text-primary);
+  background:
+    radial-gradient(circle at 50% 24%, var(--accent-soft), transparent 42%),
+    var(--bg-base);
+  text-align: center;
+}
+
+.training-library-gate svg {
+  color: var(--text-muted);
+}
+
+.training-library-gate h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.training-library-gate p {
+  margin: 0 0 8px;
+  max-width: 44ch;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.tl-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.tl-skeleton span {
+  height: 64px;
+  background: var(--glass-bg);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .tl-skeleton span {
+    animation: tl-pulse 1.5s ease-in-out infinite alternate;
+  }
+}
+
+@keyframes tl-pulse {
+  from {
+    opacity: 0.45;
+  }
+  to {
+    opacity: 0.9;
+  }
+}
+
+.tl-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 110;
+  display: grid;
+  padding: 24px;
+  background: color-mix(in srgb, var(--bg-base) 76%, transparent);
+  backdrop-filter: blur(8px);
+  place-items: center;
+}
+
+.tl-dialog {
+  width: min(460px, 100%);
+  padding: 22px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  background: var(--surface);
+  box-shadow: var(--shadow-elevated);
+}
+
+.tl-dialog h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+
+.tl-dialog p {
+  margin: 9px 0 0;
+  color: var(--text-secondary);
+  font-size: 12.5px;
+}
+
+.tl-dialog ul {
+  max-height: 200px;
+  margin: 16px 0 0;
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+}
+
+.tl-dialog li {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 9px 0;
+  border-top: 1px solid var(--tl-rule);
+  font-size: 13px;
+}
+
+.tl-dialog li span {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.tl-dialog footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 20px;
+}
+
+.tl-dialog .primary-button.danger {
+  color: #fff;
+  background: var(--error-text);
+}
+
+/* ------------------------------------------------------- Plan editor modals */
+
+.plan-editor,
+.plan-compare {
+  position: fixed;
+  inset: 16px;
+  z-index: 90;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--bg-base) 94%, var(--surface));
+  box-shadow: var(--shadow-elevated);
+  overflow: hidden;
+}
+
+.plan-editor::before,
+.plan-compare::before {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background: color-mix(in srgb, var(--bg-base) 72%, transparent);
+  backdrop-filter: blur(10px);
+  content: "";
+}
+
+.plan-editor-header,
+.plan-compare > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 18px 20px;
+  border-bottom: 1px solid var(--tl-rule);
+}
+
+.plan-editor-header .tl-eyebrow,
+.plan-compare > header .tl-eyebrow {
+  margin-bottom: 4px;
+}
+
+.plan-editor-name {
+  min-width: 300px;
+  padding: 0;
+  border: 0;
+  color: var(--text-primary);
+  background: none;
+  font-family: var(--font-display);
+  font-size: 21px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  outline: 0;
+}
+
+.plan-editor-name:focus-visible {
+  border-bottom: 1px solid var(--accent);
+}
+
+.plan-editor-header > div > p:last-of-type {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.plan-editor-source-warning {
+  display: inline-block;
+  margin-top: 8px;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  color: var(--warning-text);
+  background: var(--warning-bg);
+  font-size: 10.5px;
+}
+
+.plan-editor-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.plan-editor-layout {
+  display: grid;
+  min-height: 0;
+  grid-template-columns: 268px minmax(0, 1fr) 236px;
+  flex: 1;
+}
+
+.plan-editor-sidebar,
+.plan-editor-main,
+.plan-editor-preview {
+  min-width: 0;
+  padding: 18px;
+  overflow-y: auto;
+}
+
+.plan-editor-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  border-right: 1px solid var(--tl-rule);
+}
+
+.plan-editor-preview {
+  border-left: 1px solid var(--tl-rule);
+  background: color-mix(in srgb, var(--surface) 34%, transparent);
+}
+
+.plan-editor-sidebar h3,
+.plan-editor-preview h3,
+.plan-holding-area h3,
+.plan-week h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+
+.plan-editor-sidebar label {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-top: 12px;
+}
+
+.plan-editor-sidebar label > span:first-child {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.plan-editor-sidebar :is(input, select, textarea) {
+  min-height: 32px;
+  padding: 6px 9px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  background: var(--glass-bg);
+  font-size: 12.5px;
+}
+
+.plan-editor-sidebar textarea {
+  min-height: 58px;
+  resize: vertical;
+}
+
+.plan-editor-date,
+.plan-editor-duration {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-muted);
+}
+
+.plan-editor-date input,
+.plan-editor-duration input {
+  min-width: 0;
+  flex: 1;
+}
+
+.plan-editor-section-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.plan-editor-new-workout {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 10px;
+  padding: 12px;
+  border: 1px solid var(--tl-rule);
+  border-radius: var(--radius-sm);
+  background: var(--glass-bg);
+}
+
+.plan-editor-new-workout .primary-button {
+  margin-top: 10px;
+}
+
+.plan-editor-library-list {
+  display: flex;
+  max-height: 240px;
+  flex-direction: column;
+  margin-top: 10px;
+  overflow-y: auto;
+}
+
+.plan-editor-library-list button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 9px 2px;
+  border: 0;
+  border-bottom: 1px solid var(--tl-rule-soft);
+  color: var(--text-secondary);
+  background: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.plan-editor-library-list button:hover {
+  color: var(--text-primary);
+}
+
+.plan-editor-library-list span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.plan-editor-library-list strong {
+  overflow: hidden;
+  font-size: 12.5px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.plan-editor-library-list small {
+  color: var(--text-muted);
+  font-size: 10.5px;
+}
+
+.plan-editor-phases {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.plan-editor-phases > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+  background: var(--accent-soft);
+  font-size: 11.5px;
+}
+
+.plan-editor-phases small {
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.plan-editor-phases > span button {
+  display: inline-flex;
+  border: 0;
+  color: var(--text-muted);
+  background: none;
+  cursor: pointer;
+}
+
+.plan-editor-main {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.plan-holding-area {
+  padding: 14px;
+  border: 1px dashed var(--glass-border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface) 40%, transparent);
+}
+
+.plan-holding-area p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+
+.plan-holding-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.plan-editor-empty-inline {
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+
+.plan-week-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.plan-week {
+  border: 1px solid var(--tl-rule);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface) 30%, transparent);
+  overflow: hidden;
+}
+
+.plan-week > header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--tl-rule);
+}
+
+.plan-week > header p {
+  margin: 3px 0 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.plan-week > header > div:last-child {
+  display: flex;
+  gap: 2px;
+}
+
+.plan-week-days {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.plan-day {
+  min-height: 96px;
+  padding: 9px;
+  border-right: 1px solid var(--tl-rule-soft);
+}
+
+.plan-day:last-child {
+  border-right: 0;
+}
+
+.plan-day-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.plan-day-heading span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.plan-day-heading strong {
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.plan-day-heading small {
+  color: var(--text-muted);
+  font-size: 9.5px;
+}
+
+.plan-day-heading button {
+  display: inline-flex;
+  border: 0;
+  color: var(--text-muted);
+  background: none;
+  opacity: 0;
+  cursor: pointer;
+  transition: opacity 140ms ease;
+}
+
+.plan-day:hover .plan-day-heading button,
+.plan-day-heading button:focus-visible {
+  opacity: 1;
+}
+
+.plan-day-entries {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.plan-entry-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 7px 8px;
+  border: 1px solid color-mix(in srgb, var(--accent) 26%, transparent);
+  border-radius: var(--radius-sm);
+  background: var(--accent-soft);
+  cursor: grab;
+}
+
+.plan-entry-card.is-rest,
+.plan-entry-card.is-note {
+  border-color: var(--glass-border);
+  background: var(--glass-bg);
+  cursor: default;
+}
+
+.plan-entry-card > span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.plan-entry-card strong {
+  overflow: hidden;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.plan-entry-card small {
+  color: var(--text-muted);
+  font-size: 9.5px;
+}
+
+.plan-entry-card button {
+  display: inline-flex;
+  flex: none;
+  border: 0;
+  color: var(--text-muted);
+  background: none;
+  cursor: pointer;
+}
+
+.plan-add-week {
+  display: inline-flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 11px;
+  border: 1px dashed var(--glass-border);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  background: none;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+
+.plan-add-week:hover {
+  color: var(--text-primary);
+  border-color: var(--accent);
+}
+
+.plan-editor-preview dl,
+.plan-compare-grid dl {
+  margin: 12px 0 0;
+}
+
+.plan-editor-preview dl div,
+.plan-compare-grid dl div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--tl-rule-soft);
+}
+
+.plan-editor-preview dt,
+.plan-compare-grid dt {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.plan-editor-preview dd,
+.plan-compare-grid dd {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.plan-editor-limitation,
+.plan-editor-validation p,
+.plan-editor-valid {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 14px 0 0;
+  padding: 10px 12px;
+  border: 1px solid var(--warning-border);
+  border-radius: var(--radius-sm);
+  color: var(--warning-text);
+  background: var(--warning-bg);
+  font-size: 11.5px;
+}
+
+.plan-editor-limitation p {
+  margin: 0;
+}
+
+.plan-editor-validation p.error {
+  color: var(--error-text);
+  border-color: var(--error-border);
+  background: var(--error-bg);
+}
+
+.plan-editor-valid {
+  color: var(--success-text);
+  border-color: var(--success-border);
+  background: var(--success-bg);
+}
+
+/* ------------------------------------------------------------ Plan compare */
+
+.plan-compare {
+  overflow-y: auto;
+}
+
+.plan-compare > header h2 {
+  margin: 4px 0 0;
+  font-family: var(--font-display);
+  font-size: 21px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.plan-compare > header p:last-of-type {
+  margin: 6px 0 0;
+  max-width: 60ch;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.plan-compare-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 16px 20px;
+}
+
+.plan-compare-picker button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+  background: none;
+  cursor: pointer;
+}
+
+.plan-compare-picker button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.plan-compare-picker button.is-selected {
+  color: var(--text-primary);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.plan-compare-picker button span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  text-align: left;
+}
+
+.plan-compare-picker strong {
+  font-size: 12.5px;
+  font-weight: 500;
+}
+
+.plan-compare-picker small {
+  color: var(--text-muted);
+  font-size: 10.5px;
+}
+
+.plan-compare-grid,
+.plan-compare-chart,
+.plan-compare-insights {
+  margin: 0 20px 16px;
+}
+
+.plan-compare-grid {
+  display: grid;
+  gap: 1px;
+  border: 1px solid var(--tl-rule);
+  border-radius: var(--radius-md);
+  background: var(--tl-rule);
+  overflow: hidden;
+}
+
+.plan-compare-grid > article {
+  min-width: 0;
+  padding: 16px;
+  background: color-mix(in srgb, var(--surface) 62%, transparent);
+}
+
+.plan-compare-grid h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.plan-compare-sports {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 12px;
+}
+
+.plan-compare-sports span {
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  color: var(--text-muted);
+  background: var(--glass-bg);
+  font-size: 10.5px;
+}
+
+.plan-compare-longest {
+  display: flex;
+  flex-direction: column;
+  margin: 14px 0 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--tl-rule);
+}
+
+.plan-compare-longest small,
+.plan-compare-longest span {
+  color: var(--text-muted);
+  font-size: 10.5px;
+}
+
+.plan-compare-chart,
+.plan-compare-insights {
+  padding: 16px;
+  border: 1px solid var(--tl-rule);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface) 46%, transparent);
+}
+
+.plan-compare-chart h3,
+.plan-compare-insights h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.plan-compare-chart p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+
+.plan-compare-insights p {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 10px 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.plan-compare-insights small {
+  color: var(--text-muted);
+  font-size: 10.5px;
+}
+
+/* ------------------------------------------------------------------- Motion */
+
+@media (prefers-reduced-motion: no-preference) {
+  /* One orchestrated moment: rows settle in, then the ridges draw themselves. */
+  :is(.tl-index ul, .tl-grid) > li {
+    animation: tl-settle 260ms cubic-bezier(0.2, 0.8, 0.25, 1) backwards;
+  }
+
+  :is(.tl-index ul, .tl-grid) > li:nth-child(1) { animation-delay: 0ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(2) { animation-delay: 22ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(3) { animation-delay: 44ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(4) { animation-delay: 66ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(5) { animation-delay: 88ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(6) { animation-delay: 110ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(7) { animation-delay: 132ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(8) { animation-delay: 154ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(n + 9) { animation-delay: 176ms; }
+
+  .tl-ridge-bar,
+  .tl-bullet b,
+  .tl-bullet i {
+    animation: tl-grow 420ms cubic-bezier(0.2, 0.85, 0.3, 1) backwards;
+    animation-delay: calc(140ms + var(--tl-bar-index) * 14ms);
+  }
+}
+
+@keyframes tl-settle {
+  from {
+    opacity: 0;
+    transform: translateY(5px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes tl-grow {
+  from {
+    transform: scaleY(0);
+  }
+  to {
+    transform: scaleY(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .training-library-view *,
+  .plan-editor *,
+  .plan-compare * {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* --------------------------------------------------------------- Responsive */
+
+@media (max-width: 1500px) {
+  .tl-split {
+    grid-template-columns: minmax(0, 1fr) 330px;
+  }
+}
+
+@media (max-width: 1320px) {
+  .tl-plan-row {
+    grid-template-columns:
+      16px minmax(0, 1fr)
+      var(--tl-column) var(--tl-column) var(--tl-column)
+      104px 84px;
+  }
+
+  /* Updated is the first column to go: the ridge says more in the same space. */
+  .tl-plan-row > :nth-child(6) {
+    display: none;
+  }
+
+  .tl-template-layout {
+    grid-template-columns: minmax(0, 1fr) 250px;
+  }
+
+  .plan-editor-layout {
+    grid-template-columns: 240px minmax(0, 1fr);
+  }
+
+  .plan-editor-preview {
+    display: none;
+  }
+}
+
+@media (max-width: 1100px) {
+  .tl-split,
+  .tl-template-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .tl-catalog {
+    border-right: 0;
+    border-bottom: 1px solid var(--tl-rule);
+  }
+
+  .tl-match-row {
+    grid-template-columns: 84px minmax(0, 1fr) minmax(0, 1fr) 56px;
+  }
+
+  .tl-match-row > .tl-row-actions {
+    display: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .training-library-view {
+    padding: 22px 16px 44px;
+  }
+
+  .tl-masthead {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .tl-sections {
+    gap: 18px;
+    overflow-x: auto;
+  }
+
+  .tl-filters {
+    flex-wrap: wrap;
+  }
+
+  .tl-search {
+    flex: 1 1 100%;
+  }
+
+  .tl-filters-tail {
+    margin-left: 0;
+  }
+
+  .tl-plan-row {
+    grid-template-columns: 16px minmax(0, 1fr) 46px 78px 84px;
+  }
+
+  .tl-plan-row > :nth-child(4),
+  .tl-plan-row > :nth-child(5),
+  .tl-plan-row > :nth-child(6) {
+    display: none;
+  }
+
+  .tl-workout-row {
+    grid-template-columns: 16px minmax(0, 1fr) 78px 44px;
+  }
+
+  .tl-workout-row > :nth-child(5) {
+    display: none;
+  }
+
+  .tl-activity-row {
+    grid-template-columns: minmax(0, 1fr) 60px 52px 34px;
+  }
+
+  .tl-activity-row > :nth-child(3) {
+    display: none;
+  }
+
+  .tl-tally {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .tl-reader-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .plan-editor,
+  .plan-compare {
+    inset: 0;
+    border-radius: 0;
+  }
+
+  .plan-editor-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .plan-editor-layout {
+    grid-template-columns: minmax(0, 1fr);
+    overflow-y: auto;
+  }
+
+  .plan-editor-sidebar,
+  .plan-editor-main {
+    overflow: visible;
+  }
+
+  .plan-editor-sidebar {
+    border-right: 0;
+    border-bottom: 1px solid var(--tl-rule);
+  }
+
+  .plan-week-days {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .plan-compare-grid {
+    grid-template-columns: minmax(0, 1fr) !important;
+  }
+}

--- a/src/training-library/trainingLibrary.css
+++ b/src/training-library/trainingLibrary.css
@@ -1404,22 +1404,70 @@
   min-width: 0;
   flex-direction: column;
   gap: 18px;
-  padding: 18px 20px 22px;
-  background: var(--tl-reader-bg, color-mix(in srgb, var(--surface) 34%, transparent));
+  padding: 20px 20px 22px;
+  background:
+    radial-gradient(ellipse 140% 20% at 50% 0%, color-mix(in srgb, var(--accent) 7%, transparent), transparent 64%),
+    var(--tl-reader-bg, color-mix(in srgb, var(--surface) 34%, transparent));
 }
 
 .tl-reader > header {
   position: relative;
-  padding-right: 34px;
+  padding-right: 38px;
 }
 
 .tl-reader > header h2 {
-  margin: 5px 0 0;
+  margin: 9px 0 0;
   font-family: var(--font-display);
-  font-size: 21px;
+  font-size: 22px;
   font-weight: 600;
-  letter-spacing: -0.02em;
-  line-height: 1.2;
+  letter-spacing: -0.022em;
+  line-height: 1.16;
+  text-wrap: balance;
+}
+
+/*
+ * The sport chip answers in the sport's own colour — the same --sport-* tokens
+ * Settings → Activity colors edits, so the reader agrees with the rest of the
+ * app about what a strength day looks like.
+ */
+.tl-reader-sport {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3.5px 10px;
+  border: 1px solid color-mix(in srgb, var(--tl-sport, var(--accent)) 36%, transparent);
+  border-radius: var(--radius-pill);
+  color: color-mix(in srgb, var(--tl-sport, var(--accent-strong)) 80%, var(--text-primary));
+  background: color-mix(in srgb, var(--tl-sport, var(--accent)) 10%, transparent);
+}
+
+.tl-reader-sport::before {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--tl-sport, var(--accent));
+  box-shadow: 0 0 6px color-mix(in srgb, var(--tl-sport, var(--accent)) 62%, transparent);
+  content: "";
+}
+
+.tl-reader-sport[data-sport="strength"] {
+  --tl-sport: var(--sport-strength);
+}
+
+.tl-reader-sport[data-sport="trail"] {
+  --tl-sport: var(--sport-trail);
+}
+
+.tl-reader-sport[data-sport="run"] {
+  --tl-sport: var(--sport-run);
+}
+
+.tl-reader-sport[data-sport="bike"] {
+  --tl-sport: var(--sport-bike);
+}
+
+.tl-reader-sport[data-sport="other"] {
+  --tl-sport: var(--sport-other);
 }
 
 .tl-reader-favorite {
@@ -1477,9 +1525,19 @@
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 12px;
   margin: 0;
-  padding: 14px 0;
+  padding: 14px 0 15px;
   border-top: 1px solid var(--tl-rule);
   border-bottom: 1px solid var(--tl-rule);
+}
+
+.tl-reader-metrics > div {
+  min-width: 0;
+}
+
+/* Hairline dividers keep the four figures reading as one instrument. */
+.tl-reader-metrics > div + div {
+  border-left: 1px solid var(--tl-rule-soft);
+  padding-left: 12px;
 }
 
 .tl-reader-metrics dt {
@@ -1491,12 +1549,21 @@
 }
 
 .tl-reader-metrics dd {
-  margin: 5px 0 0;
+  margin: 6px 0 0;
+  overflow: hidden;
   font-family: var(--font-display);
-  font-size: 17px;
+  font-size: 19px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   letter-spacing: -0.02em;
+  line-height: 1.1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tl-reader-metrics dd.is-nil {
+  color: var(--text-muted);
+  font-weight: 500;
 }
 
 /* Step structure by share of the session: repeats expand into a comb. */
@@ -1549,40 +1616,101 @@
   font-size: 10.5px;
 }
 
+/* The legend keys the bar's fills without repeating words on every segment. */
+.tl-shape-legend {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px 10px;
+}
+
+.tl-shape-legend > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
+}
+
+.tl-shape-legend em {
+  width: 8px;
+  height: 8px;
+  border-radius: 2.5px;
+}
+
+.tl-shape-legend em.is-training {
+  background: linear-gradient(180deg, var(--accent-strong), var(--accent));
+  box-shadow: 0 0 5px color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
+.tl-shape-legend em.is-warmup,
+.tl-shape-legend em.is-cooldown {
+  background: color-mix(in srgb, var(--accent) 32%, transparent);
+}
+
+.tl-shape-legend em.is-rest,
+.tl-shape-legend em.is-sendOff {
+  background: color-mix(in srgb, var(--text-secondary) 26%, transparent);
+}
+
 .tl-steps {
-  margin: 0;
+  margin: 0 -20px;
   padding: 0;
   list-style: none;
   counter-reset: tl-step;
 }
 
+/* Rows run edge to edge so the hover wash can light the whole line. */
 .tl-steps li {
   position: relative;
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
   gap: 4px 10px;
-  padding: 9px 0 9px 26px;
+  padding: 10px 20px 10px 54px;
   border-bottom: 1px solid var(--tl-rule-soft);
   counter-increment: tl-step;
+  transition: background 160ms ease;
 }
 
+.tl-steps li:first-child {
+  border-top: 1px solid var(--tl-rule-soft);
+}
+
+.tl-steps li:hover {
+  background: var(--tl-row-hover);
+}
+
+/* The index number answers in the step's kind: teal to ease in and out of the
+   session, the accent for work, grey for rest. */
 .tl-steps li::before {
   position: absolute;
-  top: 11px;
-  left: 0;
-  color: var(--text-muted);
+  top: 12px;
+  left: 20px;
+  width: 24px;
+  color: color-mix(in srgb, var(--accent-strong) 84%, var(--text-muted));
   font-family: var(--font-display);
-  font-size: 10px;
+  font-size: 10.5px;
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
   content: counter(tl-step, decimal-leading-zero);
+}
+
+.tl-steps li[data-kind="warmup"]::before,
+.tl-steps li[data-kind="cooldown"]::before {
+  color: var(--accent-2);
+}
+
+.tl-steps li[data-kind="rest"]::before,
+.tl-steps li[data-kind="sendOff"]::before {
+  color: var(--text-muted);
 }
 
 .tl-step-head {
   display: flex;
   min-width: 0;
   flex: 1 1 auto;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
 }
@@ -1595,47 +1723,122 @@
   white-space: nowrap;
 }
 
+/* The target rides as a small pill; a repeat block's rounds get the accent. */
 .tl-step-head small {
   flex: none;
+  padding: 2px 8px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
   color: var(--text-secondary);
+  background: var(--glass-bg);
   font-family: var(--font-display);
-  font-size: 11.5px;
+  font-size: 10px;
+  font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
 
+.tl-step-head small.is-rounds {
+  border-color: color-mix(in srgb, var(--accent) 34%, transparent);
+  color: var(--accent-strong);
+  background: color-mix(in srgb, var(--accent) 9%, transparent);
+}
+
+/* Children hang from a guide rail, each line pinned by its own dot. */
 .tl-step-children {
   display: flex;
   width: 100%;
   flex-direction: column;
-  gap: 3px;
-  padding-left: 10px;
-  border-left: 1px solid var(--tl-rule);
+  gap: 4px;
+  margin-top: 5px;
+  margin-left: 2px;
+  padding: 2px 0 2px 13px;
+  border-left: 1px solid color-mix(in srgb, var(--accent) 24%, var(--tl-rule));
 }
 
 .tl-step-children em {
+  position: relative;
   color: var(--text-muted);
   font-size: 11.5px;
   font-style: normal;
+  line-height: 1.45;
+}
+
+.tl-step-children em::before {
+  position: absolute;
+  top: 50%;
+  left: -15.5px;
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--accent) 48%, var(--text-muted));
+  content: "";
+  transform: translateY(-50%);
+}
+
+.tl-step-children em small {
+  margin-left: 4px;
+  color: color-mix(in srgb, var(--text-muted) 84%, transparent);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
 }
 
 .tl-reader-references {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin: 0;
+  padding: 9px 12px;
+  border: 1px dashed color-mix(in srgb, var(--text-muted) 32%, transparent);
+  border-radius: var(--radius-sm);
   color: var(--text-muted);
-  font-size: 12px;
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+
+.tl-reader-references svg {
+  flex: none;
+}
+
+/* A workout that feeds plans and days gets the solid, accent-lit variant. */
+.tl-reader-references.is-linked {
+  border-style: solid;
+  border-color: color-mix(in srgb, var(--accent) 24%, transparent);
+  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--accent) 5%, transparent);
+}
+
+.tl-reader-references.is-linked svg {
+  color: var(--accent-strong);
 }
 
 .tl-reader-actions {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 7px;
-  padding-top: 16px;
+  /* Anchored to the reader's floor: always the last thing the eye lands on. */
+  margin-top: auto;
+  padding-top: 14px;
   border-top: 1px solid var(--tl-rule);
 }
 
+/* Destruction waits at the far end, away from the everyday actions. */
+.tl-reader-actions .ghost-button.danger {
+  margin-left: auto;
+}
+
+/* Scheduling is the reader's one form, so it is set as a small glass card. */
 .tl-reader-schedule {
   display: flex;
-  align-items: flex-end;
-  gap: 9px;
+  align-items: center;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(160deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012) 48%),
+    var(--glass-bg);
+  box-shadow: var(--shadow-inset);
 }
 
 .tl-reader-schedule label {
@@ -1643,7 +1846,7 @@
   min-width: 0;
   flex: 1 1 auto;
   flex-direction: column;
-  gap: 5px;
+  gap: 6px;
 }
 
 .tl-reader-schedule label span {
@@ -1662,6 +1865,13 @@
   color: var(--text-primary);
   background: var(--glass-bg);
   font-size: 12.5px;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.tl-reader-schedule input:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 46%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+  outline: 0;
 }
 
 .tl-reader-loading {
@@ -1669,6 +1879,7 @@
   align-items: center;
   gap: 8px;
   margin: 0;
+  padding: 10px 0;
   color: var(--text-muted);
   font-size: 12px;
 }
@@ -3269,6 +3480,12 @@
 
   .tl-reader-metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  /* On two rows the third cell starts fresh, so its divider would float. */
+  .tl-reader-metrics > div:nth-child(3) {
+    border-left: 0;
+    padding-left: 0;
   }
 
   .plan-editor,

--- a/src/training-library/trainingLibrary.css
+++ b/src/training-library/trainingLibrary.css
@@ -1,17 +1,22 @@
 /*
  * Training Library
  *
- * A library is a record, so this surface is set as a ledger: one calm glass
- * panel per section, and inside it nothing but hairlines, generous leading, and
- * figures that align into columns so they can be compared by eye.
+ * A library is a record, so this surface keeps a ledger's discipline — hairline
+ * columns, aligned figures — but dresses it in the app's own materials: glass
+ * panels over ambient accent washes, one segmented control for the sections,
+ * and the accent gradient reserved for moments of emphasis.
  *
  * Only one thing is ever drawn — the ridge of weekly training load (Ridge.tsx),
  * small on an index row and at reading size on the adherence lede. It keeps to
  * the accent hue alone; height carries the number.
  *
+ * Motion follows the shell's cadence: the view enters in three beats, rows
+ * settle, then ridges draw themselves. Everything sits under
+ * prefers-reduced-motion, which the guard at the end of this file honours.
+ *
  * Values derive from the app tokens in styles.css, so both themes reskin this
- * file by overriding tokens rather than restyling rules. Two small token blocks
- * follow the root: charcoal for the dark theme, and tile colours for paper.
+ * file by overriding tokens rather than restyling rules. Token blocks follow
+ * the root: charcoal for the dark theme, and warm shadows for paper.
  */
 
 .training-library-view {
@@ -26,12 +31,18 @@
   --tl-row-hover: color-mix(in srgb, var(--accent) 6%, transparent);
   --tl-figure: 15px;
   --tl-column: 58px;
+  /* The one motion signature every control in the view shares. */
+  --tl-ease-out: cubic-bezier(0.2, 0.8, 0.25, 1);
 
   min-width: 0;
   min-height: 100%;
   padding: 30px 34px 56px;
   color: var(--text-primary);
-  background: var(--tl-ground, var(--bg-base));
+  background:
+    radial-gradient(1100px 460px at 16% -8%, var(--bg-ambient-green), transparent 62%),
+    radial-gradient(880px 420px at 90% -12%, var(--bg-ambient-teal), transparent 58%),
+    var(--tl-ground, var(--bg-base));
+  background-attachment: local;
 }
 
 /*
@@ -61,17 +72,42 @@
 
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.28), 0 14px 32px rgba(0, 0, 0, 0.26);
   --shadow-elevated: 0 20px 44px rgba(0, 0, 0, 0.42);
-
-  /* Charcoal sits lighter than the old near-black, so the ridge needs more
-     accent to hold the same presence. */
-  --tl-ridge-fill: color-mix(in srgb, var(--accent) 58%, transparent);
-  --tl-ridge-fill-hover: color-mix(in srgb, var(--accent) 82%, transparent);
 }
 
 /* Crisp white tiles read better than translucent ones on the warm paper panel. */
 :root[data-theme="paper"] .training-library-view {
   --tl-card: #ffffff;
   --tl-card-hover: #fffdf9;
+}
+
+/* Black-alpha shadows go warm on paper, matching the theme's brown tints. */
+:root[data-theme="paper"] .tl-card {
+  box-shadow:
+    0 1px 2px rgba(60, 50, 35, 0.05),
+    0 10px 26px rgba(60, 50, 35, 0.07);
+}
+
+:root[data-theme="paper"] .tl-card:hover {
+  box-shadow:
+    0 2px 4px rgba(60, 50, 35, 0.06),
+    0 18px 38px rgba(60, 50, 35, 0.11),
+    0 0 0 1px color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+:root[data-theme="paper"] .tl-card.is-selected,
+:root[data-theme="paper"] .tl-card.is-active {
+  box-shadow:
+    0 1px 2px rgba(60, 50, 35, 0.05),
+    0 12px 28px rgba(60, 50, 35, 0.09),
+    0 0 0 1px color-mix(in srgb, var(--accent) 26%, transparent);
+}
+
+:root[data-theme="paper"] .training-library-view .ghost-button:hover:not(:disabled) {
+  box-shadow: 0 4px 14px rgba(60, 50, 35, 0.1);
+}
+
+:root[data-theme="paper"] .plan-week {
+  box-shadow: 0 1px 2px rgba(60, 50, 35, 0.05), 0 8px 22px rgba(60, 50, 35, 0.07);
 }
 
 .training-library-view :is(button, input, select, textarea) {
@@ -105,27 +141,49 @@
 .training-library-view .primary-button {
   border: 0;
   color: #fff;
-  background: var(--accent);
-  box-shadow: none;
-  transition: background 150ms ease;
+  background: var(--accent-gradient);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    0 6px 18px color-mix(in srgb, var(--accent) 30%, transparent);
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.14);
+  transition:
+    transform 170ms var(--tl-ease-out),
+    box-shadow 170ms var(--tl-ease-out),
+    filter 170ms ease;
 }
 
 .training-library-view .primary-button:hover:not(:disabled) {
-  background: var(--accent-hover);
-  box-shadow: none;
-  transform: none;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.26),
+    0 10px 26px color-mix(in srgb, var(--accent) 38%, transparent);
+  filter: brightness(1.07);
+  transform: translateY(-1px);
+}
+
+.training-library-view .primary-button:active:not(:disabled) {
+  transform: translateY(0);
+  filter: brightness(0.97);
 }
 
 .training-library-view .ghost-button {
   border: 1px solid var(--glass-border);
   color: var(--text-secondary);
   background: var(--glass-bg);
-  transition: color 150ms ease, background 150ms ease, border-color 150ms ease;
+  backdrop-filter: blur(8px);
+  transition:
+    color 160ms ease,
+    background 160ms ease,
+    border-color 160ms ease,
+    transform 170ms var(--tl-ease-out),
+    box-shadow 170ms var(--tl-ease-out);
 }
 
 .training-library-view .ghost-button:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--glass-border));
   color: var(--text-primary);
   background: var(--glass-bg-hover);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.14);
+  transform: translateY(-1px);
 }
 
 .training-library-view .ghost-button.danger:hover:not(:disabled) {
@@ -180,26 +238,41 @@
 .tl-masthead h1 {
   margin: 0;
   font-family: var(--font-display);
-  font-size: 30px;
+  font-size: 32px;
   font-weight: 600;
-  letter-spacing: -0.025em;
+  letter-spacing: -0.028em;
   line-height: 1.1;
+  /* The signature gradient: ink settling into the accent, left to right. */
+  background: linear-gradient(
+    100deg,
+    var(--text-primary) 38%,
+    color-mix(in srgb, var(--accent-strong) 72%, var(--text-primary)) 88%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 /* The census replaces a tagline: what is actually in the library. */
 .tl-census {
   display: flex;
   flex-wrap: wrap;
-  gap: 4px 16px;
-  margin: 9px 0 0;
+  gap: 4px 18px;
+  margin: 10px 0 0;
   color: var(--text-muted);
   font-size: 12.5px;
 }
 
+.tl-census span {
+  display: inline-flex;
+  align-items: baseline;
+}
+
 .tl-census b {
-  margin-right: 4px;
-  color: var(--text-secondary);
+  margin-right: 5px;
+  color: var(--accent-strong);
   font-family: var(--font-display);
+  font-size: 14px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
@@ -213,23 +286,46 @@
 .tl-state {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 7px;
+  padding: 5px 11px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
   color: var(--text-muted);
-  font-size: 11px;
-  letter-spacing: 0.06em;
+  background: var(--glass-bg);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.07em;
   text-transform: uppercase;
 }
 
 .tl-state::before {
-  width: 5px;
-  height: 5px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: var(--success-dot);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--success-dot) 18%, transparent);
   content: "";
 }
 
 .tl-state.is-stale::before {
   background: var(--warning-text);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--warning-text) 18%, transparent);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .tl-state::before {
+    animation: tl-dot-pulse 2.4s ease-in-out infinite;
+  }
+}
+
+@keyframes tl-dot-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 2.5px color-mix(in srgb, var(--success-dot) 22%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 5px color-mix(in srgb, var(--success-dot) 6%, transparent);
+  }
 }
 
 .tl-notice {
@@ -238,7 +334,9 @@
   border: 1px solid var(--warning-border);
   border-radius: var(--radius-md);
   color: var(--warning-text);
-  background: var(--warning-bg);
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--warning-text) 10%, transparent), var(--warning-bg));
+  box-shadow: 0 2px 10px color-mix(in srgb, var(--warning-text) 8%, transparent);
   font-size: 12.5px;
 }
 
@@ -257,57 +355,96 @@
 
 /* -------------------------------------------------------------- Section nav */
 
+/*
+ * The same segmented control the shell uses for primary navigation: one glass
+ * pill holding the sections, the active one raised into an accent-lit tile.
+ */
 .tl-sections {
-  display: flex;
-  gap: 26px;
-  margin-bottom: 18px;
-  border-bottom: 1px solid var(--tl-rule);
+  display: inline-flex;
+  max-width: 100%;
+  gap: 4px;
+  margin-bottom: 20px;
+  padding: 4px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  background: var(--glass-bg);
+  box-shadow: var(--shadow-inset);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.tl-sections::-webkit-scrollbar {
+  display: none;
 }
 
 .tl-sections button {
   position: relative;
   display: inline-flex;
-  align-items: baseline;
-  gap: 7px;
-  padding: 0 1px 13px;
-  border: 0;
+  flex: none;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 0 14px;
+  border: 1px solid transparent;
+  border-radius: calc(var(--radius-lg) - 5px);
   color: var(--text-muted);
   background: none;
   font-family: var(--font-display);
-  font-size: 13.5px;
+  font-size: 13px;
   font-weight: 600;
   letter-spacing: -0.005em;
+  white-space: nowrap;
   cursor: pointer;
-  transition: color 160ms ease;
+  transition:
+    color 180ms ease,
+    background 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.tl-sections button svg {
+  width: 15px;
+  height: 15px;
+  transition: color 180ms ease, transform 220ms var(--tl-ease-out);
 }
 
 .tl-sections button:hover {
   color: var(--text-secondary);
+  background: var(--glass-bg-hover);
 }
 
+.tl-sections button:hover svg {
+  transform: scale(1.08);
+}
+
+/* The count rides as a small pill so the tab label stays the reading line. */
 .tl-sections button span {
+  min-width: 20px;
+  padding: 1.5px 6px;
+  border-radius: var(--radius-pill);
   color: var(--text-muted);
-  font-size: 10.5px;
+  background: color-mix(in srgb, var(--text-muted) 14%, transparent);
+  font-size: 10px;
   font-variant-numeric: tabular-nums;
-  font-weight: 500;
+  font-weight: 600;
+  text-align: center;
+  transition: color 180ms ease, background 180ms ease;
 }
 
 .tl-sections button[aria-current="page"] {
-  color: var(--text-primary);
-}
-
-.tl-sections button[aria-current="page"]::after {
-  position: absolute;
-  right: 0;
-  bottom: -1px;
-  left: 0;
-  height: 1.5px;
-  background: var(--accent);
-  content: "";
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+  color: var(--accent-strong);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--accent) 16%, transparent), color-mix(in srgb, var(--accent) 9%, transparent));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--accent) 24%, transparent),
+    0 4px 14px color-mix(in srgb, var(--accent) 14%, transparent);
 }
 
 .tl-sections button[aria-current="page"] span {
-  color: var(--accent);
+  color: #fff;
+  background: var(--accent-gradient);
+  box-shadow: 0 2px 6px color-mix(in srgb, var(--accent) 34%, transparent);
 }
 
 /* ------------------------------------------------------------------- Panels */
@@ -316,8 +453,11 @@
   min-width: 0;
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-lg);
-  background: var(--tl-panel-bg);
-  box-shadow: var(--shadow-card);
+  background:
+    radial-gradient(ellipse 90% 62% at 14% 0%, var(--bg-ambient-green), transparent 58%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012) 42%),
+    var(--tl-panel-bg);
+  box-shadow: var(--shadow-card), var(--glass-inset);
   backdrop-filter: blur(var(--glass-blur));
   overflow: hidden;
 }
@@ -347,7 +487,7 @@
 
 .tl-eyebrow {
   margin: 0;
-  color: var(--text-muted);
+  color: color-mix(in srgb, var(--accent-strong) 78%, var(--text-muted));
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.16em;
@@ -379,7 +519,17 @@
   flex: 0 1 300px;
   align-items: center;
   gap: 8px;
+  min-height: 32px;
+  padding: 0 12px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
   color: var(--text-muted);
+  background: var(--glass-bg);
+  transition:
+    border-color 170ms ease,
+    box-shadow 170ms ease,
+    color 170ms ease,
+    flex-basis 240ms var(--tl-ease-out);
 }
 
 .tl-search input {
@@ -400,37 +550,55 @@
   outline: 0;
 }
 
+/* The field wakes up: accent ring, soft outer glow, and a little more room. */
 .tl-search:focus-within {
+  flex-basis: 340px;
+  border-color: color-mix(in srgb, var(--accent) 46%, transparent);
   color: var(--accent);
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent),
+    0 6px 18px color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 .tl-chips {
   display: flex;
   min-width: 0;
   flex-wrap: wrap;
-  gap: 5px;
+  gap: 6px;
 }
 
 .tl-chips button {
-  padding: 4px 11px;
-  border: 1px solid transparent;
+  padding: 5px 12px;
+  border: 1px solid var(--glass-border);
   border-radius: var(--radius-pill);
   color: var(--text-muted);
   background: none;
   font-size: 12px;
   cursor: pointer;
-  transition: color 140ms ease, background 140ms ease, border-color 140ms ease;
+  transition:
+    color 160ms ease,
+    background 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 170ms var(--tl-ease-out);
 }
 
 .tl-chips button:hover {
   color: var(--text-secondary);
+  border-color: color-mix(in srgb, var(--text-muted) 34%, transparent);
   background: var(--glass-bg);
+  transform: translateY(-1px);
 }
 
 .tl-chips button[aria-pressed="true"] {
   color: var(--accent-strong);
-  border-color: color-mix(in srgb, var(--accent) 34%, transparent);
-  background: var(--accent-soft);
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--accent) 15%, transparent), color-mix(in srgb, var(--accent) 8%, transparent));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--accent) 20%, transparent),
+    0 3px 10px color-mix(in srgb, var(--accent) 12%, transparent);
+  font-weight: 600;
 }
 
 /* The "show more" control spans the whole tile grid rather than one cell. */
@@ -463,9 +631,22 @@
   align-items: center;
   gap: 8px;
   padding: 9px 16px;
-  border-bottom: 1px solid var(--tl-rule);
-  background: var(--accent-soft);
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 22%, transparent);
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--accent) 12%, transparent), color-mix(in srgb, var(--accent) 5%, transparent));
   font-size: 12px;
+  animation: tl-bulk-in 240ms var(--tl-ease-out) both;
+}
+
+@keyframes tl-bulk-in {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }
 
 .tl-bulk strong {
@@ -559,7 +740,7 @@
 .tl-row {
   align-items: center;
   border-bottom: 1px solid var(--tl-rule-soft);
-  transition: background 140ms ease;
+  transition: background 170ms ease;
 }
 
 .tl-row:last-child {
@@ -691,24 +872,44 @@
 }
 
 .tl-mark {
-  width: 14px;
-  height: 14px;
+  width: 15px;
+  height: 15px;
   padding: 0;
-  border: 1px solid color-mix(in srgb, var(--text-muted) 52%, transparent);
-  border-radius: 4px;
+  border: 1.5px solid color-mix(in srgb, var(--text-muted) 52%, transparent);
+  border-radius: 5px;
   background: none;
   cursor: pointer;
-  transition: border-color 140ms ease, background 140ms ease;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms var(--tl-ease-out);
 }
 
 .tl-mark:hover {
   border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
 }
 
 .tl-mark[aria-checked="true"] {
   border-color: var(--accent);
-  background: var(--accent);
-  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--surface) 80%, transparent);
+  background: var(--accent-gradient);
+  box-shadow:
+    inset 0 0 0 2px color-mix(in srgb, var(--surface) 80%, transparent),
+    0 2px 8px color-mix(in srgb, var(--accent) 32%, transparent);
+  animation: tl-mark-pop 220ms var(--tl-ease-out);
+}
+
+@keyframes tl-mark-pop {
+  0% {
+    transform: scale(0.72);
+  }
+  60% {
+    transform: scale(1.12);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 /* Secondary actions stay out of the way until the row is reached. */
@@ -799,26 +1000,66 @@
      border is a 0.1-alpha dark that disappears on a white paper tile. */
   border: 1px solid var(--tl-rule);
   border-radius: var(--radius-md);
-  background: var(--tl-card, var(--glass-bg));
-  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+  background:
+    linear-gradient(158deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.014) 46%),
+    var(--tl-card, var(--glass-bg));
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.16),
+    0 10px 26px rgba(0, 0, 0, 0.14);
+  overflow: hidden;
+  transition:
+    border-color 190ms ease,
+    box-shadow 220ms var(--tl-ease-out),
+    transform 220ms var(--tl-ease-out);
+}
+
+/* A wash of accent light that rises from the top edge when the tile is touched. */
+.tl-card::before {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    radial-gradient(ellipse 120% 70% at 50% -18%, color-mix(in srgb, var(--accent) 13%, transparent), transparent 62%);
+  content: "";
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 240ms ease;
 }
 
 .tl-card:hover {
-  border-color: color-mix(in srgb, var(--accent) 30%, var(--glass-border));
-  background: var(--tl-card-hover, var(--glass-bg-hover));
-  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--glass-border));
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.18),
+    0 18px 38px rgba(0, 0, 0, 0.2),
+    0 0 0 1px color-mix(in srgb, var(--accent) 12%, transparent),
+    0 10px 30px color-mix(in srgb, var(--accent) 10%, transparent);
+  transform: translateY(-3px);
+}
+
+.tl-card:hover::before,
+.tl-card.is-active::before {
+  opacity: 1;
 }
 
 .tl-card.is-selected {
-  border-color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 62%, transparent);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.16),
+    0 12px 28px rgba(0, 0, 0, 0.15),
+    0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent),
+    0 8px 26px color-mix(in srgb, var(--accent) 16%, transparent);
 }
 
 .tl-card.is-active {
   border-color: color-mix(in srgb, var(--accent) 58%, var(--glass-border));
-  background: var(--tl-card-hover, var(--glass-bg-hover));
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.16),
+    0 12px 28px rgba(0, 0, 0, 0.15),
+    0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
 }
 
 .tl-card-open {
+  position: relative;
   display: flex;
   min-width: 0;
   flex: 1;
@@ -998,24 +1239,28 @@
 .tl-layout-switch {
   display: inline-flex;
   flex: none;
-  gap: 1px;
+  gap: 2px;
   padding: 2px;
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-sm);
+  background: var(--glass-bg);
 }
 
 .tl-layout-switch button {
   display: inline-flex;
-  width: 26px;
-  height: 24px;
+  width: 27px;
+  height: 25px;
   align-items: center;
   justify-content: center;
   border: 0;
-  border-radius: 5px;
+  border-radius: 6px;
   color: var(--text-muted);
   background: none;
   cursor: pointer;
-  transition: color 140ms ease, background 140ms ease;
+  transition:
+    color 160ms ease,
+    background 160ms ease,
+    box-shadow 160ms ease;
 }
 
 .tl-layout-switch button:hover {
@@ -1023,8 +1268,9 @@
 }
 
 .tl-layout-switch button[aria-pressed="true"] {
-  color: var(--text-primary);
-  background: var(--glass-bg-hover);
+  color: var(--accent-strong);
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 /* ------------------------------------------------- The ridge (the signature) */
@@ -1053,18 +1299,23 @@
   min-width: 1px;
   flex: 0 1 4px;
   height: var(--tl-bar-height);
-  border-radius: 1px;
-  background: var(--tl-ridge-fill, color-mix(in srgb, var(--accent) 46%, transparent));
+  border-radius: 2px 2px 1px 1px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--accent-strong) 82%, transparent), color-mix(in srgb, var(--accent) 46%, transparent));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14);
   transform-origin: bottom;
+  transition: filter 180ms ease;
 }
 
 .tl-ridge-bar.is-empty {
-  background: color-mix(in srgb, var(--text-muted) 40%, transparent);
+  background: color-mix(in srgb, var(--text-muted) 32%, transparent);
+  box-shadow: none;
 }
 
 /* Session counts, not load: grey, so the accent keeps meaning one thing. */
 .tl-ridge.is-count .tl-ridge-bar {
   background: color-mix(in srgb, var(--text-secondary) 34%, transparent);
+  box-shadow: none;
 }
 
 .tl-row:hover .tl-ridge.is-count .tl-ridge-bar {
@@ -1072,16 +1323,19 @@
 }
 
 .tl-ridge-bar.is-peak {
-  background: var(--accent-strong);
+  background: var(--accent-gradient);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    0 0 10px color-mix(in srgb, var(--accent) 46%, transparent);
 }
 
 .tl-row:hover .tl-ridge-bar:not(.is-empty),
 .tl-card:hover .tl-ridge-bar:not(.is-empty) {
-  background: var(--tl-ridge-fill-hover, color-mix(in srgb, var(--accent) 72%, transparent));
+  filter: brightness(1.16) saturate(1.1);
 }
 
 .tl-row:hover .tl-ridge-bar.is-peak {
-  background: var(--accent-strong);
+  filter: brightness(1.1);
 }
 
 /* The same axis at reading size: planned load pale, completed load solid. */
@@ -1104,8 +1358,9 @@
   position: absolute;
   bottom: 0;
   height: var(--tl-bar-height);
-  border-radius: 1.5px;
+  border-radius: 2.5px 2.5px 1px 1px;
   transform-origin: bottom;
+  transition: filter 180ms ease;
 }
 
 .tl-bullet b {
@@ -1117,11 +1372,18 @@
 .tl-bullet i {
   right: 30%;
   left: 30%;
-  background: color-mix(in srgb, var(--accent) 82%, transparent);
+  background: var(--accent-gradient);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    0 0 8px color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
 .tl-bullet:hover b {
   background: color-mix(in srgb, var(--text-muted) 42%, transparent);
+}
+
+.tl-bullet:hover i {
+  filter: brightness(1.14);
 }
 
 /* ------------------------------------------------- Workouts: catalog + reader */
@@ -1165,20 +1427,49 @@
   top: 0;
   right: 0;
   display: inline-flex;
-  width: 30px;
-  height: 30px;
+  width: 32px;
+  height: 32px;
   align-items: center;
   justify-content: center;
-  border: 0;
-  border-radius: 8px;
+  border: 1px solid transparent;
+  border-radius: 9px;
   color: var(--text-muted);
   background: none;
   cursor: pointer;
+  transition:
+    color 170ms ease,
+    background 170ms ease,
+    border-color 170ms ease,
+    transform 170ms var(--tl-ease-out);
 }
 
-.tl-reader-favorite:hover,
-.tl-reader-favorite.is-active {
+.tl-reader-favorite:hover {
+  border-color: var(--glass-border);
   color: var(--accent);
+  background: var(--glass-bg);
+  transform: translateY(-1px);
+}
+
+.tl-reader-favorite.is-active {
+  color: var(--accent-strong);
+}
+
+/* The heart answers the tap with a small leap. */
+.tl-reader-favorite.is-active svg {
+  animation: tl-heart-pop 320ms var(--tl-ease-out);
+  filter: drop-shadow(0 2px 8px color-mix(in srgb, var(--accent) 46%, transparent));
+}
+
+@keyframes tl-heart-pop {
+  0% {
+    transform: scale(0.6);
+  }
+  55% {
+    transform: scale(1.22);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 .tl-reader-metrics {
@@ -1216,23 +1507,30 @@
 /* Time is continuous, so the segments abut: only the fill marks a boundary. */
 .tl-shape > div {
   display: flex;
-  height: 34px;
-  border-radius: 3px;
+  height: 36px;
+  border: 1px solid color-mix(in srgb, var(--accent) 16%, transparent);
+  border-radius: 8px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.07);
   overflow: hidden;
 }
 
 .tl-shape span {
   min-width: 1px;
   background: color-mix(in srgb, var(--accent) 30%, transparent);
+  transition: filter 160ms ease;
+}
+
+.tl-shape span:hover {
+  filter: brightness(1.25);
 }
 
 .tl-shape span.is-training {
-  background: var(--accent);
+  background: linear-gradient(180deg, var(--accent-strong), var(--accent));
 }
 
 .tl-shape span.is-warmup,
 .tl-shape span.is-cooldown {
-  background: color-mix(in srgb, var(--accent) 26%, transparent);
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
 }
 
 .tl-shape span.is-rest,
@@ -1525,8 +1823,13 @@
 }
 
 .tl-tally div {
-  padding: 13px 20px;
+  padding: 14px 20px;
   background: var(--tl-panel-bg);
+  transition: background 180ms ease;
+}
+
+.tl-tally div:hover {
+  background: color-mix(in srgb, var(--accent) 5%, var(--tl-panel-bg));
 }
 
 .tl-tally dt {
@@ -1540,10 +1843,27 @@
 .tl-tally dd {
   margin: 5px 0 0;
   font-family: var(--font-display);
-  font-size: 22px;
+  font-size: 24px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   letter-spacing: -0.02em;
+}
+
+/* Each status number answers in its own colour, set from data-status. */
+.tl-tally [data-status="completed"] dd {
+  color: var(--success-text);
+}
+
+.tl-tally [data-status="partial"] dd {
+  color: var(--warning-text);
+}
+
+.tl-tally [data-status="missed"] dd {
+  color: var(--error-text);
+}
+
+.tl-tally [data-status="upcoming"] dd {
+  color: var(--accent-strong);
 }
 
 .tl-match-row {
@@ -1586,27 +1906,32 @@
   white-space: nowrap;
 }
 
-/* A status is a state, not a label: the day carries a hairline of its colour. */
+/* A status is a state, not a label: the day carries a rail of its colour, and
+   the whole row answers with the faintest wash of the same hue. */
 .tl-match-row {
-  border-left: 2px solid transparent;
-  padding-left: 14px;
+  border-left: 3px solid transparent;
+  padding-left: 13px;
 }
 
 .tl-match-row.is-completed {
   border-left-color: var(--success-text);
+  background: linear-gradient(90deg, color-mix(in srgb, var(--success-text) 6%, transparent), transparent 34%);
 }
 
 .tl-match-row.is-partial,
 .tl-match-row.is-rescheduled {
   border-left-color: var(--warning-text);
+  background: linear-gradient(90deg, color-mix(in srgb, var(--warning-text) 6%, transparent), transparent 34%);
 }
 
 .tl-match-row.is-missed {
   border-left-color: var(--error-text);
+  background: linear-gradient(90deg, color-mix(in srgb, var(--error-text) 6%, transparent), transparent 34%);
 }
 
 .tl-match-row.is-upcoming {
   border-left-color: color-mix(in srgb, var(--accent) 55%, transparent);
+  background: linear-gradient(90deg, color-mix(in srgb, var(--accent) 6%, transparent), transparent 34%);
 }
 
 .tl-activity-row {
@@ -1670,11 +1995,23 @@
 /* --------------------------------------------------- Empty, gate, and dialog */
 
 .tl-empty {
-  padding: 54px 20px 58px;
+  position: relative;
+  padding: 58px 20px 62px;
   text-align: center;
 }
 
+/* A breath of accent light behind the words keeps the void from feeling dead. */
+.tl-empty::before {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse 46% 60% at 50% 42%, color-mix(in srgb, var(--accent) 7%, transparent), transparent 70%);
+  content: "";
+  pointer-events: none;
+}
+
 .tl-empty h3 {
+  position: relative;
   margin: 0;
   font-family: var(--font-display);
   font-size: 16px;
@@ -1682,6 +2019,7 @@
 }
 
 .tl-empty p {
+  position: relative;
   margin: 7px auto 0;
   max-width: 38ch;
   color: var(--text-muted);
@@ -1694,32 +2032,121 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 12px;
+  gap: 14px;
   padding: 60px 30px;
   color: var(--text-primary);
   background:
-    radial-gradient(circle at 50% 24%, var(--accent-soft), transparent 42%),
+    radial-gradient(circle at 50% 22%, var(--accent-soft), transparent 44%),
+    radial-gradient(900px 420px at 82% -10%, var(--bg-ambient-teal), transparent 55%),
     var(--bg-base);
   text-align: center;
 }
 
+/* The icon floats inside a glass ring — the one piece of theatre on the gate. */
 .training-library-gate svg {
-  color: var(--text-muted);
+  width: 34px;
+  height: 34px;
+  padding: 18px;
+  border: 1px solid var(--glass-border);
+  border-radius: 50%;
+  color: var(--accent-strong);
+  background:
+    radial-gradient(circle at 32% 26%, rgba(255, 255, 255, 0.12), transparent 52%),
+    var(--glass-bg);
+  box-shadow:
+    var(--glass-inset),
+    0 18px 42px color-mix(in srgb, var(--accent) 20%, transparent);
+  box-sizing: content-box;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .training-library-gate svg {
+    animation: tl-gate-float 5s ease-in-out infinite;
+  }
+
+  .training-library-gate h1,
+  .training-library-gate p,
+  .training-library-gate .primary-button {
+    animation: tl-rise 480ms cubic-bezier(0.2, 0.8, 0.25, 1) backwards;
+  }
+
+  .training-library-gate h1 { animation-delay: 60ms; }
+  .training-library-gate p { animation-delay: 130ms; }
+  .training-library-gate .primary-button { animation-delay: 200ms; }
+}
+
+@keyframes tl-gate-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-7px);
+  }
+}
+
+@keyframes tl-rise {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }
 
 .training-library-gate h1 {
-  margin: 0;
+  margin: 6px 0 0;
   font-family: var(--font-display);
-  font-size: 24px;
+  font-size: 26px;
   font-weight: 600;
   letter-spacing: -0.02em;
+  background: linear-gradient(
+    100deg,
+    var(--text-primary) 40%,
+    color-mix(in srgb, var(--accent-strong) 70%, var(--text-primary)) 90%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 .training-library-gate p {
-  margin: 0 0 8px;
+  margin: 0 0 10px;
   max-width: 44ch;
   color: var(--text-muted);
   font-size: 13px;
+}
+
+/* The gate sits outside the view, so it styles its own call to action. */
+.training-library-gate .primary-button {
+  display: inline-flex;
+  min-height: 38px;
+  align-items: center;
+  padding: 0 20px;
+  border: 0;
+  border-radius: var(--radius-pill);
+  color: #fff;
+  background: var(--accent-gradient);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    0 8px 24px color-mix(in srgb, var(--accent) 34%, transparent);
+  font-size: 13.5px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    transform 180ms var(--tl-ease-out, cubic-bezier(0.2, 0.8, 0.25, 1)),
+    box-shadow 180ms ease,
+    filter 180ms ease;
+}
+
+.training-library-gate .primary-button:hover {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.26),
+    0 12px 32px color-mix(in srgb, var(--accent) 42%, transparent);
+  filter: brightness(1.07);
+  transform: translateY(-1px);
 }
 
 .tl-skeleton {
@@ -1728,27 +2155,46 @@
   gap: 1px;
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
   overflow: hidden;
 }
 
 .tl-skeleton span {
+  position: relative;
   height: 64px;
   background: var(--glass-bg);
+  overflow: hidden;
+}
+
+/* A light sweep travels each row; staggered, they read as one wave. */
+.tl-skeleton span::after {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 22%,
+    var(--tl-shimmer, rgba(255, 255, 255, 0.09)) 50%,
+    transparent 78%
+  );
+  content: "";
+  transform: translateX(-100%);
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .tl-skeleton span {
-    animation: tl-pulse 1.5s ease-in-out infinite alternate;
+  .tl-skeleton span::after {
+    animation: tl-shimmer 1.5s ease-in-out infinite;
+    animation-delay: calc(var(--tl-row-index, 0) * 90ms);
   }
 }
 
-@keyframes tl-pulse {
-  from {
-    opacity: 0.45;
-  }
+@keyframes tl-shimmer {
   to {
-    opacity: 0.9;
+    transform: translateX(100%);
   }
+}
+
+:root[data-theme="paper"] .tl-skeleton {
+  --tl-shimmer: rgba(38, 34, 28, 0.07);
 }
 
 .tl-dialog-backdrop {
@@ -1760,16 +2206,40 @@
   background: color-mix(in srgb, var(--bg-base) 76%, transparent);
   backdrop-filter: blur(8px);
   place-items: center;
+  animation: tl-fade-in 200ms ease both;
+}
+
+@keyframes tl-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .tl-dialog {
   width: min(460px, 100%);
   padding: 22px;
   border: 1px solid var(--glass-border);
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-lg);
   color: var(--text-primary);
-  background: var(--surface);
-  box-shadow: var(--shadow-elevated);
+  background:
+    radial-gradient(ellipse 110% 60% at 20% 0%, var(--bg-ambient-green), transparent 60%),
+    var(--surface);
+  box-shadow: var(--shadow-elevated), var(--glass-inset);
+  animation: tl-dialog-in 280ms var(--tl-ease-out, cubic-bezier(0.2, 0.8, 0.25, 1)) both;
+}
+
+@keyframes tl-dialog-in {
+  from {
+    opacity: 0;
+    transform: translateY(14px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }
 
 .tl-dialog h2 {
@@ -1817,7 +2287,16 @@
 
 .tl-dialog .primary-button.danger {
   color: #fff;
-  background: var(--error-text);
+  background: linear-gradient(135deg, #f87171 0%, #ef4444 100%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    0 6px 18px rgba(239, 68, 68, 0.32);
+}
+
+.tl-dialog .primary-button.danger:hover:not(:disabled) {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.26),
+    0 10px 26px rgba(239, 68, 68, 0.4);
 }
 
 /* ------------------------------------------------------- Plan editor modals */
@@ -1832,9 +2311,23 @@
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-lg);
   color: var(--text-primary);
-  background: color-mix(in srgb, var(--bg-base) 94%, var(--surface));
-  box-shadow: var(--shadow-elevated);
+  background:
+    radial-gradient(ellipse 70% 40% at 50% 0%, var(--bg-ambient-green), transparent 55%),
+    color-mix(in srgb, var(--bg-base) 94%, var(--surface));
+  box-shadow: var(--shadow-elevated), var(--glass-inset);
   overflow: hidden;
+  animation: tl-sheet-in 340ms var(--tl-ease-out, cubic-bezier(0.2, 0.8, 0.25, 1)) both;
+}
+
+@keyframes tl-sheet-in {
+  from {
+    opacity: 0;
+    transform: translateY(22px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }
 
 .plan-editor::before,
@@ -1845,6 +2338,7 @@
   background: color-mix(in srgb, var(--bg-base) 72%, transparent);
   backdrop-filter: blur(10px);
   content: "";
+  animation: tl-fade-in 240ms ease both;
 }
 
 .plan-editor-header,
@@ -2121,7 +2615,10 @@
 .plan-week {
   border: 1px solid var(--tl-rule);
   border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--surface) 30%, transparent);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 30%),
+    color-mix(in srgb, var(--surface) 30%, transparent);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.14), 0 8px 22px rgba(0, 0, 0, 0.12);
   overflow: hidden;
 }
 
@@ -2215,17 +2712,37 @@
   justify-content: space-between;
   gap: 6px;
   padding: 7px 8px;
-  border: 1px solid color-mix(in srgb, var(--accent) 26%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
   border-radius: var(--radius-sm);
-  background: var(--accent-soft);
+  background:
+    linear-gradient(160deg, color-mix(in srgb, var(--accent) 16%, transparent), color-mix(in srgb, var(--accent) 8%, transparent));
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--accent) 16%, transparent);
   cursor: grab;
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms var(--tl-ease-out);
+}
+
+.plan-entry-card:hover {
+  border-color: color-mix(in srgb, var(--accent) 48%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--accent) 18%, transparent),
+    0 4px 12px color-mix(in srgb, var(--accent) 14%, transparent);
+  transform: translateY(-1px);
 }
 
 .plan-entry-card.is-rest,
 .plan-entry-card.is-note {
   border-color: var(--glass-border);
   background: var(--glass-bg);
+  box-shadow: none;
   cursor: default;
+}
+
+.plan-entry-card.is-rest:hover,
+.plan-entry-card.is-note:hover {
+  transform: none;
 }
 
 .plan-entry-card > span {
@@ -2263,18 +2780,25 @@
   align-items: center;
   justify-content: center;
   gap: 7px;
-  padding: 11px;
-  border: 1px dashed var(--glass-border);
+  padding: 12px;
+  border: 1px dashed color-mix(in srgb, var(--text-muted) 38%, transparent);
   border-radius: var(--radius-md);
   color: var(--text-secondary);
   background: none;
   font-size: 12.5px;
   cursor: pointer;
+  transition:
+    color 170ms ease,
+    border-color 170ms ease,
+    background 170ms ease,
+    box-shadow 170ms ease;
 }
 
 .plan-add-week:hover {
-  color: var(--text-primary);
-  border-color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 56%, transparent);
+  color: var(--accent-strong);
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 .plan-editor-preview dl,
@@ -2376,6 +2900,18 @@
   color: var(--text-secondary);
   background: none;
   cursor: pointer;
+  transition:
+    color 170ms ease,
+    border-color 170ms ease,
+    background 170ms ease,
+    box-shadow 170ms ease,
+    transform 170ms var(--tl-ease-out, cubic-bezier(0.2, 0.8, 0.25, 1));
+}
+
+.plan-compare-picker button:hover:not(:disabled) {
+  color: var(--text-primary);
+  background: var(--glass-bg);
+  transform: translateY(-1px);
 }
 
 .plan-compare-picker button:disabled {
@@ -2384,9 +2920,11 @@
 }
 
 .plan-compare-picker button.is-selected {
-  color: var(--text-primary);
-  border-color: var(--accent);
-  background: var(--accent-soft);
+  color: var(--accent-strong);
+  border-color: color-mix(in srgb, var(--accent) 44%, transparent);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--accent) 15%, transparent), color-mix(in srgb, var(--accent) 8%, transparent));
+  box-shadow: 0 3px 12px color-mix(in srgb, var(--accent) 14%, transparent);
 }
 
 .plan-compare-picker button span {
@@ -2502,33 +3040,89 @@
 /* ------------------------------------------------------------------- Motion */
 
 @media (prefers-reduced-motion: no-preference) {
-  /* One orchestrated moment: rows settle in, then the ridges draw themselves. */
-  :is(.tl-index ul, .tl-grid) > li {
-    animation: tl-settle 260ms cubic-bezier(0.2, 0.8, 0.25, 1) backwards;
+  /*
+   * The view arrives in three beats — masthead, section control, then the
+   * working surface — the same cadence the dashboard blocks enter with.
+   */
+  .tl-masthead {
+    animation: tl-view-enter 460ms cubic-bezier(0.2, 0.8, 0.25, 1) backwards;
   }
 
-  :is(.tl-index ul, .tl-grid) > li:nth-child(1) { animation-delay: 0ms; }
-  :is(.tl-index ul, .tl-grid) > li:nth-child(2) { animation-delay: 22ms; }
-  :is(.tl-index ul, .tl-grid) > li:nth-child(3) { animation-delay: 44ms; }
-  :is(.tl-index ul, .tl-grid) > li:nth-child(4) { animation-delay: 66ms; }
-  :is(.tl-index ul, .tl-grid) > li:nth-child(5) { animation-delay: 88ms; }
-  :is(.tl-index ul, .tl-grid) > li:nth-child(6) { animation-delay: 110ms; }
-  :is(.tl-index ul, .tl-grid) > li:nth-child(7) { animation-delay: 132ms; }
-  :is(.tl-index ul, .tl-grid) > li:nth-child(8) { animation-delay: 154ms; }
-  :is(.tl-index ul, .tl-grid) > li:nth-child(n + 9) { animation-delay: 176ms; }
+  .tl-sections {
+    animation: tl-view-enter 460ms cubic-bezier(0.2, 0.8, 0.25, 1) 70ms backwards;
+  }
+
+  .tl-notice {
+    animation: tl-view-enter 460ms cubic-bezier(0.2, 0.8, 0.25, 1) 110ms backwards;
+  }
+
+  .training-library-view > .tl-panel,
+  .training-library-view > .tl-template-layout {
+    animation: tl-view-enter 520ms cubic-bezier(0.2, 0.8, 0.25, 1) 140ms backwards;
+  }
+
+  /* Adherence is a stack of panels; they cascade instead of landing together. */
+  .tl-adherence > .tl-panel:nth-child(1) {
+    animation: tl-view-enter 520ms cubic-bezier(0.2, 0.8, 0.25, 1) 140ms backwards;
+  }
+
+  .tl-adherence > .tl-panel:nth-child(2) {
+    animation: tl-view-enter 520ms cubic-bezier(0.2, 0.8, 0.25, 1) 210ms backwards;
+  }
+
+  .tl-adherence > .tl-panel:nth-child(3) {
+    animation: tl-view-enter 520ms cubic-bezier(0.2, 0.8, 0.25, 1) 280ms backwards;
+  }
+
+  /* One orchestrated moment: rows settle in, then the ridges draw themselves. */
+  :is(.tl-index ul, .tl-grid) > li {
+    animation: tl-settle 300ms cubic-bezier(0.2, 0.8, 0.25, 1) backwards;
+  }
+
+  :is(.tl-index ul, .tl-grid) > li:nth-child(1) { animation-delay: 170ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(2) { animation-delay: 196ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(3) { animation-delay: 222ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(4) { animation-delay: 248ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(5) { animation-delay: 274ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(6) { animation-delay: 300ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(7) { animation-delay: 326ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(8) { animation-delay: 352ms; }
+  :is(.tl-index ul, .tl-grid) > li:nth-child(n + 9) { animation-delay: 378ms; }
 
   .tl-ridge-bar,
   .tl-bullet b,
   .tl-bullet i {
-    animation: tl-grow 420ms cubic-bezier(0.2, 0.85, 0.3, 1) backwards;
-    animation-delay: calc(140ms + var(--tl-bar-index) * 14ms);
+    animation: tl-grow 460ms cubic-bezier(0.2, 0.85, 0.3, 1) backwards;
+    animation-delay: calc(280ms + var(--tl-bar-index) * 16ms);
+  }
+
+  /* The workout reader changes content without a route change; ease the swap. */
+  .tl-reader > * {
+    animation: tl-settle 320ms cubic-bezier(0.2, 0.8, 0.25, 1) backwards;
+  }
+
+  .tl-reader > *:nth-child(2) { animation-delay: 45ms; }
+  .tl-reader > *:nth-child(3) { animation-delay: 90ms; }
+  .tl-reader > *:nth-child(4) { animation-delay: 135ms; }
+  .tl-reader > *:nth-child(5) { animation-delay: 180ms; }
+  .tl-reader > *:nth-child(n + 6) { animation-delay: 225ms; }
+}
+
+@keyframes tl-view-enter {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
   }
 }
 
 @keyframes tl-settle {
   from {
     opacity: 0;
-    transform: translateY(5px);
+    transform: translateY(6px) scale(0.99);
   }
   to {
     opacity: 1;
@@ -2546,8 +3140,13 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .training-library-view,
   .training-library-view *,
+  .training-library-gate,
+  .training-library-gate *,
+  .plan-editor,
   .plan-editor *,
+  .plan-compare,
   .plan-compare * {
     animation-duration: 0.001ms !important;
     animation-iteration-count: 1 !important;
@@ -2622,8 +3221,8 @@
   }
 
   .tl-sections {
-    gap: 18px;
-    overflow-x: auto;
+    display: flex;
+    width: 100%;
   }
 
   .tl-filters {

--- a/src/training-library/trainingLibrary.css
+++ b/src/training-library/trainingLibrary.css
@@ -6,6 +6,10 @@
  * panels over ambient accent washes, one segmented control for the sections,
  * and the accent gradient reserved for moments of emphasis.
  *
+ * The dark theme is layered charcoal, never pure black, and the gate shares
+ * the same ground. The accent stays the app's signature green; red and
+ * yellow stay reserved for danger and caution.
+ *
  * Only one thing is ever drawn — the ridge of weekly training load (Ridge.tsx),
  * small on an index row and at reading size on the adherence lede. It keeps to
  * the accent hue alone; height carries the number.
@@ -34,15 +38,27 @@
   /* The one motion signature every control in the view shares. */
   --tl-ease-out: cubic-bezier(0.2, 0.8, 0.25, 1);
 
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
   min-width: 0;
-  min-height: 100%;
-  padding: 30px 34px 56px;
+  min-height: 0;
+  padding: 30px 34px 24px;
   color: var(--text-primary);
   background:
     radial-gradient(1100px 460px at 16% -8%, var(--bg-ambient-green), transparent 62%),
     radial-gradient(880px 420px at 90% -12%, var(--bg-ambient-teal), transparent 58%),
     var(--tl-ground, var(--bg-base));
   background-attachment: local;
+  overflow: hidden;
+}
+
+/* Highlighted text takes the accent, never the system blue. */
+.training-library-view ::selection {
+  color: var(--text-primary);
+  background: color-mix(in srgb, var(--accent) 38%, transparent);
 }
 
 /*
@@ -51,16 +67,21 @@
  *
  * It works by overriding the app tokens rather than inventing new ones, which
  * is how the paper theme reskins too: everything downstream — this file, plus
- * shared pieces like .app-select and .primary-button — follows for free.
+ * shared pieces like .app-select and .primary-button — follows for free. The
+ * modals the workspace opens render inside the view, so they inherit all of
+ * this without a rule of their own.
+ *
+ * The gate shares the block so the connect screen sits on the same charcoal.
  */
-:root:not([data-theme]) .training-library-view {
-  --tl-ground: #1b1d20;
-  --tl-panel-bg: #212429;
-  --tl-card: #262a2f;
-  --tl-card-hover: #2d3239;
-  --tl-reader-bg: #1d2023;
+:root:not([data-theme]) .training-library-view,
+:root:not([data-theme]) .training-library-gate {
+  --tl-ground: #16171b;
+  --tl-panel-bg: #1d1f25;
+  --tl-card: #23262e;
+  --tl-card-hover: #2b2f38;
+  --tl-reader-bg: #1a1c21;
 
-  --surface: #262a2f;
+  --surface: #23262e;
   --glass-bg: rgba(255, 255, 255, 0.04);
   --glass-bg-hover: rgba(255, 255, 255, 0.07);
   --glass-bg-elevated: rgba(255, 255, 255, 0.09);
@@ -377,6 +398,13 @@
   display: none;
 }
 
+/* The desktop shell stays anchored while the active workspace owns scrolling. */
+.tl-masthead,
+.tl-notice,
+.tl-sections {
+  flex: none;
+}
+
 .tl-sections button {
   position: relative;
   display: inline-flex;
@@ -408,13 +436,21 @@
   transition: color 180ms ease, transform 220ms var(--tl-ease-out);
 }
 
-.tl-sections button:hover {
+.tl-sections button:hover:not(:disabled) {
   color: var(--text-secondary);
   background: var(--glass-bg-hover);
 }
 
-.tl-sections button:hover svg {
+.tl-sections button:hover:not(:disabled) svg {
   transform: scale(1.08);
+}
+
+.tl-sections button:disabled {
+  cursor: default;
+}
+
+.tl-sections button:disabled:not([aria-current="page"]) {
+  opacity: 0.5;
 }
 
 /* The count rides as a small pill so the tab label stays the reading line. */
@@ -460,6 +496,39 @@
   box-shadow: var(--shadow-card), var(--glass-inset);
   backdrop-filter: blur(var(--glass-blur));
   overflow: hidden;
+}
+
+.training-library-view > :is(.tl-panel, .tl-template-layout, .tl-adherence) {
+  min-height: 0;
+  flex: 1 1 0;
+}
+
+.training-library-view > .tl-panel:not(.tl-split),
+.tl-template-layout > .tl-panel {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.training-library-view > .tl-panel:not(.tl-split) > :is(.tl-grid, .tl-index),
+.tl-template-layout > .tl-panel:not(.tl-collections) > :is(.tl-grid, .tl-index) {
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: var(--glass-border) transparent;
+  scrollbar-gutter: stable;
+}
+
+.training-library-view > .tl-panel:not(.tl-split) > .tl-grid,
+.tl-template-layout > .tl-panel:not(.tl-collections) > .tl-grid {
+  align-content: start;
+}
+
+.training-library-view > .tl-panel:not(.tl-split) > .tl-empty,
+.tl-template-layout > .tl-panel:not(.tl-collections) > .tl-empty {
+  min-height: 0;
+  flex: 1 1 auto;
 }
 
 .tl-panel > header {
@@ -698,9 +767,14 @@
 
 /* Column labels are stated once, so the rows can be pure data. */
 .tl-index-head {
+  position: sticky;
+  z-index: 2;
+  top: 0;
   padding: 9px 16px;
   border-bottom: 1px solid var(--tl-rule);
   color: var(--text-muted);
+  background: color-mix(in srgb, var(--surface) 94%, transparent);
+  backdrop-filter: blur(12px);
   font-size: 9.5px;
   font-weight: 600;
   letter-spacing: 0.15em;
@@ -1390,39 +1464,102 @@
 
 .tl-split {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 372px;
+  min-height: 0;
+  grid-template-columns: minmax(0, 1fr) 392px;
+  overflow: hidden;
 }
 
 .tl-catalog {
+  display: flex;
   min-width: 0;
+  min-height: 0;
+  flex-direction: column;
   border-right: 1px solid var(--tl-rule);
+}
+
+.tl-catalog > :is(.tl-grid, .tl-index) {
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: var(--glass-border) transparent;
+  scrollbar-gutter: stable;
+}
+
+.tl-catalog > .tl-grid {
+  align-content: start;
+}
+
+.tl-catalog > .tl-empty {
+  min-height: 0;
+  flex: 1 1 auto;
 }
 
 /* Sits a step below the catalog so the tiles read as the raised layer. */
 .tl-reader {
   display: flex;
   min-width: 0;
+  min-height: 0;
   flex-direction: column;
-  gap: 18px;
-  padding: 20px 20px 22px;
+  /* The metric figures scale in cqi, so the strip fits at both split widths. */
+  container-type: inline-size;
   background:
     radial-gradient(ellipse 140% 20% at 50% 0%, color-mix(in srgb, var(--accent) 7%, transparent), transparent 64%),
     var(--tl-reader-bg, color-mix(in srgb, var(--surface) 34%, transparent));
+  overflow: hidden;
 }
 
-.tl-reader > header {
+/* The workout details scroll independently, leaving the core actions docked. */
+.tl-reader-scroll {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 20px;
+  padding: 20px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: var(--glass-border) transparent;
+  scrollbar-gutter: stable;
+}
+
+.tl-reader-scroll > header {
   position: relative;
   padding-right: 38px;
 }
 
-.tl-reader > header h2 {
-  margin: 9px 0 0;
+.tl-reader-scroll > header h2 {
+  margin: 10px 0 0;
   font-family: var(--font-display);
-  font-size: 22px;
+  font-size: 23px;
   font-weight: 600;
-  letter-spacing: -0.022em;
+  letter-spacing: -0.024em;
   line-height: 1.16;
   text-wrap: balance;
+}
+
+/* The workout's own tags ride under the title as quiet ghost chips. */
+.tl-reader-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 11px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tl-reader-tags li {
+  max-width: 100%;
+  padding: 2.5px 9px;
+  border: 1px solid var(--tl-rule-soft);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /*
@@ -1498,6 +1635,12 @@
   transform: translateY(-1px);
 }
 
+.tl-reader-favorite:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 46%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+  outline: 0;
+}
+
 .tl-reader-favorite.is-active {
   color: var(--accent-strong);
 }
@@ -1523,9 +1666,9 @@
 .tl-reader-metrics {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 12px;
+  gap: 8px;
   margin: 0;
-  padding: 14px 0 15px;
+  padding: 15px 0 16px;
   border-top: 1px solid var(--tl-rule);
   border-bottom: 1px solid var(--tl-rule);
 }
@@ -1537,22 +1680,31 @@
 /* Hairline dividers keep the four figures reading as one instrument. */
 .tl-reader-metrics > div + div {
   border-left: 1px solid var(--tl-rule-soft);
-  padding-left: 12px;
+  padding-left: 10px;
 }
 
 .tl-reader-metrics dt {
+  overflow: hidden;
   color: var(--text-muted);
-  font-size: 9.5px;
+  /* Like the figure, the label scales with the panel so DISTANCE never clips. */
+  font-size: clamp(8.2px, 2.3cqi, 9px);
   font-weight: 600;
-  letter-spacing: 0.14em;
+  letter-spacing: clamp(0.8px, 0.26cqi, 1.1px);
+  text-overflow: ellipsis;
   text-transform: uppercase;
+  white-space: nowrap;
 }
 
+/*
+ * The figure scales with the reader's width (the panel is the container), so
+ * values like "12 sets" fit at full width and only shrink at the narrow
+ * breakpoint; ellipsis stays the last resort, with the full string on title.
+ */
 .tl-reader-metrics dd {
-  margin: 6px 0 0;
+  margin: 7px 0 0;
   overflow: hidden;
   font-family: var(--font-display);
-  font-size: 19px;
+  font-size: clamp(14px, 4.4cqi, 18px);
   font-weight: 600;
   font-variant-numeric: tabular-nums;
   letter-spacing: -0.02em;
@@ -1566,9 +1718,20 @@
   font-weight: 500;
 }
 
-/* Step structure by share of the session: repeats expand into a comb. */
+/*
+ * Step structure by share of the session: repeats expand into a comb. The
+ * figure is set as a small glass card — the same recipe as the schedule form —
+ * so the bar and its legend read as one contained instrument.
+ */
 .tl-shape {
   margin: 0;
+  padding: 12px 12px 11px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(160deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012) 48%),
+    var(--glass-bg);
+  box-shadow: var(--shadow-inset);
 }
 
 /* Time is continuous, so the segments abut: only the fill marks a boundary. */
@@ -1581,28 +1744,29 @@
   overflow: hidden;
 }
 
-.tl-shape span {
+/* Segment fills scope to the bar itself, never the caption or legend spans. */
+.tl-shape > div > span {
   min-width: 1px;
   background: color-mix(in srgb, var(--accent) 30%, transparent);
   transition: filter 160ms ease;
 }
 
-.tl-shape span:hover {
+.tl-shape > div > span:hover {
   filter: brightness(1.25);
 }
 
-.tl-shape span.is-training {
+.tl-shape > div > span.is-training {
   background: linear-gradient(180deg, var(--accent-strong), var(--accent));
 }
 
-.tl-shape span.is-warmup,
-.tl-shape span.is-cooldown {
+.tl-shape > div > span.is-warmup,
+.tl-shape > div > span.is-cooldown {
   background: color-mix(in srgb, var(--accent) 28%, transparent);
 }
 
-.tl-shape span.is-rest,
-.tl-shape span.is-sendOff {
-  background: color-mix(in srgb, var(--text-secondary) 20%, transparent);
+.tl-shape > div > span.is-rest,
+.tl-shape > div > span.is-sendOff {
+  background: color-mix(in srgb, var(--text-secondary) 26%, transparent);
 }
 
 .tl-shape figcaption,
@@ -1616,13 +1780,25 @@
   font-size: 10.5px;
 }
 
+/*
+ * The reader's card stacks the caption over the legend instead of squeezing
+ * both onto one line: each gets the card's full width, and the legend wraps
+ * left-aligned when every kind shows up at once.
+ */
+.tl-shape figcaption {
+  align-items: flex-start;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 10px;
+}
+
 /* The legend keys the bar's fills without repeating words on every segment. */
 .tl-shape-legend {
   display: inline-flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: flex-end;
-  gap: 4px 10px;
+  justify-content: flex-start;
+  gap: 5px 14px;
 }
 
 .tl-shape-legend > span {
@@ -1651,6 +1827,31 @@
 .tl-shape-legend em.is-rest,
 .tl-shape-legend em.is-sendOff {
   background: color-mix(in srgb, var(--text-secondary) 26%, transparent);
+}
+
+/* The list and its eyebrow label travel as one zone, apart from the shape card. */
+.tl-steps-block {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.tl-steps-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.tl-steps-label span {
+  color: color-mix(in srgb, var(--text-muted) 78%, transparent);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
 }
 
 .tl-steps {
@@ -1743,22 +1944,22 @@
   background: color-mix(in srgb, var(--accent) 9%, transparent);
 }
 
-/* Children hang from a guide rail, each line pinned by its own dot. */
+/* Children hang from a guide rail, each line pinned by a ring threaded on it. */
 .tl-step-children {
   display: flex;
   width: 100%;
   flex-direction: column;
-  gap: 4px;
-  margin-top: 5px;
+  gap: 5px;
+  margin-top: 6px;
   margin-left: 2px;
   padding: 2px 0 2px 13px;
-  border-left: 1px solid color-mix(in srgb, var(--accent) 24%, var(--tl-rule));
+  border-left: 1px solid color-mix(in srgb, var(--accent) 18%, var(--tl-rule));
 }
 
 .tl-step-children em {
   position: relative;
-  color: var(--text-muted);
-  font-size: 11.5px;
+  color: var(--text-secondary);
+  font-size: 12px;
   font-style: normal;
   line-height: 1.45;
 }
@@ -1766,18 +1967,18 @@
 .tl-step-children em::before {
   position: absolute;
   top: 50%;
-  left: -15.5px;
-  width: 5px;
-  height: 5px;
+  left: -16.5px;
+  width: 4px;
+  height: 4px;
+  border: 1.5px solid color-mix(in srgb, var(--accent) 44%, var(--text-muted));
   border-radius: 50%;
-  background: color-mix(in srgb, var(--accent) 48%, var(--text-muted));
   content: "";
   transform: translateY(-50%);
 }
 
 .tl-step-children em small {
-  margin-left: 4px;
-  color: color-mix(in srgb, var(--text-muted) 84%, transparent);
+  margin-left: 5px;
+  color: var(--text-muted);
   font-size: 10.5px;
   font-variant-numeric: tabular-nums;
 }
@@ -1811,53 +2012,111 @@
   color: var(--accent-strong);
 }
 
-.tl-reader-actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 7px;
-  /* Anchored to the reader's floor: always the last thing the eye lands on. */
-  margin-top: auto;
-  padding-top: 14px;
-  border-top: 1px solid var(--tl-rule);
-}
-
-/* Destruction waits at the far end, away from the everyday actions. */
-.tl-reader-actions .ghost-button.danger {
-  margin-left: auto;
-}
-
-/* Scheduling is the reader's one form, so it is set as a small glass card. */
-.tl-reader-schedule {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 12px;
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius-md);
+/*
+ * A web glassmorphism dock: calendar and workout commands share one anchored
+ * control surface, while the fade above it keeps the reader from ending hard.
+ */
+.tl-reader-dock {
+  position: relative;
+  isolation: isolate;
+  flex: none;
+  padding: 12px 14px 14px;
+  border-top: 1px solid color-mix(in srgb, var(--accent) 18%, var(--tl-rule));
   background:
-    linear-gradient(160deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012) 48%),
-    var(--glass-bg);
-  box-shadow: var(--shadow-inset);
+    radial-gradient(ellipse 105% 100% at 0% 0%, color-mix(in srgb, var(--accent) 11%, transparent), transparent 64%),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.075), rgba(255, 255, 255, 0.018) 54%),
+    color-mix(in srgb, var(--tl-reader-bg, var(--surface)) 86%, transparent);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.11),
+    0 -18px 42px color-mix(in srgb, var(--tl-reader-bg, var(--surface)) 72%, transparent);
+  backdrop-filter: blur(24px) saturate(145%);
+  -webkit-backdrop-filter: blur(24px) saturate(145%);
+}
+
+.tl-reader-dock::before {
+  position: absolute;
+  z-index: -1;
+  right: 0;
+  bottom: 100%;
+  left: 0;
+  height: 22px;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    color-mix(in srgb, var(--tl-reader-bg, var(--surface)) 66%, transparent)
+  );
+  content: "";
+  pointer-events: none;
+}
+
+.tl-reader-dock::after {
+  position: absolute;
+  z-index: -1;
+  inset: 1px 0 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(105deg, rgba(255, 255, 255, 0.035), transparent 42%);
+  content: "";
+  pointer-events: none;
+}
+
+/* Scheduling gets the first row and a clear two-part hierarchy. */
+.tl-reader-schedule {
+  padding-bottom: 11px;
+  border-bottom: 1px solid var(--tl-rule-soft);
+}
+
+.tl-reader-schedule-heading {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 9px;
+}
+
+.tl-reader-schedule-icon {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--glass-border));
+  border-radius: var(--radius-sm);
+  color: var(--accent-strong);
+  background: color-mix(in srgb, var(--accent) 10%, var(--glass-bg));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+.tl-reader-schedule-heading > span:last-child {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.tl-reader-schedule-heading strong {
+  font-size: 12.5px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.tl-reader-schedule-heading small {
+  color: var(--text-muted);
+  font-size: 10.5px;
+  line-height: 1.3;
+}
+
+.tl-reader-schedule-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
 }
 
 .tl-reader-schedule label {
-  display: flex;
   min-width: 0;
-  flex: 1 1 auto;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.tl-reader-schedule label span {
-  color: var(--text-muted);
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
 }
 
 .tl-reader-schedule input {
+  width: 100%;
   min-height: 34px;
   padding: 0 10px;
   border: 1px solid var(--glass-border);
@@ -1874,6 +2133,82 @@
   outline: 0;
 }
 
+.tl-reader-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 11px;
+}
+
+.tl-reader-actions-main {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 7px;
+}
+
+.tl-reader-actions-main > .primary-button {
+  min-width: 68px;
+}
+
+/* Duplicate and its destination sport read as one compound action. */
+.tl-reader-duplicate {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: auto minmax(76px, 1fr);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--glass-bg) 78%, transparent);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.055);
+}
+
+.tl-reader-duplicate > .ghost-button {
+  min-height: 32px;
+  padding: 0 9px;
+  border: 0;
+  border-radius: calc(var(--radius-sm) - 1px) 0 0 calc(var(--radius-sm) - 1px);
+  white-space: nowrap;
+}
+
+.tl-reader-duplicate .app-select-trigger {
+  min-height: 32px;
+  border: 0;
+  border-left: 1px solid var(--tl-rule-soft);
+  border-radius: 0 calc(var(--radius-sm) - 1px) calc(var(--radius-sm) - 1px) 0;
+  background: transparent;
+}
+
+.tl-reader-actions-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.tl-reader-actions-meta .ghost-button {
+  color: var(--text-muted);
+}
+
+.tl-reader-actions-meta .ghost-button:hover:not(:disabled) {
+  color: var(--text-secondary);
+}
+
+/* The dock sits at the bottom edge, so its sport picker opens into the reader. */
+.tl-reader-dock .app-select-menu {
+  top: auto;
+  right: 0;
+  bottom: calc(100% + 6px);
+  left: auto;
+  min-width: 148px;
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .tl-reader-dock {
+    background: var(--tl-reader-bg, var(--surface));
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
 .tl-reader-loading {
   display: flex;
   align-items: center;
@@ -1888,9 +2223,11 @@
 
 .tl-template-layout {
   display: grid;
+  min-height: 0;
   grid-template-columns: minmax(0, 1fr) 292px;
-  align-items: start;
+  align-items: stretch;
   gap: 16px;
+  overflow: hidden;
 }
 
 .tl-collections > header {
@@ -1917,10 +2254,16 @@
 }
 
 .tl-collections ul {
+  min-height: 0;
+  flex: 1 1 auto;
   margin: 0;
   padding: 0;
   border-top: 1px solid var(--tl-rule);
   list-style: none;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: var(--glass-border) transparent;
+  scrollbar-gutter: stable;
 }
 
 .tl-collections li {
@@ -1987,8 +2330,13 @@
 
 .tl-adherence {
   display: flex;
+  min-height: 0;
   flex-direction: column;
   gap: 16px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: var(--glass-border) transparent;
+  scrollbar-gutter: stable;
 }
 
 .tl-adherence-lede > header {
@@ -2249,7 +2597,7 @@
   background:
     radial-gradient(circle at 50% 22%, var(--accent-soft), transparent 44%),
     radial-gradient(900px 420px at 82% -10%, var(--bg-ambient-teal), transparent 55%),
-    var(--bg-base);
+    var(--tl-ground, var(--bg-base));
   text-align: center;
 }
 
@@ -2510,13 +2858,10 @@
     0 10px 26px rgba(239, 68, 68, 0.4);
 }
 
-/* ------------------------------------------------------- Plan editor modals */
+/* ----------------------------------------------- Plan editor and comparison */
 
 .plan-editor,
 .plan-compare {
-  position: fixed;
-  inset: 16px;
-  z-index: 90;
   display: flex;
   flex-direction: column;
   border: 1px solid var(--glass-border);
@@ -2524,10 +2869,23 @@
   color: var(--text-primary);
   background:
     radial-gradient(ellipse 70% 40% at 50% 0%, var(--bg-ambient-green), transparent 55%),
-    color-mix(in srgb, var(--bg-base) 94%, var(--surface));
+    color-mix(in srgb, var(--tl-ground, var(--bg-base)) 94%, var(--surface));
   box-shadow: var(--shadow-elevated), var(--glass-inset);
   overflow: hidden;
   animation: tl-sheet-in 340ms var(--tl-ease-out, cubic-bezier(0.2, 0.8, 0.25, 1)) both;
+}
+
+.plan-editor {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  flex: 1 1 0;
+}
+
+.plan-compare {
+  position: fixed;
+  inset: 16px;
+  z-index: 90;
 }
 
 @keyframes tl-sheet-in {
@@ -2541,7 +2899,6 @@
   }
 }
 
-.plan-editor::before,
 .plan-compare::before {
   position: fixed;
   inset: 0;
@@ -2571,6 +2928,7 @@
   min-width: 300px;
   padding: 0;
   border: 0;
+  border-bottom: 1px solid transparent;
   color: var(--text-primary);
   background: none;
   font-family: var(--font-display);
@@ -2578,10 +2936,15 @@
   font-weight: 600;
   letter-spacing: -0.02em;
   outline: 0;
+  transition: border-color 160ms ease;
+}
+
+.plan-editor-name:hover {
+  border-bottom-color: var(--tl-rule);
 }
 
 .plan-editor-name:focus-visible {
-  border-bottom: 1px solid var(--accent);
+  border-bottom-color: var(--accent);
 }
 
 .plan-editor-header > div > p:last-of-type {
@@ -2590,7 +2953,8 @@
   font-size: 12px;
 }
 
-.plan-editor-source-warning {
+.plan-editor-source-warning,
+.plan-editor-dirty {
   display: inline-block;
   margin-top: 8px;
   padding: 2px 8px;
@@ -2598,6 +2962,10 @@
   color: var(--warning-text);
   background: var(--warning-bg);
   font-size: 10.5px;
+}
+
+.plan-editor-dirty {
+  margin-right: 6px;
 }
 
 .plan-editor-header-actions {
@@ -2619,18 +2987,53 @@
   min-width: 0;
   padding: 18px;
   overflow-y: auto;
+  scrollbar-color: var(--glass-border) transparent;
 }
 
 .plan-editor-sidebar {
   display: flex;
   flex-direction: column;
-  gap: 22px;
+  gap: 0;
   border-right: 1px solid var(--tl-rule);
+}
+
+.plan-editor-sidebar > section {
+  padding-bottom: 20px;
+}
+
+.plan-editor-sidebar > section + section {
+  padding-top: 20px;
+  border-top: 1px solid var(--tl-rule-soft);
+}
+
+.plan-editor-sidebar > section:last-child {
+  padding-bottom: 0;
 }
 
 .plan-editor-preview {
   border-left: 1px solid var(--tl-rule);
   background: color-mix(in srgb, var(--surface) 34%, transparent);
+}
+
+/* The plan's load silhouette, at reading size, before the numbers. */
+.plan-editor-preview .tl-ridge {
+  height: 42px;
+  margin-top: 14px;
+  gap: 2px;
+}
+
+.plan-editor-preview .tl-ridge-bar {
+  flex-basis: 9px;
+  border-radius: 2px;
+}
+
+.plan-editor-preview-note {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 
 .plan-editor-sidebar h3,
@@ -2695,6 +3098,33 @@
   gap: 10px;
 }
 
+.plan-editor-section-title > div {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.plan-editor-section-title > div > span {
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+}
+
+.plan-editor-section-title .icon-button {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--glass-border);
+  background: var(--glass-bg);
+}
+
+.plan-editor-section-title .icon-button:hover:not(:disabled),
+.plan-editor-section-title .icon-button.is-active {
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--glass-border));
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+}
+
 .plan-editor-new-workout {
   display: flex;
   flex-direction: column;
@@ -2710,35 +3140,156 @@
   margin-top: 10px;
 }
 
+.plan-editor-library-search {
+  display: flex;
+  width: 100%;
+  min-height: 36px;
+  align-items: center;
+  gap: 7px;
+  margin-top: 12px;
+  padding: 0 8px 0 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  background: var(--glass-bg);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    color 160ms ease;
+}
+
+.plan-editor-sidebar .plan-editor-library-search input {
+  min-width: 0;
+  width: 100%;
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  color: var(--text-primary);
+  background: transparent;
+  font-size: 12.5px;
+  line-height: 1.4;
+  outline: 0;
+}
+
+.plan-editor-library-search input::placeholder {
+  color: color-mix(in srgb, var(--text-muted) 88%, transparent);
+}
+
+.plan-editor-library-search > button {
+  display: inline-flex;
+  width: 24px;
+  height: 24px;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.plan-editor-library-search > button:hover {
+  color: var(--text-primary);
+  background: var(--glass-bg-hover);
+}
+
+.plan-editor-library-search:focus-within {
+  border-color: color-mix(in srgb, var(--accent) 46%, transparent);
+  color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
 .plan-editor-library-list {
   display: flex;
   max-height: 240px;
   flex-direction: column;
-  margin-top: 10px;
+  gap: 2px;
+  margin-top: 8px;
+  padding: 4px;
+  border: 1px solid var(--tl-rule-soft);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface) 24%, transparent);
   overflow-y: auto;
+  scrollbar-color: var(--glass-border) transparent;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
 }
 
 .plan-editor-library-list button {
   display: flex;
+  width: 100%;
+  min-height: 48px;
   align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  padding: 9px 2px;
+  gap: 9px;
+  padding: 7px 8px;
   border: 0;
-  border-bottom: 1px solid var(--tl-rule-soft);
+  border-radius: var(--radius-sm);
   color: var(--text-secondary);
   background: none;
   text-align: left;
   cursor: pointer;
+  transition:
+    color 150ms ease,
+    background 150ms ease,
+    transform 120ms ease;
 }
 
 .plan-editor-library-list button:hover {
   color: var(--text-primary);
+  background: var(--tl-row-hover);
+}
+
+.plan-editor-library-list button:active {
+  transform: scale(0.99);
+}
+
+/* The row answers in the sport's own colour; the plus wakes on hover. */
+.plan-editor-library-list button[data-sport]::before {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--tl-sport, var(--accent));
+  content: "";
+}
+
+.plan-editor-library-list button[data-sport="run"] { --tl-sport: var(--sport-run); }
+.plan-editor-library-list button[data-sport="bike"] { --tl-sport: var(--sport-bike); }
+.plan-editor-library-list button[data-sport="strength"] { --tl-sport: var(--sport-strength); }
+.plan-editor-library-list button[data-sport="other"] { --tl-sport: var(--sport-other); }
+
+.plan-editor-library-list button > .plan-editor-library-add {
+  display: inline-flex;
+  width: 26px;
+  height: 26px;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  opacity: 0.72;
+  transition:
+    color 150ms ease,
+    background 150ms ease,
+    border-color 150ms ease,
+    opacity 150ms ease;
+}
+
+.plan-editor-library-list button:hover > .plan-editor-library-add {
+  border-color: color-mix(in srgb, var(--accent) 28%, transparent);
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+  opacity: 1;
 }
 
 .plan-editor-library-list span {
   display: flex;
   min-width: 0;
+  flex: 1;
   flex-direction: column;
 }
 
@@ -2751,8 +3302,15 @@
 }
 
 .plan-editor-library-list small {
+  margin-top: 2px;
   color: var(--text-muted);
   font-size: 10.5px;
+}
+
+.plan-editor-library-list > .plan-editor-empty-inline {
+  margin: 0;
+  padding: 18px 12px;
+  text-align: center;
 }
 
 .plan-editor-phases {
@@ -2797,6 +3355,16 @@
   border: 1px dashed var(--glass-border);
   border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--surface) 40%, transparent);
+  transition:
+    border-color 160ms ease,
+    background 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.plan-holding-area.is-drop-target {
+  border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 .plan-holding-area p {
@@ -2849,9 +3417,23 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* Week housekeeping stays out of the way until the week is reached. */
 .plan-week > header > div:last-child {
   display: flex;
   gap: 2px;
+  opacity: 0;
+  transition: opacity 140ms ease;
+}
+
+.plan-week:hover > header > div:last-child,
+.plan-week > header > div:last-child:focus-within {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  .plan-week > header > div:last-child {
+    opacity: 1;
+  }
 }
 
 .plan-week-days {
@@ -2863,6 +3445,16 @@
   min-height: 96px;
   padding: 9px;
   border-right: 1px solid var(--tl-rule-soft);
+  transition:
+    background 160ms ease,
+    box-shadow 160ms ease;
+}
+
+/* A dragged card lights the day it is over — the clearest answer to "where
+   will this land?" */
+.plan-day.is-drop-target {
+  background: color-mix(in srgb, var(--accent) 9%, transparent);
+  box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--accent) 55%, transparent);
 }
 
 .plan-day:last-child {
@@ -2917,6 +3509,17 @@
   gap: 5px;
 }
 
+/* An empty day draws its well so it reads as a place, not a gap. */
+.plan-day-entries:empty {
+  min-height: 34px;
+  border: 1px dashed var(--tl-rule-soft);
+  border-radius: var(--radius-sm);
+}
+
+.plan-day.is-drop-target .plan-day-entries:empty {
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+}
+
 .plan-entry-card {
   display: flex;
   align-items: center;
@@ -2955,6 +3558,22 @@
 .plan-entry-card.is-note:hover {
   transform: none;
 }
+
+/* Workout cards carry the sport's colour as a small dot; rest and notes
+   stay quiet. */
+.plan-entry-card[data-sport]::before {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--tl-sport, var(--accent));
+  content: "";
+}
+
+.plan-entry-card[data-sport="run"] { --tl-sport: var(--sport-run); }
+.plan-entry-card[data-sport="bike"] { --tl-sport: var(--sport-bike); }
+.plan-entry-card[data-sport="strength"] { --tl-sport: var(--sport-strength); }
+.plan-entry-card[data-sport="other"] { --tl-sport: var(--sport-other); }
 
 .plan-entry-card > span {
   display: flex;
@@ -3308,15 +3927,20 @@
   }
 
   /* The workout reader changes content without a route change; ease the swap. */
-  .tl-reader > * {
+  .tl-reader-scroll > * {
     animation: tl-settle 320ms cubic-bezier(0.2, 0.8, 0.25, 1) backwards;
   }
 
-  .tl-reader > *:nth-child(2) { animation-delay: 45ms; }
-  .tl-reader > *:nth-child(3) { animation-delay: 90ms; }
-  .tl-reader > *:nth-child(4) { animation-delay: 135ms; }
-  .tl-reader > *:nth-child(5) { animation-delay: 180ms; }
-  .tl-reader > *:nth-child(n + 6) { animation-delay: 225ms; }
+  .tl-reader-scroll > *:nth-child(2) { animation-delay: 45ms; }
+  .tl-reader-scroll > *:nth-child(3) { animation-delay: 90ms; }
+  .tl-reader-scroll > *:nth-child(4) { animation-delay: 135ms; }
+  .tl-reader-scroll > *:nth-child(5) { animation-delay: 180ms; }
+  .tl-reader-scroll > *:nth-child(n + 6) { animation-delay: 225ms; }
+
+  /* The dock rises once to establish it as the reader's persistent command area. */
+  .tl-reader-dock {
+    animation: tl-reader-dock-in 420ms cubic-bezier(0.16, 1, 0.3, 1) 190ms backwards;
+  }
 }
 
 @keyframes tl-view-enter {
@@ -3350,6 +3974,17 @@
   }
 }
 
+@keyframes tl-reader-dock-in {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .training-library-view,
   .training-library-view *,
@@ -3370,7 +4005,7 @@
 
 @media (max-width: 1500px) {
   .tl-split {
-    grid-template-columns: minmax(0, 1fr) 330px;
+    grid-template-columns: minmax(0, 1fr) 340px;
   }
 }
 
@@ -3404,11 +4039,38 @@
   .tl-split,
   .tl-template-layout {
     grid-template-columns: minmax(0, 1fr);
+    align-content: start;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-color: var(--glass-border) transparent;
+    scrollbar-gutter: stable;
   }
 
   .tl-catalog {
+    display: block;
+    min-height: auto;
     border-right: 0;
     border-bottom: 1px solid var(--tl-rule);
+  }
+
+  .tl-reader,
+  .tl-template-layout > .tl-panel {
+    min-height: auto;
+    overflow: visible;
+  }
+
+  .tl-reader-scroll {
+    min-height: auto;
+    flex: none;
+    overflow: visible;
+  }
+
+  .tl-catalog > :is(.tl-grid, .tl-index),
+  .tl-template-layout > .tl-panel:not(.tl-collections) > :is(.tl-grid, .tl-index),
+  .tl-collections ul {
+    min-height: auto;
+    flex: none;
+    overflow: visible;
   }
 
   .tl-match-row {
@@ -3422,7 +4084,7 @@
 
 @media (max-width: 900px) {
   .training-library-view {
-    padding: 22px 16px 44px;
+    padding: 22px 16px 16px;
   }
 
   .tl-masthead {
@@ -3488,7 +4150,6 @@
     padding-left: 0;
   }
 
-  .plan-editor,
   .plan-compare {
     inset: 0;
     border-radius: 0;
@@ -3521,4 +4182,710 @@
   .plan-compare-grid {
     grid-template-columns: minmax(0, 1fr) !important;
   }
+}
+
+/* Guided Coach plan generation and owned-calendar previews share the library's
+   dense, review-first modal language. */
+.plan-generator-backdrop,
+.plan-calendar-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 120;
+  display: grid;
+  padding: 20px;
+  background: color-mix(in srgb, var(--bg-base) 78%, transparent);
+  backdrop-filter: blur(10px);
+  place-items: center;
+  animation: tl-fade-in 180ms ease both;
+}
+
+.plan-generator,
+.plan-calendar-dialog {
+  display: flex;
+  width: min(1080px, 100%);
+  max-height: calc(100dvh - 40px);
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  color: var(--text-primary);
+  background:
+    radial-gradient(760px 240px at 12% 0%, var(--bg-ambient-green), transparent 62%),
+    var(--tl-reader-bg, var(--bg-base));
+  box-shadow: var(--shadow-elevated), var(--glass-inset);
+  animation: tl-dialog-in 240ms var(--tl-ease-out) both;
+}
+
+.plan-calendar-dialog {
+  width: min(680px, 100%);
+}
+
+.plan-generator > header,
+.plan-calendar-dialog > header {
+  display: flex;
+  flex: none;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 22px 24px 18px;
+  border-bottom: 1px solid var(--tl-rule);
+}
+
+.plan-generator > header h2,
+.plan-calendar-dialog > header h2 {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 2px 0 0;
+  font-family: var(--font-display);
+  font-size: 21px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.plan-generator-title-icon {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  flex: none;
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-radius: 9px;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  place-items: center;
+}
+
+.plan-generator > header p:last-child,
+.plan-calendar-dialog > header p:last-child {
+  max-width: 680px;
+  margin: 7px 0 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.plan-generator-body {
+  display: grid;
+  min-height: 0;
+  flex: 1;
+  grid-template-columns: minmax(0, 1fr) 286px;
+  overflow: hidden;
+}
+
+.plan-generator-form {
+  min-width: 0;
+  padding: 22px 24px 28px;
+  overflow-y: auto;
+}
+
+.plan-generator-form label,
+.plan-calendar-start label {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.plan-generator-form label > span:first-child,
+.plan-calendar-start label > span:first-child,
+.plan-generator-form legend {
+  color: var(--text-secondary);
+  letter-spacing: 0.025em;
+}
+
+.plan-generator-form :is(input, select, textarea),
+.plan-calendar-start input {
+  width: 100%;
+  min-height: 36px;
+  padding: 8px 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  background: var(--glass-bg);
+  outline: none;
+}
+
+.plan-generator-form textarea {
+  min-height: 76px;
+  resize: vertical;
+}
+
+.plan-generator-goal input {
+  min-height: 43px;
+  font-size: 14px;
+}
+
+.plan-generator-form fieldset {
+  margin: 20px 0 0;
+  padding: 0;
+  border: 0;
+}
+
+.plan-generator-form legend {
+  margin-bottom: 8px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.plan-generator-sports,
+.plan-generator-days {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.plan-generator-sports button,
+.plan-generator-days button {
+  display: inline-flex;
+  min-height: 30px;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
+  border: 1px solid var(--tl-rule);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  background: var(--glass-bg);
+  font-size: 11px;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease, transform 120ms ease;
+}
+
+.plan-generator-sports button svg { flex: none; opacity: 0.72; }
+
+.plan-generator-sports button:hover:not(:disabled):not(.is-selected),
+.plan-generator-days button:hover:not(:disabled):not(.is-selected) {
+  border-color: var(--glass-border);
+  color: var(--text-primary);
+  background: var(--glass-bg-hover);
+}
+
+.plan-generator-sports button:active:not(:disabled),
+.plan-generator-days button:active:not(:disabled) { transform: translateY(0.5px); }
+
+.plan-generator-form button:disabled { cursor: default; opacity: 0.5; }
+
+.plan-generator-sports button:focus-visible,
+.plan-generator-days button:focus-visible,
+.plan-generator-segmented button:focus-visible,
+.plan-generator-stepper button:focus-visible,
+.plan-generator-examples button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 1px;
+}
+
+.plan-generator-inline-error {
+  margin: 7px 0 0;
+  color: var(--warning-text);
+  font-size: 10.5px;
+}
+
+.plan-generator-sports button.is-selected {
+  border-color: color-mix(in srgb, var(--sport-accent, var(--accent)) 52%, transparent);
+  color: var(--sport-accent, var(--accent));
+  background: color-mix(in srgb, var(--sport-accent, var(--accent)) 12%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sport-accent, var(--accent)) 18%, transparent);
+  font-weight: 600;
+}
+
+.plan-generator-sports button.is-selected svg { opacity: 1; }
+
+.plan-generator-days button.is-selected {
+  border-color: color-mix(in srgb, var(--accent) 46%, transparent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  font-weight: 600;
+}
+
+.plan-generator-days button {
+  min-width: 44px;
+  justify-content: center;
+  padding: 0;
+}
+
+.plan-generator-grid {
+  display: grid;
+  margin-top: 20px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.plan-generator-grid.is-bottom {
+  grid-template-columns: 180px minmax(0, 1fr);
+}
+
+.plan-generator-date,
+.plan-generator-duration {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--glass-bg);
+}
+
+.plan-generator-date {
+  padding-left: 9px;
+}
+
+.plan-generator-date input,
+.plan-generator-duration input {
+  border: 0;
+  background: transparent;
+}
+
+.plan-generator-duration em {
+  padding-right: 9px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-style: normal;
+}
+
+.plan-generator-form small {
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: 400;
+}
+
+.plan-generator-examples {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.plan-generator-examples > span {
+  color: var(--text-muted);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.plan-generator-examples button {
+  padding: 4px 10px;
+  border: 1px dashed var(--tl-rule);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  background: transparent;
+  font-size: 10.5px;
+  cursor: pointer;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+.plan-generator-examples button:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
+}
+
+.plan-generator-segmented {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.plan-generator-segmented button {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 8px 10px;
+  border: 1px solid var(--tl-rule);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  background: var(--glass-bg);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 120ms ease, color 120ms ease, background 120ms ease;
+}
+
+.plan-generator-segmented button strong { color: inherit; font-size: 11px; font-weight: 600; }
+.plan-generator-segmented button small { font-size: 9px; color: var(--text-muted); line-height: 1.3; }
+
+.plan-generator-segmented button:hover:not(:disabled):not(.is-selected) {
+  border-color: var(--glass-border);
+  color: var(--text-primary);
+  background: var(--glass-bg-hover);
+}
+
+.plan-generator-segmented button.is-selected {
+  border-color: color-mix(in srgb, var(--accent) 46%, transparent);
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.plan-generator-segmented button.is-selected small { color: color-mix(in srgb, var(--accent) 68%, var(--text-muted)); }
+
+.plan-generator-stepper {
+  display: flex;
+  width: 100%;
+  min-height: 36px;
+  align-items: stretch;
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--glass-bg);
+}
+
+.plan-generator-stepper button {
+  display: grid;
+  width: 34px;
+  flex: none;
+  border: 0;
+  color: var(--text-secondary);
+  background: transparent;
+  cursor: pointer;
+  place-items: center;
+  transition: color 120ms ease, background 120ms ease;
+}
+
+.plan-generator-stepper button:first-child { border-right: 1px solid var(--tl-rule-soft); }
+.plan-generator-stepper button:last-child { border-left: 1px solid var(--tl-rule-soft); }
+
+.plan-generator-stepper button:hover:not(:disabled) {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+
+.plan-generator-stepper button:disabled { cursor: default; opacity: 0.4; }
+
+.plan-generator-stepper strong {
+  display: grid;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.plan-generator-status {
+  padding: 22px;
+  border-left: 1px solid var(--tl-rule);
+  background: color-mix(in srgb, var(--surface) 68%, transparent);
+  overflow-y: auto;
+}
+
+.plan-generator-provider {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-top: 8px;
+  padding: 10px 11px;
+  border: 1px solid var(--tl-rule);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  background: var(--glass-bg);
+}
+
+.plan-generator-provider-icon {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  flex: none;
+  border-radius: 8px;
+  background: color-mix(in srgb, currentColor 13%, transparent);
+  place-items: center;
+}
+
+.plan-generator-aside-eyebrow { margin-top: 20px; }
+
+.plan-generator-snapshot {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  margin: 8px 0 0;
+  padding: 11px 12px;
+  border: 1px solid var(--tl-rule);
+  border-radius: var(--radius-sm);
+  background: var(--glass-bg);
+  list-style: none;
+}
+
+.plan-generator-snapshot li {
+  display: flex;
+  min-height: 18px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.plan-generator-snapshot li > span:first-child { flex: none; color: var(--text-muted); font-size: 10px; }
+
+.plan-generator-snapshot strong {
+  overflow: hidden;
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  text-align: right;
+  text-overflow: ellipsis;
+}
+
+.plan-generator-snapshot-sports { display: flex; flex-wrap: wrap; gap: 4px; justify-content: flex-end; }
+
+.plan-generator-snapshot-sport {
+  display: grid;
+  width: 20px;
+  height: 20px;
+  border-radius: 6px;
+  color: var(--sport-accent, var(--accent));
+  background: color-mix(in srgb, var(--sport-accent, var(--accent)) 13%, transparent);
+  place-items: center;
+}
+
+.plan-generator-provider.is-ready { color: var(--accent); }
+.plan-generator-provider.is-blocked { color: var(--warning-text); }
+.plan-generator-provider span { display: flex; min-width: 0; flex-direction: column; gap: 3px; }
+.plan-generator-provider strong { color: var(--text-primary); font-size: 11.5px; }
+.plan-generator-provider small { color: var(--text-secondary); font-size: 10px; line-height: 1.4; }
+.plan-generator-status > .ghost-button { width: 100%; margin-top: 9px; }
+
+.plan-generator-progress,
+.plan-generator-failure,
+.plan-generator-privacy {
+  margin-top: 22px;
+  padding-top: 20px;
+  border-top: 1px solid var(--tl-rule);
+}
+
+.plan-generator-progress {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  text-align: center;
+}
+
+.plan-generator-pulse {
+  display: grid;
+  width: 46px;
+  height: 46px;
+  margin-bottom: 11px;
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  border-radius: 50%;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 9%, transparent);
+  place-items: center;
+  animation: plan-generator-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes plan-generator-pulse {
+  50% { box-shadow: 0 0 0 8px color-mix(in srgb, var(--accent) 0%, transparent); transform: scale(1.04); }
+}
+
+.plan-generator-stages {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 7px;
+  margin: 14px 0 0;
+  padding: 13px 2px 0;
+  border-top: 1px solid var(--tl-rule-soft);
+  list-style: none;
+  text-align: left;
+}
+
+.plan-generator-stages li { display: flex; align-items: center; gap: 8px; color: var(--text-muted); font-size: 10.5px; }
+.plan-generator-stages li.is-active { color: var(--text-primary); font-weight: 600; }
+.plan-generator-stages li.is-done { color: var(--accent); }
+
+.plan-generator-stage-dot {
+  display: grid;
+  width: 15px;
+  height: 15px;
+  flex: none;
+  border: 1px solid var(--tl-rule);
+  border-radius: 50%;
+  place-items: center;
+}
+
+.plan-generator-stages li.is-active .plan-generator-stage-dot { border-color: color-mix(in srgb, var(--accent) 55%, transparent); }
+
+.plan-generator-stages li.is-active .plan-generator-stage-dot::after {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--accent);
+  content: "";
+  animation: plan-generator-stage-blink 1.1s ease-in-out infinite;
+}
+
+.plan-generator-stages li.is-done .plan-generator-stage-dot {
+  border-color: color-mix(in srgb, var(--accent) 55%, transparent);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+@keyframes plan-generator-stage-blink {
+  50% { opacity: 0.35; }
+}
+
+.plan-generator-progress strong,
+.plan-generator-failure strong,
+.plan-generator-privacy strong { font-size: 12px; }
+.plan-generator-progress p,
+.plan-generator-failure p,
+.plan-generator-privacy p { margin: 5px 0 0; color: var(--text-secondary); font-size: 10.5px; line-height: 1.5; }
+.plan-generator-progress .ghost-button { margin-top: 12px; }
+.plan-generator-failure > svg { color: var(--warning-text); }
+.plan-generator-failure > div { display: flex; flex-direction: column; gap: 7px; margin-top: 11px; }
+
+.plan-generator > footer,
+.plan-calendar-dialog > footer {
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 13px 24px;
+  border-top: 1px solid var(--tl-rule);
+  background: color-mix(in srgb, var(--surface) 76%, transparent);
+}
+
+.plan-generator-footer-hint {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 auto 0 0;
+  color: var(--text-muted);
+  font-size: 10.5px;
+}
+
+.plan-generator-footer-hint svg { flex: none; color: var(--accent); }
+
+.plan-calendar-start,
+.plan-calendar-loading,
+.plan-calendar-offline,
+.plan-calendar-error {
+  margin: 24px;
+}
+
+.plan-calendar-start {
+  display: grid;
+  align-items: end;
+  grid-template-columns: 190px minmax(0, 1fr) auto;
+  gap: 15px;
+}
+
+.plan-calendar-start p,
+.plan-calendar-loading p,
+.plan-calendar-offline p,
+.plan-calendar-error p,
+.plan-calendar-safety {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.plan-calendar-loading {
+  display: flex;
+  min-height: 170px;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 7px;
+  color: var(--accent);
+  text-align: center;
+}
+
+.plan-calendar-loading strong { color: var(--text-primary); font-size: 13px; }
+.plan-calendar-offline,
+.plan-calendar-error { display: flex; align-items: flex-start; gap: 10px; padding: 14px; border: 1px solid var(--warning-border); border-radius: var(--radius-sm); color: var(--warning-text); background: var(--warning-bg); }
+.plan-calendar-offline strong,
+.plan-calendar-error strong { color: var(--text-primary); font-size: 12px; }
+.plan-calendar-error .ghost-button { flex: none; margin-left: auto; }
+
+.plan-calendar-preview {
+  min-height: 0;
+  padding: 22px 24px;
+  overflow-y: auto;
+}
+
+.plan-calendar-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border-block: 1px solid var(--tl-rule);
+}
+
+.plan-calendar-summary > span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px;
+  border-left: 1px solid var(--tl-rule);
+}
+
+.plan-calendar-summary > span:first-child { border-left: 0; }
+.plan-calendar-summary strong { overflow: hidden; font-size: 14px; text-overflow: ellipsis; white-space: nowrap; }
+.plan-calendar-summary small { color: var(--text-muted); font-size: 9.5px; }
+.plan-calendar-summary .has-conflict strong { color: var(--warning-text); }
+
+.plan-calendar-blockers {
+  margin-top: 15px;
+  padding: 12px;
+  border: 1px solid var(--warning-border);
+  border-radius: var(--radius-sm);
+  background: var(--warning-bg);
+}
+
+.plan-calendar-blockers strong { display: flex; align-items: center; gap: 7px; color: var(--warning-text); font-size: 11px; }
+.plan-calendar-blockers p { margin: 6px 0 0; color: var(--text-secondary); font-size: 10.5px; }
+.plan-calendar-dates { margin-top: 16px; border-top: 1px solid var(--tl-rule); }
+.plan-calendar-dates article { display: grid; align-items: start; grid-template-columns: 110px minmax(0, 1fr); gap: 12px; padding: 11px 4px; border-bottom: 1px solid var(--tl-rule-soft); }
+.plan-calendar-dates time { color: var(--text-secondary); font-size: 10.5px; font-variant-numeric: tabular-nums; }
+.plan-calendar-dates article > div { display: flex; min-width: 0; flex-direction: column; gap: 3px; }
+.plan-calendar-dates strong { overflow: hidden; font-size: 11.5px; text-overflow: ellipsis; white-space: nowrap; }
+.plan-calendar-dates small { display: flex; align-items: center; gap: 4px; color: var(--text-muted); font-size: 9.5px; }
+.plan-calendar-safety { margin-top: 14px; padding-left: 10px; border-left: 2px solid var(--accent); }
+
+.plan-entry-card .plan-entry-actions {
+  display: inline-flex;
+  flex: none;
+  flex-direction: row;
+  gap: 2px;
+}
+
+.plan-entry-card .plan-entry-actions button {
+  width: 22px;
+  height: 22px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border-radius: 4px;
+}
+
+.plan-entry-card .plan-entry-actions button:hover { color: var(--text-primary); background: var(--glass-bg-hover); }
+.plan-editor-workout-error { position: fixed; right: 22px; bottom: 22px; z-index: 95; display: flex; align-items: center; gap: 8px; max-width: 420px; padding: 10px 12px; border: 1px solid color-mix(in srgb, var(--danger, #e5484d) 36%, transparent); border-radius: var(--radius-sm); color: var(--danger, #e5484d); background: var(--surface); box-shadow: var(--shadow-elevated); font-size: 11px; }
+.plan-editor-workout-error button { display: inline-flex; margin-left: auto; border: 0; color: inherit; background: none; cursor: pointer; }
+
+@media (max-width: 840px) {
+  .plan-generator-body { display: block; overflow-y: auto; }
+  .plan-generator-form { overflow: visible; }
+  .plan-generator-status { border-top: 1px solid var(--tl-rule); border-left: 0; overflow: visible; }
+  .plan-generator-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .plan-calendar-start { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 560px) {
+  .plan-generator-backdrop,
+  .plan-calendar-backdrop { padding: 0; }
+  .plan-generator,
+  .plan-calendar-dialog { width: 100%; max-height: 100dvh; border-radius: 0; }
+  .plan-generator-grid,
+  .plan-generator-grid.is-bottom { grid-template-columns: 1fr; }
+  .plan-generator-segmented { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .plan-calendar-summary { grid-template-columns: 1fr; }
+  .plan-calendar-summary > span { border-top: 1px solid var(--tl-rule); border-left: 0; }
+  .plan-calendar-summary > span:first-child { border-top: 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .plan-generator-pulse { animation: none; }
+  .plan-generator-stages li.is-active .plan-generator-stage-dot::after { animation: none; }
 }


### PR DESCRIPTION
## Summary

- add guided AI Training Plan generation in the Training Library using the configured Coach provider
- let Coach AI plans open as editable, unsaved library plans while preserving the existing direct calendar action
- add plan-local structured workout editing plus safe calendar install/removal with exact occurrence ownership
- integrate the existing Hevy strength sync, session merge, exercise explorer, and analytics work
- add clickable Coach clarification prompts with persisted answers and display-safe reasoning summaries
- make oversized activity reads paginate through COROS's 100-item limit instead of surfacing `Parameter input error` during adherence refreshes
- remove the Training Library native-COROS read-only notice

## Impact

Coach can now pause for a structured athlete decision and resume with that answer in context. Training Library adherence refreshes retain the requested activity range without sending an invalid 500-item page to COROS.

## Root cause

`trainingLibrary:refreshMatches` requested 500 activities in one `/activity/query` call, while COROS accepts activity pages of at most 100. The shared activity reader now translates larger logical pages into valid 100-item remote requests without truncating results.

## Verification

- `npm run build:renderer`
- `npm run test:training-library`
- `node scripts/test-chat-service.mjs`
- `node scripts/test-chat-history-store.mjs`
- `node scripts/test-training-hub-write.mjs`
- `npm run test:chat-workout-tools`
- `npm run test:strength-analytics`
- `npm run test:hevy-strength`
- `npm run test:hevy-service`
- `git diff --check`

No automated live COROS writes were performed.
