### PR TITLE
Add gear management and refresh training UI

### DIFF
--- a/electron/corosWatchfaceService.ts
+++ b/electron/corosWatchfaceService.ts
@@ -43,6 +43,11 @@ import type {
   CorosBatteryUsageDetail,
   CorosBatteryUsageGroup,
   CorosBatteryDay,
+  CorosGear,
+  CorosGearCatalog,
+  CorosGearSaveInput,
+  CorosGearSupportedInfo,
+  CorosGearType,
   CorosPairedDevice,
   WatchModelId
 } from "./types";
@@ -802,6 +807,35 @@ export async function listCorosPairedDevices(): Promise<CorosPairedDevice[]> {
     body: JSON.stringify({ clientType: 1 })
   });
   return normalizeCorosPairedDevices(response.data);
+}
+
+/** Lists activity gear from the authenticated COROS mobile account. */
+export async function queryCorosGear(): Promise<CorosGearCatalog> {
+  const session = requireSession();
+  const response = await mobileRequest<unknown>("/user/gear/query", {
+    method: "GET",
+    accessToken: session.accessToken,
+    userId: session.userId,
+    extraHeaders: { "Content-Type": "application/json" }
+  });
+  return normalizeCorosGearCatalog(response.data);
+}
+
+/**
+ * Adds gear through the mobile endpoint, then mirrors the Android client's
+ * follow-up query so the renderer receives the server-assigned gear ID.
+ */
+export async function saveCorosGear(
+  input: CorosGearSaveInput
+): Promise<CorosGearCatalog> {
+  const session = requireSession();
+  await mobileRequest<unknown>("/user/gear/save", {
+    method: "POST",
+    accessToken: session.accessToken,
+    userId: session.userId,
+    body: buildCorosGearSaveBody(input)
+  });
+  return queryCorosGear();
 }
 
 /**
@@ -2591,7 +2625,7 @@ export function extractDecimalProperty(raw: string, property: string): string | 
  */
 export function parseCorosMobileJson(raw: string): unknown {
   const losslessRaw = raw.replace(
-    /("(?:watchFaceThemeId|watchFaceTemplateId|srcWatchFaceTemplateId|watchfaceId)"\s*:\s*)(\d{16,})(?=\s*[,}])/g,
+    /("(?:watchFaceThemeId|watchFaceTemplateId|srcWatchFaceTemplateId|watchfaceId|gearId|userId)"\s*:\s*)(\d{16,})(?=\s*[,}])/g,
     (_match, prefix: string, value: string) => `${prefix}"${value}"`
   );
   return JSON.parse(losslessRaw) as unknown;
@@ -2754,6 +2788,193 @@ export function normalizeCorosPairedDevices(data: unknown): CorosPairedDevice[] 
     devices.push(pairedDevice);
   }
   return devices;
+}
+
+export function normalizeCorosGearCatalog(data: unknown): CorosGearCatalog {
+  const record = asRecord(data);
+  if (!record) {
+    return { gear: [], supportedInfo: [] };
+  }
+
+  const gearInfos = Array.isArray(record.gearInfos) ? record.gearInfos : [];
+  const gear = gearInfos.flatMap((info): CorosGear[] => {
+    const group = asRecord(info);
+    if (!group || !Array.isArray(group.gearList)) {
+      return [];
+    }
+    return group.gearList.flatMap((entry) => normalizeCorosGear(entry));
+  });
+  const supportedInfo = Array.isArray(record.supportedInfoList)
+    ? record.supportedInfoList.flatMap(
+        (entry): CorosGearSupportedInfo[] => normalizeCorosGearSupportedInfo(entry)
+      )
+    : [];
+
+  return { gear, supportedInfo };
+}
+
+export function buildCorosGearSaveBody(input: CorosGearSaveInput): string {
+  const brandName = typeof input?.brandName === "string" ? input.brandName.trim() : "";
+  if (
+    !brandName ||
+    brandName.length > 80 ||
+    /[\u0000-\u001f\u007f]/.test(brandName)
+  ) {
+    throw new Error("Enter a gear name between 1 and 80 characters.");
+  }
+  const type = normalizeCorosGearType(input?.type);
+  if (!type) {
+    throw new Error("Choose a supported COROS gear type.");
+  }
+  const dayMatch = input?.firstUseDay?.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!dayMatch || !isCalendarDay(input.firstUseDay)) {
+    throw new Error("Choose a valid first-use date.");
+  }
+  const initialDistance = normalizeGearDistance(
+    input.initialDistanceMeters,
+    "Initial distance",
+    true
+  );
+  const lifeDistance = normalizeGearDistance(
+    input.lifeDistanceMeters,
+    "Lifespan distance",
+    false
+  );
+  if (initialDistance > lifeDistance) {
+    throw new Error("Initial distance cannot exceed the lifespan distance.");
+  }
+  const sportTypeList = Array.from(
+    new Set(
+      Array.isArray(input.sportTypeList)
+        ? input.sportTypeList.filter(
+            (value) =>
+              Number.isSafeInteger(value) && value > 0 && value <= 65_535
+          )
+        : []
+    )
+  );
+  if (sportTypeList.length === 0 || sportTypeList.length > 20) {
+    throw new Error("Choose between 1 and 20 activities for this gear.");
+  }
+
+  return JSON.stringify({
+    gearList: [
+      {
+        additional: { sportTypeList },
+        brandName,
+        clientGearUniqId: Date.now(),
+        firstUseDay: Number(`${dayMatch[1]}${dayMatch[2]}${dayMatch[3]}`),
+        initDistance: initialDistance,
+        lifeDistance,
+        notifyFlag: input.notify ? 1 : 0,
+        type
+      }
+    ]
+  });
+}
+
+function normalizeCorosGear(value: unknown): CorosGear[] {
+  const record = asRecord(value);
+  if (!record) {
+    return [];
+  }
+  const gearId = readString(record, ["gearId"]);
+  const type = normalizeCorosGearType(readInteger(record, ["type"]));
+  const firstUseDay = formatCorosDay(record.firstUseDay);
+  if (!gearId || !type || !firstUseDay) {
+    return [];
+  }
+  const additional = asRecord(record.additional);
+  const sportTypeList = normalizeSportTypeList(additional?.sportTypeList);
+  const brandName =
+    readString(record, ["brandName", "displayName", "name"]) ?? "Unnamed gear";
+  const name =
+    readString(record, ["displayName", "brandName", "name"]) ?? brandName;
+  const initialDistanceMeters = readFiniteNumber(record, ["initDistance"]) ?? 0;
+  const lifeDistanceMeters = readFiniteNumber(record, ["lifeDistance"]) ?? 0;
+  const realDistanceMeters = readFiniteNumber(record, ["realDistance"]) ?? 0;
+  const notifyFlag = readInteger(record, ["notifyFlag"]);
+  const status = readInteger(record, ["status"]);
+  const usageStatus = readInteger(record, ["usageStatus"]);
+  const created = readFiniteNumber(record, ["createTime"]);
+  const updated = readFiniteNumber(record, ["updateTime"]);
+  const clientGearUniqId = readString(record, ["clientGearUniqId"]);
+
+  return [
+    {
+      gearId,
+      ...(clientGearUniqId ? { clientGearUniqId } : {}),
+      name,
+      brandName,
+      type,
+      sportTypeList,
+      firstUseDay,
+      initialDistanceMeters,
+      lifeDistanceMeters,
+      realDistanceMeters,
+      notify: notifyFlag === 1,
+      ...(status !== undefined ? { status } : {}),
+      ...(usageStatus !== undefined ? { usageStatus } : {}),
+      ...(created !== undefined ? { createdAt: toIsoTimestamp(created) } : {}),
+      ...(updated !== undefined ? { updatedAt: toIsoTimestamp(updated) } : {})
+    }
+  ];
+}
+
+function normalizeCorosGearSupportedInfo(
+  value: unknown
+): CorosGearSupportedInfo[] {
+  const record = asRecord(value);
+  const type = record && normalizeCorosGearType(readInteger(record, ["type"]));
+  if (!record || !type) {
+    return [];
+  }
+  return [{ type, sportTypeList: normalizeSportTypeList(record.sportTypeList) }];
+}
+
+function normalizeCorosGearType(value: unknown): CorosGearType | undefined {
+  return value === 1 || value === 2 ? value : undefined;
+}
+
+function normalizeSportTypeList(value: unknown): number[] {
+  return Array.isArray(value)
+    ? Array.from(
+        new Set(
+          value.filter(
+            (entry): entry is number =>
+              Number.isSafeInteger(entry) && entry > 0 && entry <= 65_535
+          )
+        )
+      )
+    : [];
+}
+
+function normalizeGearDistance(
+  value: unknown,
+  label: string,
+  allowZero: boolean
+): number {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    value < (allowZero ? 0 : 1) ||
+    value > 10_000_000
+  ) {
+    throw new Error(
+      `${label} must be ${allowZero ? "between 0 and" : "greater than 0 and at most"} 10,000 km.`
+    );
+  }
+  return Math.round(value);
+}
+
+function isCalendarDay(value: string): boolean {
+  const [year, month, day] = value.split("-").map(Number);
+  const date = new Date(Date.UTC(year!, month! - 1, day));
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month! - 1 &&
+    date.getUTCDate() === day
+  );
 }
 
 function normalizeCorosBatteryDay(value: unknown): CorosBatteryDay[] {
@@ -3715,8 +3936,8 @@ function detectWatchfaceResolutionProfile(
 async function mobileRequest<T>(
   endpoint: string,
   options: {
-    method: "POST";
-    body: string | FormData;
+    method: "GET" | "POST";
+    body?: string | FormData;
     accessToken?: string;
     includeAccessTokenInQuery?: boolean;
     userId?: string;
@@ -3740,18 +3961,18 @@ async function mobileRequest<T>(
   const response = await fetch(`${baseUrl}${endpoint}${query}`, {
     method: options.method,
     headers,
-    body: options.body
+    ...(options.body !== undefined ? { body: options.body } : {})
   });
   const raw = await response.text();
   if (!response.ok) {
-    throw new Error(`COROS watchface request failed (HTTP ${response.status}).`);
+    throw new Error(`COROS mobile request failed (HTTP ${response.status}).`);
   }
 
   let payload: MobileApiEnvelope<T>;
   try {
     payload = parseCorosMobileJson(raw) as MobileApiEnvelope<T>;
   } catch {
-    throw new Error("COROS returned an unreadable watchface response.");
+    throw new Error("COROS returned an unreadable mobile API response.");
   }
   const result = mobileApiResult(payload);
   if (result !== API_SUCCESS && !options.allowedResultCodes?.includes(result)) {
@@ -3759,7 +3980,7 @@ async function mobileRequest<T>(
       logoutCorosWatchfaces();
       throw new Error("Your COROS mobile session expired. Sign in again.");
     }
-    throw new Error(payload.message?.trim() || "COROS rejected the watchface request.");
+    throw new Error(payload.message?.trim() || "COROS rejected the mobile request.");
   }
   return { ...payload, raw };
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -127,6 +127,8 @@ import {
   logoutCorosWatchfaces,
   listCorosWatchfaceProjects,
   publishCorosWatchface,
+  queryCorosGear,
+  saveCorosGear,
   saveCorosWatchfaceProject,
   deleteCorosWatchfaceProject,
   selectCorosWatchfaceArchive
@@ -215,6 +217,7 @@ import type {
   CorosWatchfaceThemeDownloadInput,
   CorosWatchfaceThemeListInput,
   CorosBatteryQueryInput,
+  CorosGearSaveInput,
   CorosBluetoothDeviceChoice,
   WatchTransferProgress
 } from "./types";
@@ -865,6 +868,14 @@ function registerIpcHandlers(): void {
     "watchfaces:getBatteryReport",
     (_event, input: CorosBatteryQueryInput) => getCorosBatteryReport(input)
   );
+
+  if (!app.isPackaged) {
+    ipcMain.handle("gear:query", () => queryCorosGear());
+    ipcMain.handle(
+      "gear:save",
+      (_event, input: CorosGearSaveInput) => saveCorosGear(input)
+    );
+  }
 
   ipcMain.handle(
     "watchfaces:listThemes",

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -146,6 +146,8 @@ import type {
   CorosWatchfaceThemeListInput,
   CorosBatteryQueryInput,
   CorosBatteryReport,
+  CorosGearCatalog,
+  CorosGearSaveInput,
   CorosPairedDevice,
   CorosBluetoothDeviceChoice,
   CommunityWatchface,
@@ -195,6 +197,10 @@ const api = {
   getCorosBatteryReport: (
     input: CorosBatteryQueryInput
   ): Promise<CorosBatteryReport> => ipcRenderer.invoke("watchfaces:getBatteryReport", input),
+  queryCorosGear: (): Promise<CorosGearCatalog> =>
+    ipcRenderer.invoke("gear:query"),
+  saveCorosGear: (input: CorosGearSaveInput): Promise<CorosGearCatalog> =>
+    ipcRenderer.invoke("gear:save", input),
   listCorosWatchfaceThemes: (
     input: CorosWatchfaceThemeListInput
   ): Promise<CorosWatchfaceTheme[]> => ipcRenderer.invoke("watchfaces:listThemes", input),

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -198,6 +198,55 @@ export interface CorosPairedDevice {
   profileVersion?: number;
 }
 
+/** Gear categories currently exposed by COROS's mobile API. */
+export type CorosGearType = 1 | 2;
+
+/** One piece of activity gear attached to the signed-in COROS account. */
+export interface CorosGear {
+  /** Decimal text because COROS gear IDs exceed Number.MAX_SAFE_INTEGER. */
+  gearId: string;
+  /** Client-generated decimal identifier used when the gear was created. */
+  clientGearUniqId?: string;
+  name: string;
+  brandName: string;
+  type: CorosGearType;
+  sportTypeList: number[];
+  /** Calendar day in YYYY-MM-DD form. */
+  firstUseDay: string;
+  /** All distance values are normalized to metres. */
+  initialDistanceMeters: number;
+  lifeDistanceMeters: number;
+  realDistanceMeters: number;
+  notify: boolean;
+  status?: number;
+  usageStatus?: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+/** Sport associations supported by COROS for a gear category. */
+export interface CorosGearSupportedInfo {
+  type: CorosGearType;
+  sportTypeList: number[];
+}
+
+export interface CorosGearCatalog {
+  gear: CorosGear[];
+  supportedInfo: CorosGearSupportedInfo[];
+}
+
+/** Values accepted when adding gear to a COROS account. */
+export interface CorosGearSaveInput {
+  brandName: string;
+  type: CorosGearType;
+  sportTypeList: number[];
+  /** Calendar day in YYYY-MM-DD form. */
+  firstUseDay: string;
+  initialDistanceMeters: number;
+  lifeDistanceMeters: number;
+  notify: boolean;
+}
+
 /** A nearby Bluetooth device exposed by Electron's Web Bluetooth chooser. */
 export interface CorosBluetoothDeviceChoice {
   deviceId: string;

--- a/scripts/test-coros-watchface-service.mjs
+++ b/scripts/test-coros-watchface-service.mjs
@@ -11,6 +11,7 @@ const distUrl = (file) =>
 
 const {
   applyCorosWatchfaceConfigOverrides,
+  buildCorosGearSaveBody,
   buildCreateLinkBody,
   buildMobileLoginRegion,
   createDuplicateProjectName,
@@ -20,6 +21,7 @@ const {
   finalizeCorosWatchfaceBarometerConfig,
   findHttpsUrlInJson,
   normalizeCorosBatteryReport,
+  normalizeCorosGearCatalog,
   normalizeCorosPairedDevices,
   normalizeCorosWatchfaceThemes,
   parseCorosMobileJson,
@@ -238,6 +240,85 @@ const configWithSynthesizedBattery = applyCorosWatchfaceConfigOverrides(
     control_battery_level_font: "13x19",
     control_battery_level_font_color: "0x12ABEF"
   }
+);
+
+const gearEnvelope = parseCorosMobileJson(
+  '{"data":{"gearInfos":[{"deletedList":[],"gearList":[{"additional":{"sportTypeList":[100]},"brandName":"adizero","clientGearUniqId":1785000000000,"createTime":1785437313,"displayName":"adizero","firstUseDay":20260730,"gearId":478900000000000001,"initDistance":0.0,"lifeDistance":700000.0,"notifyFlag":1,"realDistance":12500.0,"status":0,"type":1,"updateTime":1785437313,"usageStatus":0,"userId":478900000000000002}],"type":1}],"supportedInfoList":[{"sportTypeList":[100,101,102,103,104,900,105],"type":1},{"sportTypeList":[200,201,203,204,202,205],"type":2}]}}'
+);
+assert.equal(
+  gearEnvelope.data.gearInfos[0].gearList[0].gearId,
+  "478900000000000001",
+  "gear IDs larger than Number.MAX_SAFE_INTEGER must remain lossless"
+);
+assert.deepEqual(
+  normalizeCorosGearCatalog(gearEnvelope.data),
+  {
+    gear: [
+      {
+        gearId: "478900000000000001",
+        clientGearUniqId: "1785000000000",
+        name: "adizero",
+        brandName: "adizero",
+        type: 1,
+        sportTypeList: [100],
+        firstUseDay: "2026-07-30",
+        initialDistanceMeters: 0,
+        lifeDistanceMeters: 700000,
+        realDistanceMeters: 12500,
+        notify: true,
+        status: 0,
+        usageStatus: 0,
+        createdAt: "2026-07-30T18:48:33.000Z",
+        updatedAt: "2026-07-30T18:48:33.000Z"
+      }
+    ],
+    supportedInfo: [
+      { type: 1, sportTypeList: [100, 101, 102, 103, 104, 900, 105] },
+      { type: 2, sportTypeList: [200, 201, 203, 204, 202, 205] }
+    ]
+  },
+  "gear query responses should normalize into renderer-safe metres and dates"
+);
+const gearSaveBody = JSON.parse(
+  buildCorosGearSaveBody({
+    brandName: "Adizero",
+    type: 1,
+    sportTypeList: [100, 102, 100],
+    firstUseDay: "2026-07-30",
+    initialDistanceMeters: 0,
+    lifeDistanceMeters: 700000,
+    notify: true
+  })
+);
+assert.deepEqual(
+  {
+    ...gearSaveBody.gearList[0],
+    clientGearUniqId: "dynamic"
+  },
+  {
+    additional: { sportTypeList: [100, 102] },
+    brandName: "Adizero",
+    clientGearUniqId: "dynamic",
+    firstUseDay: 20260730,
+    initDistance: 0,
+    lifeDistance: 700000,
+    notifyFlag: 1,
+    type: 1
+  },
+  "gear save payloads should match the COROS Android request shape"
+);
+assert.throws(
+  () =>
+    buildCorosGearSaveBody({
+      brandName: "Future shoe",
+      type: 1,
+      sportTypeList: [],
+      firstUseDay: "2026-02-30",
+      initialDistanceMeters: 0,
+      lifeDistanceMeters: 700000,
+      notify: true
+    }),
+  /valid first-use date/
 );
 for (const expected of [
   "[battery_icon_pos]={20,30}",

--- a/scripts/test-strength-analytics.mjs
+++ b/scripts/test-strength-analytics.mjs
@@ -9,7 +9,11 @@ const load = async (...segments) => {
   return import(`${url.href}?cacheBust=${bust}`);
 };
 
-const { resolveExerciseTargets, MUSCLES } = await load("src", "strength", "muscles.ts");
+const { resolveCorosExerciseTargets, resolveExerciseTargets, MUSCLES } = await load(
+  "src",
+  "strength",
+  "muscles.ts"
+);
 const {
   buildStrengthAnalytics,
   estimateOneRepMax,
@@ -48,6 +52,12 @@ assert.ok(shareOf("Inverse Nordic Curl", "quads") === 1);
 // Body regions from unstructured sessions resolve too.
 assert.ok(shareOf("Legs & Hips", "quads") > 0);
 assert.ok(shareOf("Arms", "biceps") > 0 && shareOf("Arms", "triceps") > 0);
+
+// COROS S4208 means only "Full Body"; it cannot support specific attribution.
+const genericCorosTargets = resolveCorosExerciseTargets("S4208", "Full Body");
+assert.equal(genericCorosTargets.generic, true);
+assert.equal(genericCorosTargets.activations.length, 0);
+assert.equal(shareOf("Full Body", "quads"), 0);
 
 // Recovery work carries no training credit.
 for (const name of ["Quadriceps Stretch", "Foam Rolling Quads", "Warm Up", "Rest"]) {
@@ -126,6 +136,8 @@ const analytics = buildStrengthAnalytics(sessions, 90);
 
 assert.equal(analytics.summary.sessions, 2);
 assert.equal(analytics.summary.sets, 8);
+assert.equal(analytics.attributedSets, 8);
+assert.equal(analytics.genericSets, 0);
 
 // Volume load is Σ reps × weight across every set.
 const expectedVolume = 10 * 60 + 8 * 70 + 6 * 80 + 2 * 10 * 100 + 10 * 50 + 8 * 60;
@@ -157,6 +169,45 @@ const providerFallback = buildStrengthAnalytics(
 );
 assert.ok(providerFallback.muscleById.quads.sets > 0);
 assert.ok(providerFallback.muscleById.glutes.sets > 0);
+
+// A provider that explicitly supplies full-body metadata can still attribute it;
+// only COROS's S4208 placeholder is confidence-gated.
+const providerFullBody = buildStrengthAnalytics(
+  [
+    session("provider-full-body", now, [
+      {
+        ...exercise("Full Body", [{ reps: 10, weightKg: 20 }]),
+        primaryMuscleGroup: "full_body"
+      }
+    ])
+  ],
+  30
+);
+assert.equal(providerFullBody.genericSets, 0);
+assert.equal(providerFullBody.attributedSets, 1);
+assert.ok(providerFullBody.muscleById.quads.sets > 0);
+
+// Generic COROS sessions remain in workout totals without colouring the body.
+const genericCoros = buildStrengthAnalytics(
+  [
+    session("coros-generic", now, [
+      exercise("S4208", [
+        { reps: 12, weightKg: 0 },
+        { reps: 10, weightKg: 0 },
+        { reps: 8, weightKg: 0 }
+      ])
+    ])
+  ],
+  30
+);
+assert.equal(genericCoros.summary.sets, 3);
+assert.equal(genericCoros.genericSets, 3);
+assert.equal(genericCoros.attributedSets, 0);
+assert.equal(
+  genericCoros.muscles.reduce((sum, stat) => sum + stat.sets, 0),
+  0
+);
+assert.equal(genericCoros.muscleById.quads.lastTrained, undefined);
 
 // Credited sets never exceed the sets actually performed.
 const creditedSets = analytics.muscles.reduce((sum, stat) => sum + stat.sets, 0);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3180,6 +3180,9 @@ function MediaLibraryTab({
           pendingCount={pendingTransferCount}
           localCount={downloads.length}
           watchConnected={watchConnected}
+          syncing={
+            transferProgress != null || Boolean(busy?.startsWith("transfer"))
+          }
           localPanel={
             <LocalLibraryPanel
               downloads={downloads}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -152,6 +152,13 @@ const LazyTrainingHubView = lazy(() =>
     default: TrainingHubView,
   })),
 );
+const LazyGearView = IS_DEVELOPMENT_BUILD
+  ? lazy(() =>
+      import("./gear/GearView").then(({ GearView }) => ({
+        default: GearView,
+      })),
+    )
+  : null;
 const LazyTrainingLibraryView = lazy(() =>
   import("./training-library/TrainingLibraryView").then(({ TrainingLibraryView }) => ({
     default: TrainingLibraryView,
@@ -2128,6 +2135,20 @@ export default function App() {
     );
   }
 
+  function handleDevelopmentViewToggle() {
+    const nextVisible = !showDevelopmentTools;
+    setShowDevelopmentTools(nextVisible);
+    if (!nextVisible) {
+      if (activeView === "gear") {
+        setActiveView("overview");
+      }
+      if (startupView === "gear") {
+        setStartupView("overview");
+        saveStartupView("overview");
+      }
+    }
+  }
+
   const { toasts, dismissToast } = useToaster(
     message,
     error ?? watchStatus?.error ?? null,
@@ -2142,6 +2163,7 @@ export default function App() {
           <StartupViewMenu
             value={startupView}
             onChange={handleStartupViewChange}
+            showDevelopmentItems={showDevelopmentTools}
           />
           <ResourcesMenu />
           <AppUpdateControls
@@ -2163,7 +2185,7 @@ export default function App() {
                   ? "Switch to production view"
                   : "Switch to developer view"
               }
-              onClick={() => setShowDevelopmentTools((visible) => !visible)}
+              onClick={handleDevelopmentViewToggle}
             >
               {showDevelopmentTools ? "Dev view" : "Prod view"}
             </button>
@@ -2218,6 +2240,7 @@ export default function App() {
           activeView={activeView}
           onChange={setActiveView}
           coachBusy={coachBusy}
+          showDevelopmentItems={showDevelopmentTools}
           appLogo={appLogo}
           expanded={sidebarExpanded}
           onExpandedChange={setSidebarExpanded}
@@ -2411,6 +2434,14 @@ export default function App() {
                   onLoadDetail={handleTrainingHubActivityDetail}
                   onExportFile={handleTrainingHubExport}
                 />
+              </Suspense>
+            ) : null}
+            {IS_DEVELOPMENT_BUILD &&
+            showDevelopmentTools &&
+            LazyGearView &&
+            activeView === "gear" ? (
+              <Suspense fallback={<DeferredSurfaceFallback label="gear" />}>
+                <LazyGearView api={api} />
               </Suspense>
             ) : null}
             {activeView === "library" ? (

--- a/src/calendar/AddWorkoutModal.tsx
+++ b/src/calendar/AddWorkoutModal.tsx
@@ -35,6 +35,7 @@ import {
   type LucideIcon
 } from "lucide-react";
 import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { createPortal } from "react-dom";
 import type {
   ManualActivityInput,
   PlanWorkoutEntryInput,
@@ -50,6 +51,7 @@ import type {
   WorkoutSport
 } from "../../electron/types";
 import type { CorosLinkApi } from "../coroslink-api";
+import { SelectDropdown } from "../components/SelectDropdown";
 import { useUnitSystem } from "../units/UnitSystemProvider";
 import {
   displayDistanceToMeters,
@@ -916,8 +918,12 @@ function BuilderIntensityFields({ row, sport, context, exerciseOptions, exercise
   const intensityControls = <>
     <label className="calendar-builder-control">
       <span>Intensity</span>
-      <select value={row.intensityType} onChange={(event) => {
-        const intensityType = event.target.value as BuilderRow["intensityType"];
+      <SelectDropdown<BuilderRow["intensityType"]>
+        label="Intensity"
+        value={row.intensityType}
+        options={intensityTypes.map((type) => ({ value: type, label: formatIntensityType(type) }))}
+        portal
+        onChange={(intensityType) => {
         onChange({
           intensityType,
           intensityLow: intensityType === "heartRate" ? "135" : intensityType === "rpe" ? "5" : intensityType === "climbGrade" ? "0" : "80",
@@ -925,7 +931,7 @@ function BuilderIntensityFields({ row, sport, context, exerciseOptions, exercise
           intensityPreset: intensityType === "swimStroke" ? "freestyle" : intensityType === "weight" ? "bodyweight" : intensityType === "climbGrade" ? `relative:${sport === "bouldering" ? "vScale" : "yds"}` : "",
           intensityUnit: intensityType === "weight" ? (unitSystem === "imperial" ? "lb" : "kg") : intensityType === "speed" ? (unitSystem === "imperial" ? "mph" : "km/h") : sport === "run" || sport === "trailRun" || sport === "hyrox" ? "spm" : "rpm"
         });
-      }}>{intensityTypes.map((type) => <option key={type} value={type}>{formatIntensityType(type)}</option>)}</select>
+      }} />
     </label>
 
     {(row.intensityType === "pace" || row.intensityType === "effortPace") ? <label className="calendar-builder-control is-wide">
@@ -941,12 +947,39 @@ function BuilderIntensityFields({ row, sport, context, exerciseOptions, exercise
 
     {row.intensityType === "heartRatePercent" ? <label className="calendar-builder-control">
       <span>Heart-rate basis</span>
-      <select value={row.intensityBasis} onChange={(event) => onChange({ intensityBasis: event.target.value as WorkoutHeartRateBasis, intensityPreset: "" })}><option value="maxHr">% Max Heart Rate</option><option value="reserve">% Heart Rate Reserve</option><option value="lthr">% Lactate Threshold HR</option></select>
+      <SelectDropdown<WorkoutHeartRateBasis>
+        label="Heart-rate basis"
+        value={row.intensityBasis}
+        options={[
+          { value: "maxHr", label: "% Max Heart Rate" },
+          { value: "reserve", label: "% Heart Rate Reserve" },
+          { value: "lthr", label: "% Lactate Threshold HR" }
+        ]}
+        portal
+        onChange={(intensityBasis) => onChange({ intensityBasis, intensityPreset: "" })}
+      />
     </label> : null}
 
     {(percentType || (row.intensityType === "power" && sport !== "bike")) ? <label className="calendar-builder-control">
       <span>Zone</span>
-      <select value={row.intensityPreset || "custom"} onChange={(event) => onChange({ intensityPreset: event.target.value === "custom" ? "" : event.target.value })}><option value="custom">Custom range</option>{presets.map((zone) => { const configured = presetZoneKey ? context?.zones[presetZoneKey]?.find((candidate) => candidate.id === zone.id || candidate.key === zone.preset) : undefined; return <option key={zone.id} value={zone.preset}>{configured?.label ?? zone.label}{configured ? ` · ${configured.lowPercent}-${configured.highPercent}%` : ""}</option>; })}</select>
+      <SelectDropdown
+        label="Intensity zone"
+        value={row.intensityPreset || "custom"}
+        options={[
+          { value: "custom", label: "Custom range" },
+          ...presets.map((zone) => {
+            const configured = presetZoneKey
+              ? context?.zones[presetZoneKey]?.find((candidate) => candidate.id === zone.id || candidate.key === zone.preset)
+              : undefined;
+            return {
+              value: zone.preset,
+              label: `${configured?.label ?? zone.label}${configured ? ` · ${configured.lowPercent}-${configured.highPercent}%` : ""}`
+            };
+          })
+        ]}
+        portal
+        onChange={(intensityPreset) => onChange({ intensityPreset: intensityPreset === "custom" ? "" : intensityPreset })}
+      />
     </label> : null}
 
     {(numericRange || (percentType && !row.intensityPreset)) ? <>
@@ -955,20 +988,20 @@ function BuilderIntensityFields({ row, sport, context, exerciseOptions, exercise
     </> : null}
 
     {row.intensityType === "speed" ? <label className="calendar-builder-control"><span>Speed unit</span><span className="calendar-builder-readonly-value">{unitSystem === "imperial" ? "mph" : "km/h"}</span></label> : null}
-    {row.intensityType === "cadence" ? <label className="calendar-builder-control"><span>Cadence unit</span><select value={row.intensityUnit === "spm" ? "spm" : "rpm"} onChange={(event) => onChange({ intensityUnit: event.target.value as BuilderRow["intensityUnit"] })}><option value="spm">steps/min</option><option value="rpm">revs/min</option></select></label> : null}
-    {row.intensityType === "swimStroke" ? <label className="calendar-builder-control"><span>Stroke</span><select value={row.intensityPreset || "freestyle"} onChange={(event) => onChange({ intensityPreset: event.target.value })}>{Object.keys(SWIM_STROKE_IDS).map((stroke) => <option key={stroke} value={stroke}>{formatBuilderToken(stroke)}</option>)}</select></label> : null}
+    {row.intensityType === "cadence" ? <label className="calendar-builder-control"><span>Cadence unit</span><SelectDropdown label="Cadence unit" value={row.intensityUnit === "spm" ? "spm" : "rpm"} options={[{ value: "spm", label: "steps/min" }, { value: "rpm", label: "revs/min" }]} portal onChange={(intensityUnit) => onChange({ intensityUnit })} /></label> : null}
+    {row.intensityType === "swimStroke" ? <label className="calendar-builder-control"><span>Stroke</span><SelectDropdown label="Swim stroke" value={row.intensityPreset || "freestyle"} options={Object.keys(SWIM_STROKE_IDS).map((stroke) => ({ value: stroke, label: formatBuilderToken(stroke) }))} portal onChange={(intensityPreset) => onChange({ intensityPreset })} /></label> : null}
 
     {row.intensityType === "weight" ? <>
-      <label className="calendar-builder-control"><span>Load type</span><select value={row.intensityPreset || "bodyweight"} onChange={(event) => onChange({ intensityPreset: event.target.value })}><option value="bodyweight">Bodyweight</option><option value="weight">Added weight</option></select></label>
+      <label className="calendar-builder-control"><span>Load type</span><SelectDropdown label="Load type" value={row.intensityPreset || "bodyweight"} options={[{ value: "bodyweight", label: "Bodyweight" }, { value: "weight", label: "Added weight" }]} portal onChange={(intensityPreset) => onChange({ intensityPreset })} /></label>
       {row.intensityPreset === "weight" ? <><label className="calendar-builder-control"><span>Weight ({unitSystem === "imperial" ? "lb" : "kg"})</span><input type="number" min="0" value={row.intensityLow} onChange={(event) => onChange({ intensityLow: event.target.value, intensityUnit: unitSystem === "imperial" ? "lb" : "kg" })} /></label></> : null}
     </> : null}
 
-    {row.intensityType === "rpe" ? <label className="calendar-builder-control"><span>RPE</span><select value={row.intensityLow || "5"} onChange={(event) => onChange({ intensityLow: event.target.value })}>{Array.from({ length: 10 }, (_, index) => index + 1).map((value) => <option key={value}>{value}</option>)}</select></label> : null}
+    {row.intensityType === "rpe" ? <label className="calendar-builder-control"><span>RPE</span><SelectDropdown label="RPE" value={row.intensityLow || "5"} options={Array.from({ length: 10 }, (_, index) => String(index + 1)).map((value) => ({ value, label: value }))} portal onChange={(intensityLow) => onChange({ intensityLow })} /></label> : null}
 
     {row.intensityType === "climbGrade" ? <>
-      <label className="calendar-builder-control"><span>Grade system</span><select value={climbSystem} onChange={(event) => onChange({ intensityPreset: `relative:${event.target.value}` })}>{Object.keys(CLIMB_SYSTEM_IDS).map((system) => <option key={system} value={system}>{formatBuilderToken(system)}</option>)}</select></label>
-      <label className="calendar-builder-control"><span>Grade mode</span><select value={row.intensityPreset.startsWith("relative:") ? "relative" : "absolute"} onChange={(event) => onChange({ intensityPreset: event.target.value === "relative" ? `relative:${climbSystem}` : `${climbSystem}:${CLIMB_GRADES[climbSystem][0]}` })}><option value="relative">Relative to onsight</option><option value="absolute">Absolute grade</option></select></label>
-      {row.intensityPreset.startsWith("relative:") ? <label className="calendar-builder-control"><span>Relative level</span><input type="number" min="-8" max="4" value={row.intensityLow || "0"} onChange={(event) => onChange({ intensityLow: event.target.value })} /></label> : <label className="calendar-builder-control"><span>Grade</span><select value={row.intensityPreset.split(":")[1]} onChange={(event) => onChange({ intensityPreset: `${climbSystem}:${event.target.value}` })}>{CLIMB_GRADES[climbSystem].map((grade) => <option key={grade}>{grade}</option>)}</select></label>}
+      <label className="calendar-builder-control"><span>Grade system</span><SelectDropdown label="Grade system" value={climbSystem} options={(Object.keys(CLIMB_SYSTEM_IDS) as Array<keyof typeof CLIMB_SYSTEM_IDS>).map((system) => ({ value: system, label: formatBuilderToken(system) }))} portal onChange={(system) => onChange({ intensityPreset: `relative:${system}` })} /></label>
+      <label className="calendar-builder-control"><span>Grade mode</span><SelectDropdown label="Grade mode" value={row.intensityPreset.startsWith("relative:") ? "relative" : "absolute"} options={[{ value: "relative", label: "Relative to onsight" }, { value: "absolute", label: "Absolute grade" }]} portal onChange={(mode) => onChange({ intensityPreset: mode === "relative" ? `relative:${climbSystem}` : `${climbSystem}:${CLIMB_GRADES[climbSystem][0]}` })} /></label>
+      {row.intensityPreset.startsWith("relative:") ? <label className="calendar-builder-control"><span>Relative level</span><input type="number" min="-8" max="4" value={row.intensityLow || "0"} onChange={(event) => onChange({ intensityLow: event.target.value })} /></label> : <label className="calendar-builder-control"><span>Grade</span><SelectDropdown label="Climbing grade" value={row.intensityPreset.split(":")[1] ?? CLIMB_GRADES[climbSystem][0]} options={CLIMB_GRADES[climbSystem].map((grade) => ({ value: grade, label: grade }))} portal onChange={(grade) => onChange({ intensityPreset: `${climbSystem}:${grade}` })} /></label>}
     </> : null}
 
     {context ? <div className="calendar-builder-derived"><BuilderDerivedIntensityPreview intensity={rowIntensity(row, sport, unitSystem)} context={context} /></div> : null}
@@ -1118,11 +1151,16 @@ function BuilderStrengthStepFields({
       <div className="strength-step-form">
         <label className="calendar-builder-control strength-step-kind">
           <span>{kindLabel}</span>
-          <select value={row.kind} onChange={(event) => onKindChange(event.target.value as BuilderKind)}>
-            {allowedKinds.map((kind) => (
-              <option key={kind} value={kind}>{BUILDER_KIND_META[kind].label}</option>
-            ))}
-          </select>
+          <SelectDropdown<BuilderKind>
+            label={kindLabel ?? "Step type"}
+            value={row.kind}
+            options={allowedKinds.map((kind) => ({
+              value: kind,
+              label: BUILDER_KIND_META[kind].label
+            }))}
+            portal
+            onChange={onKindChange}
+          />
         </label>
 
         <section className="strength-block">
@@ -1186,17 +1224,17 @@ function BuilderStrengthStepFields({
                     )}
                   />
                 )}
-                <select
-                  aria-label="Measure each set by"
+                <SelectDropdown<BuilderRow["targetType"]>
+                  className="set-line-select"
+                  label="Measure each set by"
                   value={row.targetType}
-                  onChange={(event) => changeMeasure(event.target.value as BuilderRow["targetType"])}
-                >
-                  {targetTypes.map((target) => (
-                    <option key={target} value={target}>
-                      {measureLabels[target] ?? builderTargetTypeLabel(target)}
-                    </option>
-                  ))}
-                </select>
+                  options={targetTypes.map((target) => ({
+                    value: target,
+                    label: measureLabels[target] ?? builderTargetTypeLabel(target)
+                  }))}
+                  portal
+                  onChange={changeMeasure}
+                />
               </div>
             </div>
 
@@ -1205,15 +1243,18 @@ function BuilderStrengthStepFields({
             <div className="set-line-cell is-load">
               <span>Load</span>
               <div className="set-line-compound">
-                <select
-                  aria-label="Load"
+                <SelectDropdown<StrengthLoadMode>
+                  className="set-line-select"
+                  label="Load"
                   value={loadMode}
-                  onChange={(event) => changeLoadMode(event.target.value as StrengthLoadMode)}
-                >
-                  <option value="bodyweight">Bodyweight</option>
-                  <option value="added">Added weight</option>
-                  <option value="unspecified">Not set</option>
-                </select>
+                  options={[
+                    { value: "bodyweight", label: "Bodyweight" },
+                    { value: "added", label: "Added weight" },
+                    { value: "unspecified", label: "Not set" }
+                  ]}
+                  portal
+                  onChange={changeLoadMode}
+                />
                 {loadMode === "added" ? (
                   <span className="set-line-weight">
                     <input
@@ -1342,28 +1383,30 @@ function BuilderStepFields({
       <div className="calendar-builder-primary-grid">
         <label className="calendar-builder-control">
           <span>{kindLabel}</span>
-          <select
+          <SelectDropdown<BuilderKind>
+            label={kindLabel ?? "Step type"}
             value={row.kind}
-            onChange={(event) => onKindChange(event.target.value as BuilderKind)}
-          >
-            {allowedKinds.map((kind) => (
-              <option key={kind} value={kind}>{BUILDER_KIND_META[kind].label}</option>
-            ))}
-          </select>
+            options={allowedKinds.map((kind) => ({
+              value: kind,
+              label: BUILDER_KIND_META[kind].label
+            }))}
+            portal
+            onChange={onKindChange}
+          />
         </label>
 
         <label className="calendar-builder-control">
           <span>{sport === "strength" && row.kind === "training" ? "Measure by" : "Target"}</span>
-          <select
+          <SelectDropdown<BuilderRow["targetType"]>
+            label={sport === "strength" && row.kind === "training" ? "Measure by" : "Target"}
             value={row.targetType}
-            onChange={(event) => onChange({
-              targetType: event.target.value as BuilderRow["targetType"]
-            })}
-          >
-            {targetTypes.map((target) => (
-              <option key={target} value={target}>{builderTargetTypeLabel(target)}</option>
-            ))}
-          </select>
+            options={targetTypes.map((target) => ({
+              value: target,
+              label: builderTargetTypeLabel(target)
+            }))}
+            portal
+            onChange={(targetType) => onChange({ targetType })}
+          />
         </label>
 
         <label className="calendar-builder-control">
@@ -2101,7 +2144,7 @@ export function AddWorkoutModal({
     setActiveBuilderChildId(nextRow.children?.[0]?.id ?? null);
   };
 
-  return (
+  return createPortal(
     <AnimatePresence>
       <motion.div
         className="calendar-modal-backdrop"
@@ -2424,7 +2467,7 @@ export function AddWorkoutModal({
                     </div>
                   </div>
                   {builderSport === "swim" ? <div className="calendar-field-row"><label className="calendar-field"><span>Pool length ({swimDistanceUnit(unitSystem)})</span><input type="number" min="1" value={builderPoolLength} onChange={(event) => { setBuilderPoolLength(event.target.value); setBuilderPoolUnit(unitSystem === "imperial" ? "yd" : "m"); }} /></label></div> : null}
-                  {(builderSport === "indoorClimb" || builderSport === "bouldering") ? <label className="calendar-field"><span>Grading system</span><select value={builderGradeSystem} onChange={(event) => setBuilderGradeSystem(event.target.value as keyof typeof CLIMB_SYSTEM_IDS)}>{Object.keys(CLIMB_SYSTEM_IDS).map((system) => <option key={system} value={system}>{formatBuilderToken(system)}</option>)}</select></label> : null}
+                  {(builderSport === "indoorClimb" || builderSport === "bouldering") ? <label className="calendar-field"><span>Grading system</span><SelectDropdown label="Grading system" value={builderGradeSystem} options={(Object.keys(CLIMB_SYSTEM_IDS) as Array<keyof typeof CLIMB_SYSTEM_IDS>).map((system) => ({ value: system, label: formatBuilderToken(system) }))} portal onChange={setBuilderGradeSystem} /></label> : null}
                   <label className="calendar-field">
                     <span className="calendar-field-label">
                       <span>Workout name</span>
@@ -2978,6 +3021,7 @@ export function AddWorkoutModal({
           ) : null}
         </motion.div>
       </motion.div>
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }

--- a/src/calendar/ExerciseCombobox.tsx
+++ b/src/calendar/ExerciseCombobox.tsx
@@ -45,8 +45,6 @@ interface ExerciseMenuPosition {
   maxHeight: number;
 }
 
-const MAX_VISIBLE_RESULTS = 12;
-
 function normalizeSearch(value: string): string {
   return value.trim().toLocaleLowerCase();
 }
@@ -94,10 +92,9 @@ export function ExerciseCombobox({
     const showAll = !term || Boolean(
       selectedId && selectedLabel && normalizeSearch(selectedLabel) === term
     );
-    const matches = showAll
+    return showAll
       ? labeledOptions
       : labeledOptions.filter((option) => normalizeSearch(option.label).includes(term));
-    return matches.slice(0, MAX_VISIBLE_RESULTS);
   }, [labeledOptions, query, selectedId]);
 
   useEffect(() => {

--- a/src/calendar/WorkoutEditorModal.tsx
+++ b/src/calendar/WorkoutEditorModal.tsx
@@ -36,6 +36,7 @@ import type {
   WorkoutSport
 } from "../../electron/types";
 import type { CorosLinkApi } from "../coroslink-api";
+import { SelectDropdown } from "../components/SelectDropdown";
 import {
   editorDraftToPlanWorkoutInput,
   planWorkoutInputToEditorDraft
@@ -539,9 +540,14 @@ export function WorkoutEditorModal({
                 <div className="workout-editor-basics">
                   <label className="calendar-field">
                     <span>Sport</span>
-                    <select value={draft.sport} disabled title="An existing COROS workout cannot change sport in place.">
-                      <option value={draft.sport}>{formatWorkoutSport(draft.sport)}</option>
-                    </select>
+                    <SelectDropdown
+                      label="Sport"
+                      value={draft.sport}
+                      options={[{ value: draft.sport, label: formatWorkoutSport(draft.sport) }]}
+                      disabled
+                      title="An existing COROS workout cannot change sport in place."
+                      onChange={() => undefined}
+                    />
                   </label>
                   {draft.sport === "swim" ? (
                     <label className="calendar-field">
@@ -572,11 +578,14 @@ export function WorkoutEditorModal({
                   {(draft.sport === "indoorClimb" || draft.sport === "bouldering") ? (
                     <label className="calendar-field">
                       <span>Grading system</span>
-                      <select
+                      <SelectDropdown<keyof typeof CLIMB_SYSTEM_IDS>
+                        label="Grading system"
                         value={draft.sportOptions?.gradingSystem ?? document.context.climbSystems[draft.sport] ?? (draft.sport === "bouldering" ? "vScale" : "yds")}
                         disabled={!document.canEdit || saving}
-                        onChange={(event) => setDraft({ ...draft, sportOptions: { ...draft.sportOptions, gradingSystem: event.target.value as keyof typeof CLIMB_SYSTEM_IDS } })}
-                      >{Object.keys(CLIMB_SYSTEM_IDS).map((system) => <option key={system} value={system}>{system}</option>)}</select>
+                        options={(Object.keys(CLIMB_SYSTEM_IDS) as Array<keyof typeof CLIMB_SYSTEM_IDS>).map((system) => ({ value: system, label: system }))}
+                        portal
+                        onChange={(gradingSystem) => setDraft({ ...draft, sportOptions: { ...draft.sportOptions, gradingSystem } })}
+                      />
                     </label>
                   ) : null}
                   <label className="calendar-field">
@@ -716,9 +725,15 @@ function StepCard({ step, context, sport, exerciseOptions, exerciseOptionsLoadin
     <motion.article layout className={`workout-step-card is-${step.kind} ${!step.editable ? "is-locked" : ""}`} draggable={draggable && !disabled} onDragStartCapture={onDragStart} onDragOver={(event) => { if (onDropCard) event.preventDefault(); }} onDrop={(event) => { if (!onDropCard) return; event.preventDefault(); onDropCard(event.dataTransfer.getData("text/workout-node")); }}>
       <header className="workout-step-header">
         <GripVertical className="workout-drag-handle" size={18} aria-hidden="true" />
-        <select aria-label="Step kind" value={step.kind} disabled={locked} onChange={(event) => changeKind(event.target.value as RunWorkoutEditorStepKind)}>
-          {capability.stepKinds.map((kind) => <option key={kind} value={kind}>{stepTitle(kind)}</option>)}
-        </select>
+        <SelectDropdown<RunWorkoutEditorStepKind>
+          className="workout-step-kind-select"
+          label="Step kind"
+          value={step.kind}
+          options={capability.stepKinds.map((kind) => ({ value: kind, label: stepTitle(kind) }))}
+          disabled={locked}
+          portal
+          onChange={changeKind}
+        />
         <input aria-label="Step name" value={step.name} disabled={locked} maxLength={90} onChange={(event) => onChange({ ...step, name: event.target.value })} />
         <div className="workout-step-actions">
           <IconAction label="Move up" onClick={() => onMove(-1)} disabled={disabled}><ChevronUp /></IconAction>
@@ -766,9 +781,7 @@ function TargetFields({ step, context, sport, disabled, onChange }: { step: RunW
     ? swimDistanceUnit(context.distanceUnit)
     : context.distanceUnit === "imperial" ? "mi" : "km";
   return <div className="workout-control-group">
-    <label><span>Target</span><select value={target.type} disabled={disabled} onChange={(event) => onChange({ ...step, target: targetForType(event.target.value as RunWorkoutEditorTarget["type"], step.kind) })}>
-      {targetTypes.map((type) => <option key={type} value={type}>{type === "load" ? "Training Load" : type === "hrRecovery" ? "HR Recovery" : type === "elevationGain" ? "Elevation Gain" : type[0]!.toUpperCase() + type.slice(1)}</option>)}
-    </select></label>
+    <label><span>Target</span><SelectDropdown<RunWorkoutEditorTarget["type"]> label="Target" value={target.type} options={targetTypes.map((type) => ({ value: type, label: type === "load" ? "Training Load" : type === "hrRecovery" ? "HR Recovery" : type === "elevationGain" ? "Elevation Gain" : type[0]!.toUpperCase() + type.slice(1) }))} disabled={disabled} portal onChange={(type) => onChange({ ...step, target: targetForType(type, step.kind) })} /></label>
     {target.type === "time" ? <label><span>Duration</span><ClockInput label="Duration" seconds={target.seconds} disabled={disabled} onChange={(seconds) => onChange({ ...step, target: { type: "time", seconds } })} /></label> : null}
     {target.type === "distance" ? <label><span>Distance ({targetDistanceUnit})</span><input type="number" min="0" step="0.1" value={Number((target.meters / distanceMultiplier).toFixed(3))} disabled={disabled} onChange={(event) => onChange({ ...step, target: { type: "distance", meters: Number(event.target.value) * distanceMultiplier } })} /></label> : null}
     {target.type === "load" ? <label><span>Training Load</span><input type="number" min="0" max="999" step="1" value={target.load} disabled={disabled} onChange={(event) => onChange({ ...step, target: { type: "load", load: Number(event.target.value) } })} /></label> : null}
@@ -806,52 +819,50 @@ function IntensityFields({ step, context, sport, disabled, onChange }: { step: R
   );
   const percentRange = (value: { lowPercent: number; highPercent: number }, update: (low: number, high: number) => WorkoutIntensityInput) => numberRange(value.lowPercent, value.highPercent, "Low %", "High %", update, 1, 300);
   return <div className="workout-control-group">
-    <label><span>Intensity</span><select value={intensity.type === "lthrPercent" ? "heartRatePercent" : intensity.type} disabled={disabled} onChange={(event) => setIntensity(intensityForType(event.target.value as RunWorkoutEditorIntensity["type"], context))}>
-      {intensityTypes.map((type) => <option key={type} value={type}>{formatIntensityType(type)}</option>)}
-    </select></label>
+    <label><span>Intensity</span><SelectDropdown<RunWorkoutEditorIntensity["type"]> label="Intensity" value={intensity.type === "lthrPercent" ? "heartRatePercent" : intensity.type} options={intensityTypes.map((type) => ({ value: type, label: formatIntensityType(type) }))} disabled={disabled} portal onChange={(type) => setIntensity(intensityForType(type, context))} /></label>
 
     {(intensity.type === "pace" || intensity.type === "effortPace") ? <div className="workout-range-inputs"><label><span>Fast ({context.paceUnit})</span><ClockInput label={`Fast pace per ${context.paceUnit}`} seconds={intensity.lowSecondsPerKm * paceFactor} disabled={disabled} onChange={(seconds) => setIntensity({ ...intensity, lowSecondsPerKm: seconds / paceFactor, displayUnit: context.paceUnit })} /></label><span>to</span><label><span>Slow ({context.paceUnit})</span><ClockInput label={`Slow pace per ${context.paceUnit}`} seconds={intensity.highSecondsPerKm * paceFactor} disabled={disabled} onChange={(seconds) => setIntensity({ ...intensity, highSecondsPerKm: seconds / paceFactor, displayUnit: context.paceUnit })} /></label></div> : null}
 
     {intensity.type === "heartRate" ? numberRange(intensity.lowBpm, intensity.highBpm, "Low bpm", "High bpm", (lowBpm, highBpm) => ({ type: "heartRate", lowBpm, highBpm }), 30, 250) : null}
 
     {intensity.type === "heartRatePercent" ? <>
-      <label><span>Basis</span><select value={intensity.basis} disabled={disabled} onChange={(event) => setIntensity({ type: "heartRatePercent", basis: event.target.value as WorkoutHeartRateBasis, preset: "aerobicEndurance" })}><option value="maxHr">% Max Heart Rate</option><option value="reserve">% Heart Rate Reserve</option><option value="lthr">% Lactate Threshold HR</option></select></label>
-      <label><span>Zone or custom</span><select value={intensity.preset ?? "custom"} disabled={disabled} onChange={(event) => { const preset = event.target.value; const definition = HEART_RATE_PRESETS[intensity.basis].find((zone) => zone.preset === preset); const configured = profileZone(context, intensity.basis, preset, definition?.id); setIntensity(preset === "custom" ? { type: "heartRatePercent", basis: intensity.basis, lowPercent: 80, highPercent: 90 } : { type: "heartRatePercent", basis: intensity.basis, preset: preset as never, ...(configured ? { zoneId: configured.id } : {}) }); }}><option value="custom">Custom range</option>{HEART_RATE_PRESETS[intensity.basis].map((zone) => { const configured = profileZone(context, intensity.basis, zone.preset, zone.id); return <option key={zone.id} value={zone.preset}>{configured?.label ?? zone.label} · {configured?.lowPercent ?? zone.low}–{configured?.highPercent ?? zone.high}%</option>; })}</select></label>
+      <label><span>Basis</span><SelectDropdown<WorkoutHeartRateBasis> label="Heart-rate basis" value={intensity.basis} options={[{ value: "maxHr", label: "% Max Heart Rate" }, { value: "reserve", label: "% Heart Rate Reserve" }, { value: "lthr", label: "% Lactate Threshold HR" }]} disabled={disabled} portal onChange={(basis) => setIntensity({ type: "heartRatePercent", basis, preset: "aerobicEndurance" })} /></label>
+      <label><span>Zone or custom</span><SelectDropdown label="Heart-rate zone" value={intensity.preset ?? "custom"} options={[{ value: "custom", label: "Custom range" }, ...HEART_RATE_PRESETS[intensity.basis].map((zone) => { const configured = profileZone(context, intensity.basis, zone.preset, zone.id); return { value: zone.preset, label: `${configured?.label ?? zone.label} · ${configured?.lowPercent ?? zone.low}-${configured?.highPercent ?? zone.high}%` }; })]} disabled={disabled} portal onChange={(preset) => { const definition = HEART_RATE_PRESETS[intensity.basis].find((zone) => zone.preset === preset); const configured = profileZone(context, intensity.basis, preset, definition?.id); setIntensity(preset === "custom" ? { type: "heartRatePercent", basis: intensity.basis, lowPercent: 80, highPercent: 90 } : { type: "heartRatePercent", basis: intensity.basis, preset: preset as never, ...(configured ? { zoneId: configured.id } : {}) }); }} /></label>
       {!intensity.preset ? percentRange(intensity, (lowPercent, highPercent) => ({ type: "heartRatePercent", basis: intensity.basis, lowPercent, highPercent })) : null}
       <HeartRatePreview intensity={intensity} context={context} />
     </> : null}
 
     {(intensity.type === "thresholdPacePercent" || intensity.type === "effortPacePercent") ? <>
-      <label><span>Zone or custom</span><select value={intensity.preset ?? "custom"} disabled={disabled} onChange={(event) => { const preset = event.target.value; const definition = PACE_PRESETS.find((zone) => zone.preset === preset); const configured = profileZone(context, "thresholdPace", preset, definition?.id); setIntensity((preset === "custom" ? { type: intensity.type, lowPercent: 90, highPercent: 100 } : { type: intensity.type, preset, ...(configured ? { zoneId: configured.id } : {}) }) as WorkoutIntensityInput); }}><option value="custom">Custom range</option>{PACE_PRESETS.map((zone) => { const configured = profileZone(context, "thresholdPace", zone.preset, zone.id); return <option key={zone.id} value={zone.preset}>{configured?.label ?? zone.label} · {configured?.lowPercent ?? zone.low}–{configured?.highPercent ?? zone.high}%</option>; })}</select></label>
+      <label><span>Zone or custom</span><SelectDropdown label="Pace zone" value={intensity.preset ?? "custom"} options={[{ value: "custom", label: "Custom range" }, ...PACE_PRESETS.map((zone) => { const configured = profileZone(context, "thresholdPace", zone.preset, zone.id); return { value: zone.preset, label: `${configured?.label ?? zone.label} · ${configured?.lowPercent ?? zone.low}-${configured?.highPercent ?? zone.high}%` }; })]} disabled={disabled} portal onChange={(preset) => { const definition = PACE_PRESETS.find((zone) => zone.preset === preset); const configured = profileZone(context, "thresholdPace", preset, definition?.id); setIntensity((preset === "custom" ? { type: intensity.type, lowPercent: 90, highPercent: 100 } : { type: intensity.type, preset, ...(configured ? { zoneId: configured.id } : {}) }) as WorkoutIntensityInput); }} /></label>
       {!intensity.preset ? percentRange(intensity, (lowPercent, highPercent) => ({ type: intensity.type, lowPercent, highPercent })) : null}
       <PacePercentPreview intensity={intensity} context={context} />
     </> : null}
 
     {intensity.type === "ftpPercent" ? <>
-      <label><span>Zone or custom</span><select value={intensity.preset ?? "custom"} disabled={disabled} onChange={(event) => { const preset = event.target.value; const definition = FTP_PRESETS.find((zone) => zone.preset === preset); const configured = profileZone(context, "ftp", preset, definition?.id); setIntensity(preset === "custom" ? { type: "ftpPercent", lowPercent: 90, highPercent: 100 } : { type: "ftpPercent", preset: preset as never, ...(configured ? { zoneId: configured.id } : {}) }); }}><option value="custom">Custom range</option>{FTP_PRESETS.map((zone) => { const configured = profileZone(context, "ftp", zone.preset, zone.id); return <option key={zone.id} value={zone.preset}>{configured?.label ?? zone.label} · {configured?.lowPercent ?? zone.low}–{configured?.highPercent ?? zone.high}%</option>; })}</select></label>
+      <label><span>Zone or custom</span><SelectDropdown label="Cycling power zone" value={intensity.preset ?? "custom"} options={[{ value: "custom", label: "Custom range" }, ...FTP_PRESETS.map((zone) => { const configured = profileZone(context, "ftp", zone.preset, zone.id); return { value: zone.preset, label: `${configured?.label ?? zone.label} · ${configured?.lowPercent ?? zone.low}-${configured?.highPercent ?? zone.high}%` }; })]} disabled={disabled} portal onChange={(preset) => { const definition = FTP_PRESETS.find((zone) => zone.preset === preset); const configured = profileZone(context, "ftp", preset, definition?.id); setIntensity(preset === "custom" ? { type: "ftpPercent", lowPercent: 90, highPercent: 100 } : { type: "ftpPercent", preset: preset as never, ...(configured ? { zoneId: configured.id } : {}) }); }} /></label>
       {!intensity.preset ? percentRange(intensity, (lowPercent, highPercent) => ({ type: "ftpPercent", lowPercent, highPercent })) : null}
       <PowerPercentPreview intensity={intensity} context={context} reference={context.ftp} zoneKey="ftp" />
     </> : null}
 
     {intensity.type === "power" ? <>
-      <label><span>Zone or custom</span><select value={intensity.preset ?? "custom"} disabled={disabled} onChange={(event) => { const preset = event.target.value; const definition = RUNNING_POWER_PRESETS.find((zone) => zone.preset === preset); const configured = profileZone(context, "runningPower", preset, definition?.id); setIntensity(preset === "custom" ? { type: "power", lowWatts: 180, highWatts: 220 } : { type: "power", preset: preset as never, ...(configured ? { zoneId: configured.id } : {}) }); }}><option value="custom">Custom watts</option>{RUNNING_POWER_PRESETS.map((zone) => { const configured = profileZone(context, "runningPower", zone.preset, zone.id); return <option key={zone.id} value={zone.preset}>{configured?.label ?? zone.label} · {configured?.lowPercent ?? zone.low}–{configured?.highPercent ?? zone.high}%</option>; })}</select></label>
+      <label><span>Zone or custom</span><SelectDropdown label="Running power zone" value={intensity.preset ?? "custom"} options={[{ value: "custom", label: "Custom watts" }, ...RUNNING_POWER_PRESETS.map((zone) => { const configured = profileZone(context, "runningPower", zone.preset, zone.id); return { value: zone.preset, label: `${configured?.label ?? zone.label} · ${configured?.lowPercent ?? zone.low}-${configured?.highPercent ?? zone.high}%` }; })]} disabled={disabled} portal onChange={(preset) => { const definition = RUNNING_POWER_PRESETS.find((zone) => zone.preset === preset); const configured = profileZone(context, "runningPower", preset, definition?.id); setIntensity(preset === "custom" ? { type: "power", lowWatts: 180, highWatts: 220 } : { type: "power", preset: preset as never, ...(configured ? { zoneId: configured.id } : {}) }); }} /></label>
       {!intensity.preset ? numberRange(intensity.lowWatts, intensity.highWatts, "Low W", "High W", (lowWatts, highWatts) => ({ type: "power", lowWatts, highWatts }), 0, 3000) : <PowerPercentPreview intensity={intensity} context={context} reference={context.criticalPower} zoneKey="runningPower" />}
     </> : null}
 
     {intensity.type === "speed" ? numberRange(intensity.low, intensity.high, `Low ${intensity.unit}`, `High ${intensity.unit}`, (low, high) => ({ ...intensity, low, high }), 0, 200) : null}
     {intensity.type === "cadence" ? numberRange(intensity.low, intensity.high, `Low ${intensity.unit}`, `High ${intensity.unit}`, (low, high) => ({ ...intensity, low, high }), 0, 300) : null}
 
-    {intensity.type === "swimStroke" ? <label><span>Stroke</span><select value={intensity.stroke} disabled={disabled} onChange={(event) => setIntensity({ type: "swimStroke", stroke: event.target.value as keyof typeof SWIM_STROKE_IDS })}>{Object.keys(SWIM_STROKE_IDS).map((stroke) => <option key={stroke} value={stroke}>{stroke}</option>)}</select></label> : null}
+    {intensity.type === "swimStroke" ? <label><span>Stroke</span><SelectDropdown label="Swim stroke" value={intensity.stroke} options={(Object.keys(SWIM_STROKE_IDS) as Array<keyof typeof SWIM_STROKE_IDS>).map((stroke) => ({ value: stroke, label: stroke }))} disabled={disabled} portal onChange={(stroke) => setIntensity({ type: "swimStroke", stroke })} /></label> : null}
 
-    {intensity.type === "weight" ? <><label><span>Load</span><select value={intensity.mode} disabled={disabled} onChange={(event) => setIntensity(event.target.value === "bodyweight" ? { type: "weight", mode: "bodyweight" } : { type: "weight", mode: "weight", value: 10, unit: context.distanceUnit === "imperial" ? "lb" : "kg" })}><option value="bodyweight">Bodyweight</option><option value="weight">Weight</option></select></label>{intensity.mode === "weight" ? <label><span>Weight ({context.distanceUnit === "imperial" ? "lb" : "kg"})</span><input type="number" min="0" max="2000" value={intensity.value} disabled={disabled} onChange={(event) => setIntensity({ ...intensity, value: Number(event.target.value), unit: context.distanceUnit === "imperial" ? "lb" : "kg" })} /></label> : null}</> : null}
+    {intensity.type === "weight" ? <><label><span>Load</span><SelectDropdown label="Load" value={intensity.mode} options={[{ value: "bodyweight", label: "Bodyweight" }, { value: "weight", label: "Weight" }]} disabled={disabled} portal onChange={(mode) => setIntensity(mode === "bodyweight" ? { type: "weight", mode: "bodyweight" } : { type: "weight", mode: "weight", value: 10, unit: context.distanceUnit === "imperial" ? "lb" : "kg" })} /></label>{intensity.mode === "weight" ? <label><span>Weight ({context.distanceUnit === "imperial" ? "lb" : "kg"})</span><input type="number" min="0" max="2000" value={intensity.value} disabled={disabled} onChange={(event) => setIntensity({ ...intensity, value: Number(event.target.value), unit: context.distanceUnit === "imperial" ? "lb" : "kg" })} /></label> : null}</> : null}
 
-    {intensity.type === "rpe" ? <label><span>RPE</span><select value={intensity.value} disabled={disabled} onChange={(event) => setIntensity({ type: "rpe", value: Number(event.target.value) })}>{Array.from({ length: 10 }, (_, index) => index + 1).map((value) => <option key={value} value={value}>{value}</option>)}</select></label> : null}
+    {intensity.type === "rpe" ? <label><span>RPE</span><SelectDropdown label="RPE" value={String(intensity.value)} options={Array.from({ length: 10 }, (_, index) => String(index + 1)).map((value) => ({ value, label: value }))} disabled={disabled} portal onChange={(value) => setIntensity({ type: "rpe", value: Number(value) })} /></label> : null}
 
     {intensity.type === "climbGrade" ? <>
-      <label><span>System</span><select value={intensity.system} disabled={disabled} onChange={(event) => setIntensity({ type: "climbGrade", system: event.target.value as keyof typeof CLIMB_SYSTEM_IDS, relativeToOnsight: 0 })}>{Object.keys(CLIMB_SYSTEM_IDS).map((system) => <option key={system} value={system}>{system}</option>)}</select></label>
-      <label><span>Grade mode</span><select value={"relativeToOnsight" in intensity ? "relative" : "absolute"} disabled={disabled} onChange={(event) => setIntensity(event.target.value === "relative" ? { type: "climbGrade", system: intensity.system, relativeToOnsight: 0 } : { type: "climbGrade", system: intensity.system, absoluteGrade: CLIMB_GRADES[intensity.system][0]! })}><option value="relative">Relative to onsight</option><option value="absolute">Absolute grade</option></select></label>
-      {"relativeToOnsight" in intensity && intensity.relativeToOnsight !== undefined ? <label><span>Relative level</span><select value={intensity.relativeToOnsight} disabled={disabled} onChange={(event) => setIntensity({ ...intensity, relativeToOnsight: Number(event.target.value) })}>{Array.from({ length: 13 }, (_, index) => index - 8).map((value) => <option key={value} value={value}>{value === 0 ? "Onsight" : `${value > 0 ? "+" : ""}${value}`}</option>)}</select></label> : null}
-      {"absoluteGrade" in intensity && intensity.absoluteGrade !== undefined ? <label><span>Grade</span><select value={intensity.absoluteGrade} disabled={disabled} onChange={(event) => setIntensity({ ...intensity, absoluteGrade: event.target.value })}>{CLIMB_GRADES[intensity.system].map((grade) => <option key={grade} value={grade}>{grade}</option>)}</select></label> : null}
+      <label><span>System</span><SelectDropdown<keyof typeof CLIMB_SYSTEM_IDS> label="Climbing system" value={intensity.system} options={(Object.keys(CLIMB_SYSTEM_IDS) as Array<keyof typeof CLIMB_SYSTEM_IDS>).map((system) => ({ value: system, label: system }))} disabled={disabled} portal onChange={(system) => setIntensity({ type: "climbGrade", system, relativeToOnsight: 0 })} /></label>
+      <label><span>Grade mode</span><SelectDropdown label="Grade mode" value={"relativeToOnsight" in intensity ? "relative" : "absolute"} options={[{ value: "relative", label: "Relative to onsight" }, { value: "absolute", label: "Absolute grade" }]} disabled={disabled} portal onChange={(mode) => setIntensity(mode === "relative" ? { type: "climbGrade", system: intensity.system, relativeToOnsight: 0 } : { type: "climbGrade", system: intensity.system, absoluteGrade: CLIMB_GRADES[intensity.system][0]! })} /></label>
+      {"relativeToOnsight" in intensity && intensity.relativeToOnsight !== undefined ? <label><span>Relative level</span><SelectDropdown label="Relative climbing level" value={String(intensity.relativeToOnsight)} options={Array.from({ length: 13 }, (_, index) => index - 8).map((value) => ({ value: String(value), label: value === 0 ? "Onsight" : `${value > 0 ? "+" : ""}${value}` }))} disabled={disabled} portal onChange={(value) => setIntensity({ ...intensity, relativeToOnsight: Number(value) })} /></label> : null}
+      {"absoluteGrade" in intensity && intensity.absoluteGrade !== undefined ? <label><span>Grade</span><SelectDropdown label="Climbing grade" value={intensity.absoluteGrade} options={CLIMB_GRADES[intensity.system].map((grade) => ({ value: grade, label: grade }))} disabled={disabled} portal onChange={(absoluteGrade) => setIntensity({ ...intensity, absoluteGrade })} /></label> : null}
     </> : null}
   </div>;
 }

--- a/src/chat/ChatSettingsPanel.tsx
+++ b/src/chat/ChatSettingsPanel.tsx
@@ -132,11 +132,7 @@ export function ChatSettingsPanel({
         <h3>ChatGPT account</h3>
         {authStatus?.signedIn ? (
           <div className="chat-settings-account">
-            {authStatus.email ? (
-              <span className="chat-settings-email">{authStatus.email}</span>
-            ) : (
-              <span className="chat-settings-email">Signed in</span>
-            )}
+            <span className="chat-settings-email">Signed in</span>
             <button
               type="button"
               className="chat-signout chat-signout-settings"

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -2087,9 +2087,6 @@ export function ChatView({
             );
             })()}
           </div>
-          {isChatGptProvider && authStatus?.email ? (
-            <span className="chat-account">{authStatus.email}</span>
-          ) : null}
           {isChatGptProvider ? (
             <button
               type="button"

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -8,10 +8,10 @@ import {
   useState,
 } from "react";
 import {
-  PRIMARY_NAV_ITEMS,
   SIDEBAR_COLLAPSED_WIDTH,
   SIDEBAR_EXPANDED_WIDTH,
   type PrimaryView,
+  visiblePrimaryNavItems,
 } from "../navigation/primaryNav";
 
 const SIDEBAR_COLLAPSED_KEY = "coroslink.sidebarCollapsed";
@@ -108,6 +108,7 @@ export interface AppSidebarProps {
   activeView: PrimaryView;
   onChange: (view: PrimaryView) => void;
   coachBusy?: boolean;
+  showDevelopmentItems?: boolean;
   appLogo: string;
   expanded: boolean;
   onExpandedChange: (expanded: boolean) => void;
@@ -119,6 +120,7 @@ export function AppSidebar({
   activeView,
   onChange,
   coachBusy = false,
+  showDevelopmentItems = false,
   appLogo,
   expanded,
   onExpandedChange,
@@ -126,6 +128,7 @@ export function AppSidebar({
   onOverlayOpenChange,
 }: AppSidebarProps) {
   const overlayMode = useMediaQuery("(max-width: 720px)");
+  const navItems = visiblePrimaryNavItems(showDevelopmentItems);
   const reducedMotion = useReducedMotion();
   const navRef = useRef<HTMLElement>(null);
   const itemRefs = useRef(new Map<PrimaryView, HTMLButtonElement>());
@@ -287,7 +290,7 @@ export function AppSidebar({
               opacity: indicator.ready ? 1 : 0,
             }}
           />
-          {PRIMARY_NAV_ITEMS.map((item, index) => {
+          {navItems.map((item, index) => {
             const Icon = item.icon;
             const isActive = activeView === item.id;
             const tooltip = item.beta

--- a/src/components/DonateButton.tsx
+++ b/src/components/DonateButton.tsx
@@ -1,4 +1,4 @@
-import { Coffee, Sparkles } from "lucide-react";
+import { Coffee } from "lucide-react";
 
 const DONATE_URL = "https://www.buymeacoffee.com/addridoa";
 
@@ -14,7 +14,6 @@ export function DonateButton() {
     >
       <span className="donate-button-art" aria-hidden="true">
         <Coffee className="donate-button-cup" size={17} strokeWidth={2.6} />
-        <Sparkles className="donate-button-spark" size={10} strokeWidth={2.8} />
       </span>
       <span className="donate-button-label">Donate</span>
     </a>

--- a/src/components/PrimaryTabs.tsx
+++ b/src/components/PrimaryTabs.tsx
@@ -6,8 +6,8 @@ import {
   useState,
 } from "react";
 import {
-  PRIMARY_NAV_ITEMS,
   type PrimaryView,
+  visiblePrimaryNavItems,
 } from "../navigation/primaryNav";
 import { SelectDropdown } from "./SelectDropdown";
 
@@ -17,6 +17,7 @@ interface PrimaryTabsProps {
   activeView: PrimaryView;
   onChange: (view: PrimaryView) => void;
   coachBusy?: boolean;
+  showDevelopmentItems?: boolean;
 }
 
 function useMediaQuery(query: string): boolean {
@@ -45,8 +46,10 @@ export function PrimaryTabs({
   activeView,
   onChange,
   coachBusy = false,
+  showDevelopmentItems = false,
 }: PrimaryTabsProps) {
   const compactNav = useMediaQuery("(max-width: 720px)");
+  const navItems = visiblePrimaryNavItems(showDevelopmentItems);
   const navRef = useRef<HTMLElement>(null);
   const tabRefs = useRef(new Map<PrimaryView, HTMLButtonElement>());
   const [indicator, setIndicator] = useState({
@@ -104,7 +107,7 @@ export function PrimaryTabs({
     return (
       <SelectDropdown
         value={activeView}
-        options={PRIMARY_NAV_ITEMS.map((tab) => ({
+        options={navItems.map((tab) => ({
           value: tab.id,
           label: tab.beta ? `${tab.label} (Beta)` : tab.label,
         }))}
@@ -127,7 +130,7 @@ export function PrimaryTabs({
           opacity: indicator.ready ? 1 : 0,
         }}
       />
-      {PRIMARY_NAV_ITEMS.map((tab) => {
+      {navItems.map((tab) => {
         const Icon = tab.icon;
         const isActive = activeView === tab.id;
 

--- a/src/components/SelectDropdown.tsx
+++ b/src/components/SelectDropdown.tsx
@@ -1,11 +1,15 @@
 import { Check, ChevronDown } from "lucide-react";
 import {
+  type CSSProperties,
   type KeyboardEvent,
+  useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useRef,
   useState
 } from "react";
+import { createPortal } from "react-dom";
 
 export type SelectOption<T extends string> = {
   value: T;
@@ -19,7 +23,30 @@ export interface SelectDropdownProps<T extends string> {
   label: string;
   className?: string;
   disabled?: boolean;
+  portal?: boolean;
+  title?: string;
 }
+
+interface MenuPosition {
+  left: number;
+  top: number;
+  width: number;
+  maxHeight: number;
+  transform?: string;
+}
+
+type PortalTheme = CSSProperties & Record<`--${string}`, string>;
+
+const PORTAL_THEME_VARIABLES = [
+  "--surface",
+  "--glass-border",
+  "--glass-bg-hover",
+  "--text-primary",
+  "--text-secondary",
+  "--accent",
+  "--accent-soft",
+  "--radius-sm"
+] as const;
 
 export function SelectDropdown<T extends string>({
   value,
@@ -27,17 +54,53 @@ export function SelectDropdown<T extends string>({
   onChange,
   label,
   className,
-  disabled = false
+  disabled = false,
+  portal = false,
+  title
 }: SelectDropdownProps<T>) {
   const dropdownId = useId();
   const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const typeaheadRef = useRef({ query: "", updatedAt: 0 });
   const [isOpen, setIsOpen] = useState(false);
   const [highlightedValue, setHighlightedValue] = useState<T>(value);
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+  const [portalTheme, setPortalTheme] = useState<PortalTheme>({});
   const selectedOption = options.find((option) => option.value === value);
   const selectedLabel = selectedOption?.label ?? "Select";
   const labelId = `${dropdownId}-label`;
   const valueId = `${dropdownId}-value`;
   const menuId = `${dropdownId}-menu`;
+
+  const updateMenuPosition = useCallback(() => {
+    if (!portal || !triggerRef.current) return;
+
+    const trigger = triggerRef.current.getBoundingClientRect();
+    const computedStyle = window.getComputedStyle(triggerRef.current);
+    const viewportMargin = 8;
+    const menuGap = 6;
+    const menuWidth = Math.min(
+      Math.max(trigger.width, 220),
+      window.innerWidth - viewportMargin * 2
+    );
+    const preferredHeight = Math.min(menuRef.current?.scrollHeight ?? 280, 280);
+    const roomBelow = window.innerHeight - trigger.bottom - viewportMargin;
+    const roomAbove = trigger.top - viewportMargin;
+    const opensUp = roomBelow < Math.min(preferredHeight, 180) && roomAbove > roomBelow;
+    const availableRoom = Math.max(96, (opensUp ? roomAbove : roomBelow) - menuGap);
+
+    setMenuPosition({
+      left: Math.max(viewportMargin, Math.min(trigger.left, window.innerWidth - menuWidth - viewportMargin)),
+      top: opensUp ? trigger.top - menuGap : trigger.bottom + menuGap,
+      width: menuWidth,
+      maxHeight: Math.min(preferredHeight, availableRoom),
+      transform: opensUp ? "translateY(-100%)" : undefined
+    });
+    setPortalTheme(Object.fromEntries(
+      PORTAL_THEME_VARIABLES.map((name) => [name, computedStyle.getPropertyValue(name)])
+    ) as PortalTheme);
+  }, [portal]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -47,7 +110,8 @@ export function SelectDropdown<T extends string>({
     setHighlightedValue(value);
 
     function handlePointerDown(event: PointerEvent) {
-      if (!rootRef.current?.contains(event.target as Node)) {
+      const target = event.target as Node;
+      if (!rootRef.current?.contains(target) && !menuRef.current?.contains(target)) {
         setIsOpen(false);
       }
     }
@@ -66,6 +130,25 @@ export function SelectDropdown<T extends string>({
       document.removeEventListener("keydown", handleDocumentKeyDown);
     };
   }, [isOpen, value]);
+
+  useLayoutEffect(() => {
+    if (!isOpen || !portal) {
+      setMenuPosition(null);
+      return;
+    }
+
+    updateMenuPosition();
+    const observer = typeof ResizeObserver === "undefined"
+      ? null
+      : new ResizeObserver(updateMenuPosition);
+    if (triggerRef.current) observer?.observe(triggerRef.current);
+    window.addEventListener("resize", updateMenuPosition);
+
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", updateMenuPosition);
+    };
+  }, [isOpen, portal, updateMenuPosition]);
 
   function moveHighlight(direction: 1 | -1) {
     if (options.length === 0) {
@@ -88,6 +171,7 @@ export function SelectDropdown<T extends string>({
 
   function selectOption(nextValue: T) {
     onChange(nextValue);
+    setHighlightedValue(nextValue);
     setIsOpen(false);
   }
 
@@ -109,11 +193,81 @@ export function SelectDropdown<T extends string>({
       return;
     }
 
+    if (isOpen && (event.key === "Home" || event.key === "End")) {
+      event.preventDefault();
+      const option = event.key === "Home" ? options[0] : options[options.length - 1];
+      if (option) setHighlightedValue(option.value);
+      return;
+    }
+
     if ((event.key === "Enter" || event.key === " ") && isOpen) {
       event.preventDefault();
       selectOption(highlightedValue);
+      return;
+    }
+
+    if (event.key.length === 1 && !event.altKey && !event.ctrlKey && !event.metaKey) {
+      event.preventDefault();
+      const now = Date.now();
+      const previous = typeaheadRef.current;
+      const query = `${now - previous.updatedAt > 700 ? "" : previous.query}${event.key}`.toLocaleLowerCase();
+      typeaheadRef.current = { query, updatedAt: now };
+      const match = options.find((option) => option.label.toLocaleLowerCase().startsWith(query));
+      if (match) {
+        setIsOpen(true);
+        setHighlightedValue(match.value);
+      }
     }
   }
+
+  const menu = isOpen ? (
+    <div
+      className={`app-select-menu${portal ? " is-portaled" : ""}`}
+      id={menuId}
+      ref={menuRef}
+      role="listbox"
+      aria-label={label}
+      style={portal ? ({
+        ...portalTheme,
+        left: menuPosition?.left ?? 0,
+        top: menuPosition?.top ?? 0,
+        width: menuPosition?.width ?? 0,
+        maxHeight: menuPosition?.maxHeight ?? 280,
+        transform: menuPosition?.transform,
+        visibility: menuPosition ? "visible" : "hidden"
+      } satisfies CSSProperties) : undefined}
+    >
+      {options.map((option) => {
+        const isSelected = option.value === value;
+        const isActive = option.value === highlightedValue;
+
+        return (
+          <button
+            type="button"
+            className={[
+              "app-select-option",
+              isSelected ? "is-selected" : "",
+              isActive ? "is-active" : ""
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            id={`${dropdownId}-option-${String(option.value)}`}
+            key={option.value}
+            role="option"
+            aria-selected={isSelected}
+            onClick={() => selectOption(option.value)}
+            onMouseDown={(event) => event.preventDefault()}
+            onMouseEnter={() => setHighlightedValue(option.value)}
+          >
+            <span>{option.label}</span>
+            {isSelected ? (
+              <Check size={15} strokeWidth={2.6} aria-hidden="true" />
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  ) : null;
 
   return (
     <div
@@ -125,12 +279,16 @@ export function SelectDropdown<T extends string>({
       </span>
       <button
         type="button"
+        role="combobox"
         className="app-select-trigger"
+        ref={triggerRef}
         aria-controls={menuId}
         aria-expanded={isOpen}
         aria-haspopup="listbox"
+        aria-activedescendant={isOpen && options.length ? `${dropdownId}-option-${String(highlightedValue)}` : undefined}
         aria-labelledby={`${labelId} ${valueId}`}
         disabled={disabled}
+        title={title}
         onClick={() => {
           if (!disabled) {
             setIsOpen((current) => !current);
@@ -149,42 +307,9 @@ export function SelectDropdown<T extends string>({
         />
       </button>
 
-      {isOpen ? (
-        <div
-          className="app-select-menu"
-          id={menuId}
-          role="listbox"
-          aria-label={label}
-        >
-          {options.map((option) => {
-            const isSelected = option.value === value;
-            const isActive = option.value === highlightedValue;
-
-            return (
-              <button
-                type="button"
-                className={[
-                  "app-select-option",
-                  isSelected ? "is-selected" : "",
-                  isActive ? "is-active" : ""
-                ]
-                  .filter(Boolean)
-                  .join(" ")}
-                key={option.value}
-                role="option"
-                aria-selected={isSelected}
-                onClick={() => selectOption(option.value)}
-                onMouseEnter={() => setHighlightedValue(option.value)}
-              >
-                <span>{option.label}</span>
-                {isSelected ? (
-                  <Check size={15} strokeWidth={2.6} aria-hidden="true" />
-                ) : null}
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
+      {portal && menu && typeof document !== "undefined"
+        ? createPortal(menu, document.body)
+        : menu}
     </div>
   );
 }

--- a/src/components/StartupViewMenu.tsx
+++ b/src/components/StartupViewMenu.tsx
@@ -1,14 +1,22 @@
 import { useEffect, useRef, useState } from "react";
 import { Check, Star } from "lucide-react";
-import { PRIMARY_NAV_ITEMS, type PrimaryView } from "../navigation/primaryNav";
+import {
+  type PrimaryView,
+  visiblePrimaryNavItems,
+} from "../navigation/primaryNav";
 import { getPrimaryViewLabel } from "../navigation/startupView";
 
 interface StartupViewMenuProps {
   value: PrimaryView;
   onChange: (view: PrimaryView) => void;
+  showDevelopmentItems?: boolean;
 }
 
-export function StartupViewMenu({ value, onChange }: StartupViewMenuProps) {
+export function StartupViewMenu({
+  value,
+  onChange,
+  showDevelopmentItems = false,
+}: StartupViewMenuProps) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const activeLabel = getPrimaryViewLabel(value);
@@ -55,7 +63,7 @@ export function StartupViewMenu({ value, onChange }: StartupViewMenuProps) {
         <div className="startup-view-popover" role="menu">
           <p className="update-settings-heading">Startup view</p>
           <div className="startup-view-options">
-            {PRIMARY_NAV_ITEMS.filter(
+            {visiblePrimaryNavItems(showDevelopmentItems).filter(
               (item) => !item.excludeFromStartup,
             ).map(({ id, label, icon: Icon, beta }) => {
               const active = id === value;

--- a/src/coroslink-api.ts
+++ b/src/coroslink-api.ts
@@ -145,6 +145,8 @@ import type {
   CorosWatchfaceThemeListInput,
   CorosBatteryQueryInput,
   CorosBatteryReport,
+  CorosGearCatalog,
+  CorosGearSaveInput,
   CorosPairedDevice,
   CorosBluetoothDeviceChoice,
   CommunityWatchface,
@@ -180,6 +182,8 @@ export interface CorosLinkApi {
   getCorosBatteryReport: (
     input: CorosBatteryQueryInput
   ) => Promise<CorosBatteryReport>;
+  queryCorosGear: () => Promise<CorosGearCatalog>;
+  saveCorosGear: (input: CorosGearSaveInput) => Promise<CorosGearCatalog>;
   listCorosWatchfaceThemes: (
     input: CorosWatchfaceThemeListInput
   ) => Promise<CorosWatchfaceTheme[]>;

--- a/src/gear/GearView.tsx
+++ b/src/gear/GearView.tsx
@@ -1,0 +1,595 @@
+import {
+  Bike,
+  CalendarDays,
+  Check,
+  Footprints,
+  Gauge,
+  Loader2,
+  LockKeyhole,
+  LogOut,
+  Mail,
+  Plus,
+  RefreshCw,
+  ShieldCheck
+} from "lucide-react";
+import { type FormEvent, useEffect, useMemo, useState } from "react";
+import type {
+  CorosGear,
+  CorosGearCatalog,
+  CorosGearType,
+  CorosWatchfaceRegion,
+  CorosWatchfaceStatus
+} from "../../electron/types";
+import type { CorosLinkApi } from "../coroslink-api";
+import { resolveSportName } from "../training/sportTypes";
+import { useUnitSystem } from "../units/UnitSystemProvider";
+import {
+  displayDistanceToMeters,
+  distanceUnit,
+  formatDistanceValue,
+  metersToDisplayDistance
+} from "../units/units";
+import "./gear.css";
+
+const REGION_OPTIONS: ReadonlyArray<{
+  value: CorosWatchfaceRegion;
+  label: string;
+}> = [
+  { value: "us", label: "United States" },
+  { value: "eu", label: "Europe" },
+  { value: "cn", label: "China / Asia-Pacific" }
+];
+
+const FALLBACK_SPORTS: Record<CorosGearType, number[]> = {
+  1: [100, 101, 102, 103, 104, 900, 105],
+  2: [200, 201, 203, 204, 202, 205]
+};
+
+function localCalendarDay(): string {
+  const date = new Date();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
+}
+
+function messageFrom(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function typeLabel(type: CorosGearType): string {
+  return type === 1 ? "Running shoes" : "Bike";
+}
+
+function sportLabel(sportType: number): string {
+  return resolveSportName({ sportType }) ?? `Sport ${sportType}`;
+}
+
+export function GearView({ api }: { api: CorosLinkApi }) {
+  const { unitSystem } = useUnitSystem();
+  const unit = distanceUnit(unitSystem);
+  const [status, setStatus] = useState<CorosWatchfaceStatus | null>(null);
+  const [catalog, setCatalog] = useState<CorosGearCatalog | null>(null);
+  const [busy, setBusy] = useState<
+    "login" | "saved-login" | "query" | "save" | "logout" | null
+  >(null);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [remember, setRemember] = useState(true);
+  const [region, setRegion] = useState<CorosWatchfaceRegion>("us");
+  const [regionTouched, setRegionTouched] = useState(false);
+
+  const [name, setName] = useState("");
+  const [type, setType] = useState<CorosGearType>(1);
+  const [sportTypes, setSportTypes] = useState<number[]>([100]);
+  const [firstUseDay, setFirstUseDay] = useState(localCalendarDay);
+  const [initialDistance, setInitialDistance] = useState("0");
+  const [lifeDistance, setLifeDistance] = useState(() =>
+    String(Math.round(metersToDisplayDistance(700_000, unitSystem)))
+  );
+  const [notify, setNotify] = useState(true);
+
+  const connected = Boolean(status?.authenticated);
+  const availableSports = useMemo(
+    () =>
+      catalog?.supportedInfo.find((entry) => entry.type === type)
+        ?.sportTypeList ?? FALLBACK_SPORTS[type],
+    [catalog?.supportedInfo, type]
+  );
+
+  async function loadGear() {
+    setBusy("query");
+    setError(null);
+    try {
+      setCatalog(await api.queryCorosGear());
+    } catch (caught) {
+      setError(messageFrom(caught));
+      void api.getCorosWatchfaceStatus().then(setStatus).catch(() => undefined);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  useEffect(() => {
+    let cancelled = false;
+    void api
+      .getCorosWatchfaceStatus()
+      .then((nextStatus) => {
+        if (cancelled) return;
+        setStatus(nextStatus);
+        if (!regionTouched) {
+          setRegion(nextStatus.region ?? nextStatus.suggestedRegion);
+        }
+      })
+      .catch((caught) => {
+        if (!cancelled) setError(messageFrom(caught));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [api, regionTouched]);
+
+  useEffect(() => {
+    if (connected && catalog === null) {
+      void loadGear();
+    }
+    // `loadGear` intentionally runs once when an authenticated session appears.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connected]);
+
+  useEffect(() => {
+    setSportTypes((current) => {
+      const supported = current.filter((sport) => availableSports.includes(sport));
+      return supported.length > 0 ? supported : [availableSports[0]!];
+    });
+  }, [availableSports]);
+
+  async function handleLogin(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setBusy("login");
+    setError(null);
+    setNotice(null);
+    try {
+      const nextStatus = await api.loginCorosWatchfaces(
+        email.trim(),
+        password,
+        region,
+        remember
+      );
+      setStatus(nextStatus);
+      setPassword("");
+      setCatalog(null);
+      setNotice("COROS mobile account connected.");
+    } catch (caught) {
+      setError(messageFrom(caught));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleSavedLogin() {
+    setBusy("saved-login");
+    setError(null);
+    setNotice(null);
+    try {
+      const nextStatus = await api.loginCorosWatchfacesWithSavedCredentials(region);
+      setStatus(nextStatus);
+      setCatalog(null);
+      setNotice("COROS mobile account connected.");
+    } catch (caught) {
+      setError(messageFrom(caught));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleLogout() {
+    setBusy("logout");
+    setError(null);
+    try {
+      setStatus(await api.logoutCorosWatchfaces());
+      setCatalog(null);
+      setNotice("COROS mobile account disconnected.");
+    } catch (caught) {
+      setError(messageFrom(caught));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleSave(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setBusy("save");
+    setError(null);
+    setNotice(null);
+    try {
+      const initialValue = Number(initialDistance);
+      const lifeValue = Number(lifeDistance);
+      const nextCatalog = await api.saveCorosGear({
+        brandName: name.trim(),
+        type,
+        sportTypeList: sportTypes,
+        firstUseDay,
+        initialDistanceMeters: displayDistanceToMeters(initialValue, unitSystem),
+        lifeDistanceMeters: displayDistanceToMeters(lifeValue, unitSystem),
+        notify
+      });
+      setCatalog(nextCatalog);
+      setName("");
+      setInitialDistance("0");
+      setNotice(`${typeLabel(type)} added to your COROS account.`);
+    } catch (caught) {
+      setError(messageFrom(caught));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const loadingStatus = status === null;
+
+  return (
+    <div className="gear-view">
+      <header className="gear-header">
+        <div>
+          <p className="eyebrow">Equipment lifecycle</p>
+          <h1>Gear</h1>
+          <p>Track shoe and bike mileage in the same gear library as the COROS app.</p>
+        </div>
+        {connected ? (
+          <div className="gear-header-actions">
+            <span className="gear-connected-pill">
+              <ShieldCheck size={15} aria-hidden="true" />
+              COROS connected
+            </span>
+            <button
+              className="secondary-button"
+              type="button"
+              disabled={busy !== null}
+              onClick={() => void loadGear()}
+            >
+              {busy === "query" ? (
+                <Loader2 className="spin" size={16} aria-hidden="true" />
+              ) : (
+                <RefreshCw size={16} aria-hidden="true" />
+              )}
+              Refresh
+            </button>
+            <button
+              className="secondary-button danger-button"
+              type="button"
+              disabled={busy !== null}
+              onClick={() => void handleLogout()}
+            >
+              <LogOut size={16} aria-hidden="true" />
+              Disconnect
+            </button>
+          </div>
+        ) : null}
+      </header>
+
+      {error ? <div className="gear-message is-error" role="alert">{error}</div> : null}
+      {notice ? <div className="gear-message is-success" role="status">{notice}</div> : null}
+
+      {loadingStatus ? (
+        <section className="panel gear-loading" aria-busy="true">
+          <Loader2 className="spin" size={24} aria-hidden="true" />
+          Checking your COROS mobile session…
+        </section>
+      ) : !connected ? (
+        <section className="gear-auth-layout">
+          <div className="gear-auth-copy">
+            <span className="gear-auth-icon"><Footprints size={30} /></span>
+            <p className="eyebrow">One account, every mile</p>
+            <h2>Connect your COROS mobile account</h2>
+            <p>
+              Gear uses the mobile COROS API. The encrypted session is shared
+              with Watch Face Studio and stays on this computer.
+            </p>
+            <div className="gear-auth-points">
+              <span><Check size={16} /> Read your current gear library</span>
+              <span><Check size={16} /> Add running shoes and bikes</span>
+              <span><Check size={16} /> Set mileage alerts and activity types</span>
+            </div>
+          </div>
+
+          <form className="panel gear-auth-card" onSubmit={handleLogin}>
+            <div>
+              <p className="eyebrow">COROS sign-in</p>
+              <h2>Connect account</h2>
+            </div>
+            {status.savedCredentialsAvailable ? (
+              <button
+                className="secondary-button gear-saved-login"
+                type="button"
+                disabled={busy !== null}
+                onClick={() => void handleSavedLogin()}
+              >
+                {busy === "saved-login" ? (
+                  <Loader2 className="spin" size={16} />
+                ) : (
+                  <RefreshCw size={16} />
+                )}
+                Use saved account{status.savedEmail ? ` · ${status.savedEmail}` : ""}
+              </button>
+            ) : null}
+            <label className="field">
+              <span>Email</span>
+              <span className="gear-input-icon">
+                <Mail size={17} aria-hidden="true" />
+                <input
+                  type="email"
+                  value={email}
+                  autoComplete="username"
+                  placeholder="you@example.com"
+                  onChange={(event) => setEmail(event.target.value)}
+                />
+              </span>
+            </label>
+            <label className="field">
+              <span>Password</span>
+              <span className="gear-input-icon">
+                <LockKeyhole size={17} aria-hidden="true" />
+                <input
+                  type="password"
+                  value={password}
+                  autoComplete="current-password"
+                  placeholder="COROS password"
+                  onChange={(event) => setPassword(event.target.value)}
+                />
+              </span>
+            </label>
+            <label className="field">
+              <span>Account region</span>
+              <select
+                value={region}
+                onChange={(event) => {
+                  setRegion(event.target.value as CorosWatchfaceRegion);
+                  setRegionTouched(true);
+                }}
+              >
+                {REGION_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="gear-checkbox gear-remember">
+              <input
+                type="checkbox"
+                checked={remember}
+                onChange={(event) => setRemember(event.target.checked)}
+              />
+              <span>Save this account securely on this computer</span>
+            </label>
+            <button
+              className="primary-button"
+              type="submit"
+              disabled={busy !== null || !email.trim() || !password}
+            >
+              {busy === "login" ? (
+                <Loader2 className="spin" size={17} />
+              ) : (
+                <ShieldCheck size={17} />
+              )}
+              Connect to COROS
+            </button>
+          </form>
+        </section>
+      ) : (
+        <div className="gear-dashboard">
+          <section className="gear-library" aria-labelledby="gear-library-title">
+            <div className="gear-section-heading">
+              <div>
+                <p className="eyebrow">Your equipment</p>
+                <h2 id="gear-library-title">
+                  {catalog?.gear.length ?? 0} active{" "}
+                  {(catalog?.gear.length ?? 0) === 1 ? "item" : "items"}
+                </h2>
+              </div>
+              <Gauge size={23} aria-hidden="true" />
+            </div>
+
+            {catalog === null || busy === "query" ? (
+              <div className="panel gear-loading">
+                <Loader2 className="spin" size={22} />
+                Loading COROS gear…
+              </div>
+            ) : catalog.gear.length === 0 ? (
+              <div className="panel gear-empty">
+                <Footprints size={28} aria-hidden="true" />
+                <h3>No gear yet</h3>
+                <p>Add your first pair of shoes or bike with the form.</p>
+              </div>
+            ) : (
+              <div className="gear-card-grid">
+                {catalog.gear.map((item) => (
+                  <GearCard key={item.gearId} gear={item} unitSystem={unitSystem} />
+                ))}
+              </div>
+            )}
+          </section>
+
+          <form className="panel gear-add-card" onSubmit={handleSave}>
+            <div className="gear-add-heading">
+              <span><Plus size={20} aria-hidden="true" /></span>
+              <div>
+                <p className="eyebrow">New equipment</p>
+                <h2>Add gear</h2>
+              </div>
+            </div>
+
+            <label className="field">
+              <span>Name</span>
+              <input
+                value={name}
+                maxLength={80}
+                placeholder={type === 1 ? "Adizero Boston 13" : "Road bike"}
+                onChange={(event) => setName(event.target.value)}
+              />
+            </label>
+
+            <div className="gear-type-picker" role="group" aria-label="Gear type">
+              {([1, 2] as CorosGearType[]).map((gearType) => {
+                const Icon = gearType === 1 ? Footprints : Bike;
+                return (
+                  <button
+                    key={gearType}
+                    type="button"
+                    className={type === gearType ? "is-active" : ""}
+                    aria-pressed={type === gearType}
+                    onClick={() => setType(gearType)}
+                  >
+                    <Icon size={18} />
+                    {typeLabel(gearType)}
+                  </button>
+                );
+              })}
+            </div>
+
+            <label className="field">
+              <span>First use</span>
+              <span className="gear-input-icon">
+                <CalendarDays size={17} aria-hidden="true" />
+                <input
+                  type="date"
+                  value={firstUseDay}
+                  onChange={(event) => setFirstUseDay(event.target.value)}
+                />
+              </span>
+            </label>
+
+            <div className="gear-distance-fields">
+              <label className="field">
+                <span>Starting distance ({unit})</span>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.1"
+                  value={initialDistance}
+                  onChange={(event) => setInitialDistance(event.target.value)}
+                />
+              </label>
+              <label className="field">
+                <span>Replace after ({unit})</span>
+                <input
+                  type="number"
+                  min="0.1"
+                  step="0.1"
+                  value={lifeDistance}
+                  onChange={(event) => setLifeDistance(event.target.value)}
+                />
+              </label>
+            </div>
+
+            <fieldset className="gear-sports">
+              <legend>Count these activities</legend>
+              <div>
+                {availableSports.map((sport) => (
+                  <label className="gear-sport-chip" key={sport}>
+                    <input
+                      type="checkbox"
+                      checked={sportTypes.includes(sport)}
+                      onChange={(event) =>
+                        setSportTypes((current) =>
+                          event.target.checked
+                            ? [...current, sport]
+                            : current.filter((item) => item !== sport)
+                        )
+                      }
+                    />
+                    <span>{sportLabel(sport)}</span>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+
+            <label className="gear-checkbox">
+              <input
+                type="checkbox"
+                checked={notify}
+                onChange={(event) => setNotify(event.target.checked)}
+              />
+              <span>
+                Alert me at the replacement distance
+                <small>COROS will use this limit for its gear notification.</small>
+              </span>
+            </label>
+
+            <button
+              className="primary-button gear-save-button"
+              type="submit"
+              disabled={
+                busy !== null ||
+                !name.trim() ||
+                !firstUseDay ||
+                sportTypes.length === 0 ||
+                !Number.isFinite(Number(initialDistance)) ||
+                !Number.isFinite(Number(lifeDistance))
+              }
+            >
+              {busy === "save" ? (
+                <Loader2 className="spin" size={17} />
+              ) : (
+                <Plus size={17} />
+              )}
+              Add to COROS
+            </button>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GearCard({
+  gear,
+  unitSystem
+}: {
+  gear: CorosGear;
+  unitSystem: "metric" | "imperial";
+}) {
+  const Icon = gear.type === 1 ? Footprints : Bike;
+  const usedMeters = Math.max(
+    0,
+    gear.initialDistanceMeters + gear.realDistanceMeters
+  );
+  const progress =
+    gear.lifeDistanceMeters > 0
+      ? Math.min(100, (usedMeters / gear.lifeDistanceMeters) * 100)
+      : 0;
+  const sportNames = gear.sportTypeList.map(sportLabel);
+
+  return (
+    <article className="panel gear-card">
+      <div className="gear-card-top">
+        <span className="gear-card-icon"><Icon size={22} /></span>
+        <div>
+          <span>{typeLabel(gear.type)}</span>
+          <h3>{gear.name}</h3>
+        </div>
+        {gear.notify ? <span className="gear-alert-pill">Alert on</span> : null}
+      </div>
+      <div className="gear-distance-summary">
+        <strong>{formatDistanceValue(usedMeters, unitSystem, { digits: 1 })}</strong>
+        <span>of {formatDistanceValue(gear.lifeDistanceMeters, unitSystem, { digits: 0 })}</span>
+      </div>
+      <div
+        className="gear-progress"
+        role="progressbar"
+        aria-label={`${gear.name} lifespan`}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(progress)}
+      >
+        <span style={{ width: `${progress}%` }} />
+      </div>
+      <div className="gear-card-meta">
+        <span>Since {new Date(`${gear.firstUseDay}T00:00:00`).toLocaleDateString()}</span>
+        <span>{sportNames.join(" · ") || "No activities"}</span>
+      </div>
+    </article>
+  );
+}

--- a/src/gear/gear.css
+++ b/src/gear/gear.css
@@ -1,0 +1,503 @@
+.gear-view {
+  --gear-accent: #9be15d;
+  --gear-accent-strong: #70c63b;
+  display: grid;
+  gap: 20px;
+  width: min(1380px, 100%);
+  margin: 0 auto;
+}
+
+.gear-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 8px 2px 2px;
+}
+
+.gear-header h1 {
+  margin: 3px 0 5px;
+  font-size: clamp(30px, 4vw, 48px);
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+.gear-header p:last-child {
+  max-width: 620px;
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.gear-header-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 9px;
+}
+
+.gear-connected-pill,
+.gear-alert-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid color-mix(in srgb, var(--gear-accent) 42%, transparent);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--gear-accent) 12%, transparent);
+  color: var(--gear-accent);
+  padding: 7px 11px;
+  font-size: 12px;
+  font-weight: 750;
+}
+
+.gear-message {
+  border: 1px solid;
+  border-radius: var(--radius-sm);
+  padding: 11px 14px;
+  font-size: 13px;
+}
+
+.gear-message.is-error {
+  border-color: color-mix(in srgb, var(--danger) 40%, transparent);
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+  color: var(--danger);
+}
+
+.gear-message.is-success {
+  border-color: color-mix(in srgb, var(--gear-accent) 35%, transparent);
+  background: color-mix(in srgb, var(--gear-accent) 9%, transparent);
+  color: var(--gear-accent);
+}
+
+.gear-loading,
+.gear-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  min-height: 150px;
+  color: var(--text-secondary);
+}
+
+.gear-empty {
+  flex-direction: column;
+  text-align: center;
+}
+
+.gear-empty h3,
+.gear-empty p {
+  margin: 0;
+}
+
+.gear-auth-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(340px, 0.8fr);
+  gap: 24px;
+  min-height: min(620px, calc(100vh - 210px));
+}
+
+.gear-auth-copy {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--gear-accent) 20%, var(--glass-border));
+  border-radius: var(--radius-lg);
+  background:
+    radial-gradient(circle at 82% 22%, color-mix(in srgb, var(--gear-accent) 21%, transparent), transparent 30%),
+    linear-gradient(145deg, color-mix(in srgb, var(--gear-accent) 8%, transparent), transparent 60%),
+    var(--panel);
+  padding: clamp(34px, 6vw, 76px);
+}
+
+.gear-auth-copy::after {
+  content: "";
+  position: absolute;
+  right: -80px;
+  bottom: -150px;
+  width: 420px;
+  height: 420px;
+  border: 1px solid color-mix(in srgb, var(--gear-accent) 14%, transparent);
+  border-radius: 50%;
+  box-shadow:
+    0 0 0 55px color-mix(in srgb, var(--gear-accent) 4%, transparent),
+    0 0 0 115px color-mix(in srgb, var(--gear-accent) 2%, transparent);
+  pointer-events: none;
+}
+
+.gear-auth-icon {
+  display: grid;
+  place-items: center;
+  width: 58px;
+  height: 58px;
+  margin-bottom: 26px;
+  border-radius: 18px;
+  background: var(--gear-accent);
+  color: #102307;
+  box-shadow: 0 16px 44px color-mix(in srgb, var(--gear-accent) 20%, transparent);
+}
+
+.gear-auth-copy h2 {
+  max-width: 650px;
+  margin: 7px 0 14px;
+  font-size: clamp(30px, 4vw, 54px);
+  line-height: 1.02;
+  letter-spacing: -0.045em;
+}
+
+.gear-auth-copy > p:last-of-type {
+  max-width: 580px;
+  color: var(--text-secondary);
+  font-size: 15px;
+  line-height: 1.65;
+}
+
+.gear-auth-points {
+  z-index: 1;
+  display: grid;
+  gap: 11px;
+  margin-top: 25px;
+}
+
+.gear-auth-points span {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.gear-auth-points svg {
+  color: var(--gear-accent);
+}
+
+.gear-auth-card,
+.gear-add-card {
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: 17px;
+  padding: clamp(24px, 4vw, 38px);
+}
+
+.gear-auth-card {
+  justify-content: center;
+}
+
+.gear-auth-card h2,
+.gear-add-card h2 {
+  margin: 2px 0 0;
+}
+
+.gear-auth-card .primary-button,
+.gear-saved-login {
+  width: 100%;
+  justify-content: center;
+}
+
+.gear-input-icon {
+  position: relative;
+  display: block;
+}
+
+.gear-input-icon > svg {
+  position: absolute;
+  z-index: 1;
+  top: 50%;
+  left: 12px;
+  translate: 0 -50%;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.gear-input-icon > input {
+  width: 100%;
+  padding-left: 39px;
+}
+
+.gear-checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.gear-checkbox input {
+  margin-top: 2px;
+  accent-color: var(--gear-accent-strong);
+}
+
+.gear-checkbox span {
+  display: grid;
+  gap: 3px;
+}
+
+.gear-checkbox small {
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.gear-dashboard {
+  display: grid;
+  grid-template-columns: minmax(0, 1.55fr) minmax(330px, 0.75fr);
+  align-items: start;
+  gap: 20px;
+}
+
+.gear-library {
+  display: grid;
+  gap: 14px;
+}
+
+.gear-section-heading,
+.gear-add-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.gear-section-heading h2 {
+  margin: 3px 0 0;
+}
+
+.gear-section-heading > svg {
+  color: var(--gear-accent);
+}
+
+.gear-card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.gear-card {
+  display: grid;
+  gap: 17px;
+  min-width: 0;
+  padding: 20px;
+}
+
+.gear-card-top {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+}
+
+.gear-card-icon,
+.gear-add-heading > span {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--gear-accent) 14%, transparent);
+  color: var(--gear-accent);
+}
+
+.gear-card-top > div > span {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.gear-card h3 {
+  overflow: hidden;
+  margin: 2px 0 0;
+  font-size: 17px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gear-alert-pill {
+  padding: 5px 8px;
+  font-size: 10px;
+}
+
+.gear-distance-summary {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+}
+
+.gear-distance-summary strong {
+  font-size: 27px;
+  letter-spacing: -0.035em;
+}
+
+.gear-distance-summary span,
+.gear-card-meta {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.gear-progress {
+  overflow: hidden;
+  height: 7px;
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--text-primary) 8%, transparent);
+}
+
+.gear-progress > span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--gear-accent-strong), var(--gear-accent));
+  box-shadow: 0 0 16px color-mix(in srgb, var(--gear-accent) 35%, transparent);
+}
+
+.gear-card-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.gear-card-meta span:last-child {
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gear-add-card {
+  position: sticky;
+  top: 0;
+}
+
+.gear-add-heading {
+  justify-content: flex-start;
+  padding-bottom: 4px;
+}
+
+.gear-type-picker {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.gear-type-picker button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--text-primary) 3%, transparent);
+  color: var(--text-secondary);
+  padding: 11px 8px;
+}
+
+.gear-type-picker button.is-active {
+  border-color: color-mix(in srgb, var(--gear-accent) 44%, transparent);
+  background: color-mix(in srgb, var(--gear-accent) 12%, transparent);
+  color: var(--gear-accent);
+}
+
+.gear-distance-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.gear-sports {
+  min-width: 0;
+  margin: 0;
+  border: 0;
+  padding: 0;
+}
+
+.gear-sports legend {
+  margin-bottom: 9px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.gear-sports > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.gear-sport-chip {
+  position: relative;
+  cursor: pointer;
+}
+
+.gear-sport-chip input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.gear-sport-chip span {
+  display: block;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--text-primary) 3%, transparent);
+  color: var(--text-muted);
+  padding: 6px 9px;
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.gear-sport-chip input:checked + span {
+  border-color: color-mix(in srgb, var(--gear-accent) 40%, transparent);
+  background: color-mix(in srgb, var(--gear-accent) 11%, transparent);
+  color: var(--gear-accent);
+}
+
+.gear-sport-chip input:focus-visible + span {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.gear-save-button {
+  justify-content: center;
+  margin-top: 2px;
+}
+
+:root[data-theme="paper"] .gear-view {
+  --gear-accent: #438c1d;
+  --gear-accent-strong: #327214;
+}
+
+@media (max-width: 1080px) {
+  .gear-dashboard,
+  .gear-auth-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .gear-add-card {
+    position: static;
+  }
+}
+
+@media (max-width: 720px) {
+  .gear-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .gear-header-actions {
+    justify-content: flex-start;
+  }
+
+  .gear-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gear-distance-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .gear-auth-copy {
+    padding: 30px 24px;
+  }
+}

--- a/src/media/LibraryPanels.tsx
+++ b/src/media/LibraryPanels.tsx
@@ -1,14 +1,23 @@
-import { useDeferredValue, useMemo, useState, type ReactNode } from "react";
+import {
+  useDeferredValue,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
 import {
   ArrowDown,
   ArrowUp,
   ArrowUpDown,
+  Cable,
   CheckCircle2,
+  HardDrive,
   Loader2,
   Music,
   Search,
   Trash2,
   Upload,
+  Watch,
   X,
 } from "lucide-react";
 import type { LocalTrack, WatchStatus, WatchTrack } from "../../electron/types";
@@ -26,7 +35,6 @@ type SortDirection = "asc" | "desc";
 type LocalLibrarySortKey = "title" | "size" | "created" | "status";
 type WatchLibrarySortKey = "name" | "size" | "modified";
 type LocalTrackFilter = "all" | "pending" | "synced";
-type WatchTrackFilter = "all" | "selected";
 
 interface SortState<Key extends string> {
   key: Key;
@@ -165,6 +173,7 @@ interface LibrarySyncLayoutProps {
   pendingCount: number;
   localCount: number;
   watchConnected: boolean;
+  syncing?: boolean;
 }
 
 export function LibrarySyncLayout({
@@ -173,6 +182,7 @@ export function LibrarySyncLayout({
   pendingCount,
   localCount,
   watchConnected,
+  syncing = false,
 }: LibrarySyncLayoutProps) {
   return (
     <div className="library-sync-grid">
@@ -181,38 +191,69 @@ export function LibrarySyncLayout({
         pendingCount={pendingCount}
         localCount={localCount}
         watchConnected={watchConnected}
+        syncing={syncing}
       />
       {watchPanel}
     </div>
   );
 }
 
+type ConnectorState = "disconnected" | "syncing" | "pending" | "ready" | "idle";
+
 function LibraryConnector({
   pendingCount,
   localCount,
   watchConnected,
+  syncing,
 }: {
   pendingCount: number;
   localCount: number;
   watchConnected: boolean;
+  syncing: boolean;
 }) {
-  let label = watchConnected ? "Watch connected" : "Connect watch";
-  if (watchConnected && pendingCount > 0) {
-    label = `${pendingCount} to sync`;
-  } else if (watchConnected && pendingCount === 0 && localCount > 0) {
-    label = "All synced";
+  let state: ConnectorState = "idle";
+  if (!watchConnected) {
+    state = "disconnected";
+  } else if (syncing) {
+    state = "syncing";
+  } else if (pendingCount > 0) {
+    state = "pending";
+  } else if (localCount > 0) {
+    state = "ready";
   }
 
+  const label =
+    state === "disconnected"
+      ? "Connect watch"
+      : state === "syncing"
+        ? "Syncing…"
+        : state === "pending"
+          ? `${pendingCount} to sync`
+          : state === "ready"
+            ? "All synced"
+            : "Watch connected";
+
+  const Icon =
+    state === "disconnected"
+      ? Cable
+      : state === "syncing"
+        ? Loader2
+        : state === "ready"
+          ? CheckCircle2
+          : Watch;
+
   return (
-    <div className="library-connector" aria-hidden="true">
+    <div
+      className={`library-connector${state === "syncing" ? " is-syncing" : ""}`}
+      aria-hidden="true"
+    >
       <span className="library-connector-line" />
-      <span
-        className={
-          watchConnected && pendingCount === 0
-            ? "library-connector-pill ready"
-            : "library-connector-pill"
-        }
-      >
+      <span className={`library-connector-pill library-connector-pill--${state}`}>
+        <Icon
+          size={13}
+          className={state === "syncing" ? "spin" : undefined}
+          aria-hidden="true"
+        />
         {label}
       </span>
       <span className="library-connector-line" />
@@ -422,68 +463,6 @@ export function LocalLibraryPanel({
         </em>
       </header>
 
-      <div className="library-panel-actions">
-        {someSelected ? (
-          <div className="library-bulk-actions">
-            {pendingSelectedTracks.length > 0 ? (
-              <button
-                className="primary-button compact-button"
-                type="button"
-                disabled={!watchConnected || isTransferring || isDeletingLocal}
-                onClick={handleBulkTransfer}
-              >
-                {busy === "transfer-selected" ? (
-                  <Loader2 className="spin" size={17} aria-hidden="true" />
-                ) : (
-                  <Upload size={17} aria-hidden="true" />
-                )}
-                Transfer selected ({pendingSelectedTracks.length})
-              </button>
-            ) : null}
-            <button
-              className="secondary-button compact-button danger-button"
-              type="button"
-              disabled={isDeletingLocal || isTransferring}
-              onClick={handleBulkDelete}
-            >
-              {busy === "delete-local-bulk" ? (
-                <Loader2 className="spin" size={17} aria-hidden="true" />
-              ) : (
-                <Trash2 size={17} aria-hidden="true" />
-              )}
-              Delete selected ({selectedIds.size})
-            </button>
-          </div>
-        ) : canTransferAll ? (
-          <button
-            className="primary-button compact-button"
-            type="button"
-            disabled={isTransferring}
-            onClick={onTransferAll}
-          >
-            {busy === "transfer-all" ? (
-              <Loader2 className="spin" size={17} aria-hidden="true" />
-            ) : (
-              <Upload size={17} aria-hidden="true" />
-            )}
-            Transfer all ({pendingLocalCount})
-          </button>
-        ) : (
-          <span className="library-panel-hint">
-            {downloads.length === 0
-              ? "Download tracks from YouTube or Spotify"
-              : pendingLocalCount === 0
-                ? (
-                    <span className="library-sync-indicator">
-                      <CheckCircle2 size={15} aria-hidden="true" />
-                      All synced
-                    </span>
-                  )
-                : `${pendingLocalCount} not on watch`}
-          </span>
-        )}
-      </div>
-
       {transferProgress ? (
         <div
           className="library-transfer-progress"
@@ -555,33 +534,32 @@ export function LocalLibraryPanel({
               </button>
             ))}
           </div>
-        </div>
-      ) : null}
-
-      {downloads.length > 0 ? (
-        <div className="library-selection-bar">
-          <label className="library-select-all">
-            <input
-              type="checkbox"
-              aria-label="Select visible local tracks"
-              checked={allVisibleSelected}
-              disabled={visibleLocalItems.length === 0}
-              onChange={handleSelectVisible}
-            />
-            Select visible
-          </label>
-          {someSelected ? (
-            <div className="library-selection-meta">
-              <span>
-                {selectedTracks.length} selected · {formatBytes(selectedSize)}
-              </span>
-              <button
-                className="library-selection-clear"
-                type="button"
-                onClick={onClearSelection}
-              >
-                Clear
-              </button>
+          {!someSelected ? (
+            <div className="library-panel-cta">
+              {canTransferAll ? (
+                <button
+                  className="primary-button compact-button"
+                  type="button"
+                  disabled={isTransferring}
+                  onClick={onTransferAll}
+                >
+                  {busy === "transfer-all" ? (
+                    <Loader2 className="spin" size={17} aria-hidden="true" />
+                  ) : (
+                    <Upload size={17} aria-hidden="true" />
+                  )}
+                  Transfer all ({pendingLocalCount})
+                </button>
+              ) : pendingLocalCount === 0 ? (
+                <span className="library-sync-indicator">
+                  <CheckCircle2 size={15} aria-hidden="true" />
+                  All synced
+                </span>
+              ) : (
+                <span className="library-pending-chip">
+                  {pendingLocalCount} pending
+                </span>
+              )}
             </div>
           ) : null}
         </div>
@@ -589,7 +567,15 @@ export function LocalLibraryPanel({
 
       {visibleLocalItems.length > 0 ? (
         <div className="library-track-header">
-          <span />
+          <span className="library-header-select">
+            <input
+              type="checkbox"
+              aria-label="Select visible local tracks"
+              checked={allVisibleSelected}
+              disabled={visibleLocalItems.length === 0}
+              onChange={handleSelectVisible}
+            />
+          </span>
           <span />
           <SortButton
             label="Track"
@@ -635,9 +621,22 @@ export function LocalLibraryPanel({
         </div>
       ) : null}
 
-      <div className="library-track-stack">
+      <div
+        className={
+          someSelected
+            ? "library-track-stack has-selection-fab"
+            : "library-track-stack"
+        }
+      >
         {visibleLocalItems.length === 0 ? (
-          <LibraryEmptyState title={emptyTitle()} />
+          <LibraryEmptyState
+            title={emptyTitle()}
+            subtitle={
+              downloads.length === 0
+                ? "Download tracks from YouTube or Spotify to get started"
+                : undefined
+            }
+          />
         ) : (
           visibleLocalItems.map(({ track, fileName, onWatch }) => {
             const selected = selectedIds.has(track.id);
@@ -646,6 +645,7 @@ export function LocalLibraryPanel({
               <div
                 key={track.id}
                 className={selected ? "library-track-row is-selected" : "library-track-row"}
+                onClick={() => onToggleSelect(track.id)}
               >
                 <input
                   type="checkbox"
@@ -653,10 +653,15 @@ export function LocalLibraryPanel({
                   aria-label={`Select ${track.title}`}
                   checked={selected}
                   onChange={() => onToggleSelect(track.id)}
+                  onClick={(event) => event.stopPropagation()}
                 />
                 <div
-                  className="track-avatar"
-                  style={{ backgroundColor: trackAvatarColor(track.title) }}
+                  className="track-avatar track-avatar--library"
+                  style={
+                    {
+                      "--track-color": trackAvatarColor(track.title),
+                    } as CSSProperties
+                  }
                   aria-hidden="true"
                 >
                   {trackInitial(track.title)}
@@ -668,11 +673,17 @@ export function LocalLibraryPanel({
                 <span className="library-track-size">{formatBytes(track.sizeBytes)}</span>
                 <span className="library-track-date">{formatDate(track.createdAt)}</span>
                 <span
-                  className={onWatch ? "badge ready library-track-status" : "badge library-track-status"}
+                  className={
+                    onWatch ? "library-status is-synced" : "library-status"
+                  }
                 >
-                  {onWatch ? "Synced" : "Not synced"}
+                  <span className="library-status-dot" aria-hidden="true" />
+                  {onWatch ? "Synced" : "Pending"}
                 </span>
-                <div className="library-track-actions">
+                <div
+                  className="library-track-actions"
+                  onClick={(event) => event.stopPropagation()}
+                >
                   <button
                     className="icon-button"
                     type="button"
@@ -710,6 +721,55 @@ export function LocalLibraryPanel({
           })
         )}
       </div>
+
+      {someSelected ? (
+        <div
+          className="library-selection-fab"
+          role="toolbar"
+          aria-label="Local track selection actions"
+        >
+          <span className="library-selection-fab-meta">
+            {selectedTracks.length} selected · {formatBytes(selectedSize)}
+          </span>
+          {pendingSelectedTracks.length > 0 ? (
+            <button
+              className="primary-button compact-button"
+              type="button"
+              disabled={!watchConnected || isTransferring || isDeletingLocal}
+              onClick={handleBulkTransfer}
+            >
+              {busy === "transfer-selected" ? (
+                <Loader2 className="spin" size={16} aria-hidden="true" />
+              ) : (
+                <Upload size={16} aria-hidden="true" />
+              )}
+              Transfer ({pendingSelectedTracks.length})
+            </button>
+          ) : null}
+          <button
+            className="secondary-button compact-button danger-button"
+            type="button"
+            disabled={isDeletingLocal || isTransferring}
+            onClick={handleBulkDelete}
+          >
+            {busy === "delete-local-bulk" ? (
+              <Loader2 className="spin" size={16} aria-hidden="true" />
+            ) : (
+              <Trash2 size={16} aria-hidden="true" />
+            )}
+            Delete
+          </button>
+          <button
+            className="icon-button library-selection-fab-close"
+            type="button"
+            title="Clear selection"
+            aria-label="Clear selection"
+            onClick={onClearSelection}
+          >
+            <X size={15} aria-hidden="true" />
+          </button>
+        </div>
+      ) : null}
     </section>
   );
 }
@@ -738,7 +798,6 @@ export function WatchLibraryPanel({
   onDeleteWatchTracks,
 }: WatchLibraryPanelProps) {
   const [searchQuery, setSearchQuery] = useState("");
-  const [trackFilter, setTrackFilter] = useState<WatchTrackFilter>("all");
   const [sort, setSort] = useState<SortState<WatchLibrarySortKey>>({
     key: "name",
     direction: "asc",
@@ -766,19 +825,12 @@ export function WatchLibraryPanel({
   const totalSize = useMemo(() => sumBytes(watchTracks), [watchTracks]);
   const selectedSize = useMemo(() => sumBytes(selectedTracks), [selectedTracks]);
   const visibleWatchItems = useMemo(() => {
-    const filtered = watchTrackItems.filter((item) => {
-      if (
-        trackFilter === "selected" &&
-        !selectedPaths.has(item.track.relativePath)
-      ) {
-        return false;
-      }
-
-      return searchTextMatchesTerms(item.searchText, searchTerms);
-    });
+    const filtered = watchTrackItems.filter((item) =>
+      searchTextMatchesTerms(item.searchText, searchTerms),
+    );
 
     return sortWatchTrackItems(filtered, sort);
-  }, [searchTerms, selectedPaths, sort, trackFilter, watchTrackItems]);
+  }, [searchTerms, sort, watchTrackItems]);
   const visibleWatchTracks = useMemo(
     () => visibleWatchItems.map(({ track }) => track),
     [visibleWatchItems],
@@ -802,19 +854,6 @@ export function WatchLibraryPanel({
     visibleWatchTracks.length === watchTracks.length
       ? `${watchTracks.length} track${watchTracks.length === 1 ? "" : "s"}`
       : `${visibleWatchTracks.length}/${watchTracks.length} tracks`;
-  const storageLabel =
-    watchStatus?.usedBytes != null
-      ? `${formatBytes(watchStatus.usedBytes)} used`
-      : formatBytes(totalSize);
-  const filterOptions: Array<{
-    value: WatchTrackFilter;
-    label: string;
-    count: number;
-  }> = [
-    { value: "all", label: "All", count: watchTracks.length },
-    { value: "selected", label: "Selected", count: selectedTracks.length },
-  ];
-
   function handleBulkDelete() {
     if (selectedTracks.length === 0) {
       return;
@@ -841,9 +880,6 @@ export function WatchLibraryPanel({
     if (searchTerms.length > 0) {
       return "No matching watch tracks";
     }
-    if (trackFilter === "selected") {
-      return "No selected watch tracks";
-    }
 
     return "No MP3 files on the watch";
   }
@@ -860,43 +896,19 @@ export function WatchLibraryPanel({
           <p className="eyebrow">{presentation.displayName}</p>
           <h3>On watch</h3>
         </div>
-        <em>
-          {watchConnected
-            ? `${countLabel} · ${storageLabel}`
-            : "Not connected"}
-        </em>
+        <em>{watchConnected ? countLabel : "Not connected"}</em>
       </header>
 
-      <div className="library-panel-actions">
-        {someSelected ? (
-          <button
-            className="secondary-button danger-button"
-            type="button"
-            disabled={isDeletingWatch}
-            onClick={handleBulkDelete}
-          >
-            {busy === "delete-watch-bulk" ? (
-              <Loader2 className="spin" size={17} aria-hidden="true" />
-            ) : (
-              <Trash2 size={17} aria-hidden="true" />
-            )}
-            Delete selected ({selectedPaths.size})
-          </button>
-        ) : (
-          <span className="library-panel-hint">
-            {!watchConnected
-              ? presentation.connectHint || "Connect your watch via USB"
-              : watchTracks.length === 0
-                ? "No MP3 files on the watch"
-                : "Select tracks to delete from watch"}
-          </span>
-        )}
-      </div>
+      {watchConnected && watchTracks.length > 0 ? (
+        <WatchStorageMeter watchStatus={watchStatus} tracksSize={totalSize} />
+      ) : null}
 
       {!watchConnected ? (
         <LibraryEmptyState
           title={emptyTitle()}
-          subtitle="to view and manage your music"
+          subtitle={
+            presentation.connectHint || "to view and manage your music"
+          }
           variant="watch"
         />
       ) : watchTracks.length > 0 ? (
@@ -922,53 +934,18 @@ export function WatchLibraryPanel({
                 </button>
               ) : null}
             </div>
-            <div className="library-filter-group" aria-label="Watch track filter">
-              {filterOptions.map((option) => (
-                <button
-                  key={option.value}
-                  className={
-                    trackFilter === option.value
-                      ? "library-filter-option active"
-                      : "library-filter-option"
-                  }
-                  type="button"
-                  onClick={() => setTrackFilter(option.value)}
-                >
-                  <span>{option.label}</span>
-                  <small>{option.count}</small>
-                </button>
-              ))}
-            </div>
-          </div>
-          <div className="library-selection-bar">
-            <label className="library-select-all">
-              <input
-                type="checkbox"
-                aria-label="Select visible watch tracks"
-                checked={allVisibleSelected}
-                disabled={visibleWatchTracks.length === 0}
-                onChange={handleSelectVisible}
-              />
-              Select visible
-            </label>
-            {someSelected ? (
-              <div className="library-selection-meta">
-                <span>
-                  {selectedTracks.length} selected · {formatBytes(selectedSize)}
-                </span>
-                <button
-                  className="library-selection-clear"
-                  type="button"
-                  onClick={onClearSelection}
-                >
-                  Clear
-                </button>
-              </div>
-            ) : null}
           </div>
           {visibleWatchTracks.length > 0 ? (
             <div className="library-track-header">
-              <span />
+              <span className="library-header-select">
+                <input
+                  type="checkbox"
+                  aria-label="Select visible watch tracks"
+                  checked={allVisibleSelected}
+                  disabled={visibleWatchTracks.length === 0}
+                  onChange={handleSelectVisible}
+                />
+              </span>
               <span />
               <SortButton
                 label="Track"
@@ -1000,11 +977,16 @@ export function WatchLibraryPanel({
                   )
                 }
               />
-              <span>Status</span>
               <span />
             </div>
           ) : null}
-          <div className="library-track-stack">
+          <div
+            className={
+              someSelected
+                ? "library-track-stack has-selection-fab"
+                : "library-track-stack"
+            }
+          >
             {visibleWatchTracks.length === 0 ? (
               <LibraryEmptyState title={emptyTitle()} />
             ) : (
@@ -1017,6 +999,7 @@ export function WatchLibraryPanel({
                     className={
                       selected ? "library-track-row is-selected" : "library-track-row"
                     }
+                    onClick={() => onToggleSelect(track.relativePath)}
                   >
                     <input
                       type="checkbox"
@@ -1024,16 +1007,21 @@ export function WatchLibraryPanel({
                       aria-label={`Select ${track.name}`}
                       checked={selected}
                       onChange={() => onToggleSelect(track.relativePath)}
+                      onClick={(event) => event.stopPropagation()}
                     />
-                    <div className="track-avatar track-avatar--watch" aria-hidden="true" />
+                    <div className="track-avatar track-avatar--watch" aria-hidden="true">
+                      <Music size={15} aria-hidden="true" />
+                    </div>
                     <span className="library-track-meta">
                       <strong>{track.name}</strong>
                       <small>{track.relativePath}</small>
                     </span>
                     <span className="library-track-size">{formatBytes(track.sizeBytes)}</span>
                     <span className="library-track-date">{formatDate(track.modifiedAt)}</span>
-                    <span className="badge ready library-track-status">On watch</span>
-                    <div className="library-track-actions">
+                    <div
+                      className="library-track-actions"
+                      onClick={(event) => event.stopPropagation()}
+                    >
                       <button
                         className="icon-button danger"
                         type="button"
@@ -1053,11 +1041,86 @@ export function WatchLibraryPanel({
               })
             )}
           </div>
+
+          {someSelected ? (
+            <div
+              className="library-selection-fab"
+              role="toolbar"
+              aria-label="Watch track selection actions"
+            >
+              <span className="library-selection-fab-meta">
+                {selectedTracks.length} selected · {formatBytes(selectedSize)}
+              </span>
+              <button
+                className="secondary-button compact-button danger-button"
+                type="button"
+                disabled={isDeletingWatch}
+                onClick={handleBulkDelete}
+              >
+                {busy === "delete-watch-bulk" ? (
+                  <Loader2 className="spin" size={16} aria-hidden="true" />
+                ) : (
+                  <Trash2 size={16} aria-hidden="true" />
+                )}
+                Delete
+              </button>
+              <button
+                className="icon-button library-selection-fab-close"
+                type="button"
+                title="Clear selection"
+                aria-label="Clear selection"
+                onClick={onClearSelection}
+              >
+                <X size={15} aria-hidden="true" />
+              </button>
+            </div>
+          ) : null}
         </>
       ) : (
         <LibraryEmptyState title={emptyTitle()} />
       )}
     </section>
+  );
+}
+
+function WatchStorageMeter({
+  watchStatus,
+  tracksSize,
+}: {
+  watchStatus: WatchStatus | null;
+  tracksSize: number;
+}) {
+  const totalBytes = watchStatus?.totalBytes;
+  if (!totalBytes || totalBytes <= 0) {
+    return null;
+  }
+
+  const usedBytes = watchStatus?.usedBytes ?? tracksSize;
+  const percent = Math.min(100, Math.round((usedBytes / totalBytes) * 100));
+
+  return (
+    <div className="watch-storage">
+      <div className="watch-storage-meta">
+        <HardDrive size={13} aria-hidden="true" />
+        <span>
+          {formatBytes(usedBytes)} of {formatBytes(totalBytes)} used
+        </span>
+        <em>{percent}%</em>
+      </div>
+      <div
+        className="watch-storage-track"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={percent}
+        aria-label="Watch storage used"
+      >
+        <div
+          className="watch-storage-bar"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+    </div>
   );
 }
 
@@ -1172,7 +1235,9 @@ function LibraryEmptyState({
       {variant === "watch" ? (
         <WatchConnectIllustration />
       ) : (
-        <Music size={24} aria-hidden="true" />
+        <span className="library-empty-icon">
+          <Music size={22} aria-hidden="true" />
+        </span>
       )}
       <strong>{title}</strong>
       {subtitle ? (

--- a/src/navigation/primaryNav.ts
+++ b/src/navigation/primaryNav.ts
@@ -4,6 +4,7 @@ import {
   CalendarDays,
   Database,
   Dumbbell,
+  Footprints,
   LayoutGrid,
   Map as MapIcon,
   MessageCircle,
@@ -17,6 +18,7 @@ export type PrimaryView =
   | "overview"
   | "media"
   | "training"
+  | "gear"
   | "library"
   | "strength"
   | "data"
@@ -32,6 +34,8 @@ export interface PrimaryNavItem {
   icon: LucideIcon;
   beta?: boolean;
   showActivity?: boolean;
+  /** Shown only while the development build's Dev view is active. */
+  developmentOnly?: boolean;
   /** Hidden from the startup-view picker (e.g. Settings). */
   excludeFromStartup?: boolean;
 }
@@ -42,6 +46,14 @@ export const PRIMARY_NAV_ITEMS: PrimaryNavItem[] = [
   { id: "maps", label: "Maps", icon: MapIcon, beta: true },
   { id: "watchfaces", label: "Watch Faces", icon: Watch, beta: true },
   { id: "training", label: "Training Hub", icon: Activity },
+  ...(import.meta.env.DEV
+    ? [{
+        id: "gear" as const,
+        label: "Gear",
+        icon: Footprints,
+        developmentOnly: true,
+      }]
+    : []),
   { id: "library", label: "Training Library", icon: BookOpen },
   { id: "strength", label: "Strength", icon: Dumbbell, beta: true },
   { id: "calendar", label: "Calendar", icon: CalendarDays },
@@ -59,6 +71,14 @@ export const PRIMARY_NAV_ITEMS: PrimaryNavItem[] = [
     excludeFromStartup: true,
   },
 ];
+
+export function visiblePrimaryNavItems(
+  showDevelopmentItems: boolean,
+): PrimaryNavItem[] {
+  return PRIMARY_NAV_ITEMS.filter(
+    (item) => !item.developmentOnly || showDevelopmentItems,
+  );
+}
 
 export const SIDEBAR_EXPANDED_WIDTH = 248;
 export const SIDEBAR_COLLAPSED_WIDTH = 72;

--- a/src/strength/StrengthView.tsx
+++ b/src/strength/StrengthView.tsx
@@ -24,6 +24,7 @@ import {
   ChevronRight,
   ExternalLink,
   FlaskConical,
+  Info,
   Link2,
   Loader2,
   LockKeyhole,
@@ -689,6 +690,11 @@ export function StrengthView({
     WINDOW_OPTIONS.find((option) => option.days === days) ?? WINDOW_OPTIONS[1];
   const summary = analytics.summary;
   const hasSessions = summary.sessions > 0;
+  const attributedSetCount = Math.round(analytics.attributedSets);
+  const genericSetCount = Math.round(analytics.genericSets);
+  const workingSetCount = Math.round(
+    analytics.attributedSets + analytics.genericSets + analytics.unmappedSets
+  );
   // A history of dips and pull-ups carries no load, so the page switches to
   // counting sets rather than showing a column of zeroes.
   const usesWeights = summary.volumeKg > 0;
@@ -1163,6 +1169,17 @@ export function StrengthView({
         </p>
       ) : null}
 
+      {hasSessions && genericSetCount > 0 ? (
+        <p className="strength-notice is-attribution" role="note">
+          <Info size={15} aria-hidden="true" />
+          <span>
+            {`COROS recorded ${genericSetCount.toLocaleString()} working ${
+              genericSetCount === 1 ? "set" : "sets"
+            } only as Full Body, so ${genericSetCount === 1 ? "it is" : "they are"} excluded from the map. Specific attribution is available for ${attributedSetCount.toLocaleString()} of ${workingSetCount.toLocaleString()} working sets.`}
+          </span>
+        </p>
+      ) : null}
+
       {sampleButton && !sampleMode ? (
         <div className="strength-sample-cta">{sampleButton}</div>
       ) : null}
@@ -1247,16 +1264,33 @@ export function StrengthView({
         </section>
 
         <section className="panel strength-muscle-panel">
-          <MusclePanel
-            muscles={analytics.muscles}
-            muscleById={analytics.muscleById}
-            metric={metric}
-            max={heatMax}
-            active={panelMuscle}
-            onSelect={selectMuscle}
-            onHover={setListHover}
-            unitSystem={unitSystem}
-          />
+          {hasSessions && workingSetCount > 0 && analytics.attributedSets <= 0 ? (
+            <div className="muscle-panel is-unattributed">
+              <span className="muscle-panel-unattributed-icon" aria-hidden="true">
+                <Info size={22} />
+              </span>
+              <p className="eyebrow">Muscle attribution</p>
+              <h3>No specific muscle data</h3>
+              <p>
+                {genericSetCount > 0
+                  ? `COROS recorded ${genericSetCount.toLocaleString()} working ${
+                      genericSetCount === 1 ? "set" : "sets"
+                    } only as Full Body. Session totals remain available, but the map stays neutral because no specific muscles were identified.`
+                  : "None of the exercises in this window could be matched to specific muscles. Session totals remain available, but the map stays neutral."}
+              </p>
+            </div>
+          ) : (
+            <MusclePanel
+              muscles={analytics.muscles}
+              muscleById={analytics.muscleById}
+              metric={metric}
+              max={heatMax}
+              active={panelMuscle}
+              onSelect={selectMuscle}
+              onHover={setListHover}
+              unitSystem={unitSystem}
+            />
+          )}
         </section>
       </div>
 
@@ -1594,6 +1628,9 @@ export function StrengthView({
                   <p className="strength-mix-note">
                     Helper muscles count for part of a set, so a bench press
                     mostly counts as pushing.
+                    {analytics.genericSets > 0
+                      ? " COROS Full Body sets are left out because they do not identify a specific muscle."
+                      : ""}
                     {analytics.mobilitySets > 0 || analytics.unmappedSets > 0
                       ? " Warm-ups, stretching and moves we don't recognise are left out."
                       : ""}

--- a/src/strength/muscles.ts
+++ b/src/strength/muscles.ts
@@ -190,6 +190,8 @@ export interface ExerciseTargets {
   activations: MuscleActivation[];
   /** Stretching, foam rolling and warm-up drills carry no training credit. */
   mobility: boolean;
+  /** The provider supplied only a non-anatomical label such as "Full Body". */
+  generic: boolean;
 }
 
 interface MuscleRule {
@@ -209,7 +211,6 @@ const SECONDARY_WEIGHT = 0.45;
  */
 const MUSCLE_RULES: MuscleRule[] = [
   // ---- Body regions reported by unstructured (free) strength sessions ----
-  { match: /^full body$/, primary: ["chest", "lats", "quads", "glutes"], secondary: ["shoulders", "abs", "hamstrings"] },
   { match: /^shoulders$/, primary: ["shoulders"], secondary: ["traps"] },
   { match: /^arms$/, primary: ["biceps", "triceps"], secondary: ["forearms"] },
   { match: /^chest$/, primary: ["chest"], secondary: ["triceps", "shoulders"] },
@@ -385,7 +386,29 @@ function normalizeExerciseName(name: string): string {
 
 const targetsCache = new Map<string, ExerciseTargets>();
 
-const NO_TARGETS: ExerciseTargets = { activations: [], mobility: false };
+const NO_TARGETS: ExerciseTargets = {
+  activations: [],
+  mobility: false,
+  generic: false
+};
+
+const GENERIC_TARGETS: ExerciseTargets = {
+  activations: [],
+  mobility: false,
+  generic: true
+};
+
+/**
+ * COROS uses S4208 for unstructured segments it can only describe as "Full
+ * Body". That label is useful for display, but it contains no evidence that a
+ * particular anatomical muscle was trained.
+ */
+export function resolveCorosExerciseTargets(
+  nameKey: string,
+  displayName: string
+): ExerciseTargets {
+  return nameKey === "S4208" ? GENERIC_TARGETS : resolveExerciseTargets(displayName);
+}
 
 const HEVY_GROUPS: Record<string, MuscleId[]> = {
   abdominals: ["abs"],
@@ -427,6 +450,7 @@ export function resolveProviderMuscleTargets(
     ? NO_TARGETS
     : {
         mobility: false,
+        generic: false,
         activations: [...weights.entries()].map(([muscle, weight]) => ({
           muscle,
           share: weight / total
@@ -454,7 +478,7 @@ export function resolveExerciseTargets(name: string): ExerciseTargets {
   let resolved: ExerciseTargets = NO_TARGETS;
 
   if (rule?.mobility) {
-    resolved = { activations: [], mobility: true };
+    resolved = { activations: [], mobility: true, generic: false };
   } else if (rule) {
     const weights = new Map<MuscleId, number>();
     for (const muscle of rule.primary ?? []) {
@@ -467,6 +491,7 @@ export function resolveExerciseTargets(name: string): ExerciseTargets {
     if (total > 0) {
       resolved = {
         mobility: false,
+        generic: false,
         activations: [...weights.entries()].map(([muscle, weight]) => ({
           muscle,
           share: weight / total

--- a/src/strength/strength.css
+++ b/src/strength/strength.css
@@ -498,6 +498,16 @@
   color: var(--warning-text);
 }
 
+.strength-notice.is-attribution {
+  align-items: flex-start;
+  line-height: 1.45;
+}
+
+.strength-notice.is-attribution svg {
+  flex: 0 0 auto;
+  margin-top: 2px;
+}
+
 .strength-notice.is-sample button {
   margin-left: auto;
   padding: 0;
@@ -1112,6 +1122,45 @@
   gap: 12px;
   width: 100%;
   min-height: 0;
+}
+
+.muscle-panel.is-unattributed {
+  align-items: center;
+  justify-content: center;
+  max-width: 36ch;
+  margin: auto;
+  padding: 36px 18px;
+  text-align: center;
+}
+
+.muscle-panel-unattributed-icon {
+  display: inline-grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  border: 1px solid var(--glass-border);
+  border-radius: 50%;
+  background: var(--sx-well);
+  color: var(--text-secondary);
+}
+
+.muscle-panel.is-unattributed .eyebrow,
+.muscle-panel.is-unattributed h3,
+.muscle-panel.is-unattributed p {
+  margin: 0;
+}
+
+.muscle-panel.is-unattributed h3 {
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: 22px;
+  letter-spacing: -0.025em;
+}
+
+.muscle-panel.is-unattributed > p:last-child {
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.55;
 }
 
 .muscle-panel-head {

--- a/src/strength/strengthAnalytics.ts
+++ b/src/strength/strengthAnalytics.ts
@@ -17,7 +17,7 @@ import { resolveExerciseName } from "../training/exerciseNames";
 import { kilogramsToDisplayWeight, weightUnit } from "../units/units";
 import {
   MUSCLES,
-  resolveExerciseTargets,
+  resolveCorosExerciseTargets,
   resolveProviderMuscleTargets,
   type MuscleId
 } from "./muscles";
@@ -130,6 +130,10 @@ export interface StrengthAnalytics {
   balance: PatternBalance;
   /** Credited sets that went to warm-ups, stretching or foam rolling. */
   mobilitySets: number;
+  /** Working sets assigned to at least one specific muscle. */
+  attributedSets: number;
+  /** COROS sets reported only as the non-anatomical S4208 "Full Body" label. */
+  genericSets: number;
   /** Sets whose exercise name has no muscle mapping. */
   unmappedSets: number;
 }
@@ -243,8 +247,8 @@ function exerciseDisplayName(nameKey: string, rawName: string | undefined): stri
 }
 
 function exerciseTargets(exercise: StrengthExercise, name: string) {
-  const named = resolveExerciseTargets(name);
-  if (named.mobility || named.activations.length > 0) return named;
+  const named = resolveCorosExerciseTargets(exercise.nameKey, name);
+  if (named.mobility || named.generic || named.activations.length > 0) return named;
   return resolveProviderMuscleTargets(
     exercise.primaryMuscleGroup,
     exercise.secondaryMuscleGroups
@@ -274,6 +278,8 @@ export function buildStrengthAnalytics(
   let totalTrainingLoad = 0;
   let totalCalories = 0;
   let mobilitySets = 0;
+  let attributedSets = 0;
+  let genericSets = 0;
   let unmappedSets = 0;
   let heaviestLift: StrengthSummaryStats["heaviestLift"];
   let bestE1rm: StrengthSummaryStats["bestE1rm"];
@@ -339,10 +345,15 @@ export function buildStrengthAnalytics(
         mobilitySets += setCount;
         continue;
       }
+      if (targets.generic) {
+        genericSets += setCount;
+        continue;
+      }
       if (targets.activations.length === 0) {
         unmappedSets += setCount;
         continue;
       }
+      attributedSets += setCount;
 
       if (topWeightKg > (heaviestLift?.weightKg ?? 0)) {
         heaviestLift = { name, weightKg: topWeightKg, reps: topWeightReps, at };
@@ -503,6 +514,8 @@ export function buildStrengthAnalytics(
     weeks: weekList,
     balance,
     mobilitySets,
+    attributedSets,
+    genericSets,
     unmappedSets
   };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -6627,6 +6627,14 @@ td span {
   box-shadow: 0 18px 44px rgba(0, 0, 0, 0.5);
 }
 
+/* Form dropdowns inside scrollable dialogs escape their clipping containers. */
+.app-select-menu.is-portaled {
+  position: fixed;
+  z-index: 420;
+  right: auto;
+  bottom: auto;
+}
+
 .app-select-option {
   display: flex;
   align-items: center;
@@ -23950,6 +23958,19 @@ tr.data-intervals-row-missing {
   font-size: 13px;
 }
 
+.calendar-field > .app-select,
+.calendar-builder-control > .app-select {
+  width: 100%;
+}
+
+.calendar-field > .app-select .app-select-trigger,
+.calendar-builder-control > .app-select .app-select-trigger {
+  min-height: 40px;
+  padding: 9px 12px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
 .calendar-field input:focus,
 .calendar-field select:focus,
 .calendar-field textarea:focus,
@@ -26725,6 +26746,27 @@ tr.data-intervals-row-missing {
   background: var(--glass-bg-hover);
 }
 
+.calendar-builder-row .set-line .set-line-select {
+  min-width: 108px;
+  flex: 0 1 auto;
+}
+
+.calendar-builder-row .set-line .set-line-select .app-select-trigger {
+  min-height: 0;
+  padding: 5px 8px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--glass-bg);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.calendar-builder-row .set-line .set-line-select .app-select-trigger:hover,
+.calendar-builder-row .set-line .set-line-select .app-select-trigger[aria-expanded="true"] {
+  background: var(--glass-bg-hover);
+}
+
 .set-line-cell.is-load select {
   font-size: 13px;
 }
@@ -27214,6 +27256,25 @@ tr.data-intervals-row-missing {
   font-weight: 650;
 }
 
+.workout-step-header .workout-step-kind-select {
+  width: 126px;
+  flex: 0 0 auto;
+}
+
+.workout-step-header .workout-step-kind-select .app-select-trigger {
+  min-height: 34px;
+  border-color: transparent;
+  background: transparent;
+  padding: 0 4px 0 2px;
+  font-weight: 650;
+}
+
+.workout-step-header .workout-step-kind-select .app-select-trigger:hover,
+.workout-step-header .workout-step-kind-select .app-select-trigger[aria-expanded="true"] {
+  border-color: var(--glass-border);
+  background: var(--glass-bg-hover);
+}
+
 .workout-step-header > input {
   flex: 1;
   border-color: transparent;
@@ -27311,6 +27372,17 @@ tr.data-intervals-row-missing {
 .workout-control-group select {
   width: 100%;
   min-height: 34px;
+}
+
+.workout-control-group .app-select {
+  width: 100%;
+  flex: 1;
+}
+
+.workout-control-group .app-select-trigger {
+  min-height: 34px;
+  padding: 7px 9px;
+  font-weight: 500;
 }
 
 .workout-range-inputs {

--- a/src/styles.css
+++ b/src/styles.css
@@ -435,22 +435,9 @@ input::placeholder {
   transform-origin: 50% 80%;
 }
 
-.donate-button-spark {
-  position: absolute;
-  top: -5px;
-  right: -6px;
-  opacity: 0.48;
-  transform: scale(0.72) rotate(-10deg);
-  transform-origin: center;
-}
-
 @media (prefers-reduced-motion: no-preference) {
   .donate-button::after {
     animation: donate-shine 4.4s cubic-bezier(0.45, 0, 0.2, 1) infinite;
-  }
-
-  .donate-button-spark {
-    animation: donate-sparkle 3.6s cubic-bezier(0.16, 1, 0.3, 1) infinite;
   }
 
   .donate-button:hover .donate-button-cup {
@@ -476,25 +463,6 @@ input::placeholder {
   82%,
   100% {
     transform: translateX(460%) skewX(-18deg);
-  }
-}
-
-@keyframes donate-sparkle {
-  0%,
-  68%,
-  100% {
-    opacity: 0.35;
-    transform: scale(0.7) rotate(-12deg);
-  }
-
-  76% {
-    opacity: 1;
-    transform: scale(1.24) rotate(8deg);
-  }
-
-  84% {
-    opacity: 0.56;
-    transform: scale(0.88) rotate(0deg);
   }
 }
 
@@ -3247,8 +3215,8 @@ input::placeholder {
   border-radius: var(--radius-lg);
   background:
     radial-gradient(ellipse 80% 60% at 20% 0%, var(--bg-ambient-green), transparent 55%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.075), rgba(255, 255, 255, 0.045)),
-    var(--glass-bg);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(255, 255, 255, 0)),
+    #14171c;
   box-shadow: var(--glass-shadow), var(--glass-inset);
   animation: training-card-enter 0.55s cubic-bezier(0.2, 0.8, 0.2, 1) both;
 }
@@ -3264,10 +3232,11 @@ input::placeholder {
 .library-panel {
   --library-track-grid: 16px 36px minmax(0, 1fr) 68px 92px 96px 76px;
   --library-track-row-height: 56px;
-  --library-row-bg: rgba(0, 0, 0, 0.26);
-  --library-row-bg-hover: rgba(0, 0, 0, 0.18);
-  --library-row-border: rgba(255, 255, 255, 0.05);
+  --library-row-bg: rgba(255, 255, 255, 0.04);
+  --library-row-bg-hover: rgba(255, 255, 255, 0.07);
+  --library-row-border: rgba(255, 255, 255, 0.06);
 
+  position: relative;
   display: flex;
   min-width: 0;
   min-height: 0;
@@ -3277,12 +3246,17 @@ input::placeholder {
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-md);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.075), rgba(255, 255, 255, 0.045)),
-    var(--glass-bg);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.015)),
+    #1b2026;
   -webkit-backdrop-filter: blur(var(--glass-blur));
   backdrop-filter: blur(var(--glass-blur));
   padding: 20px;
   box-shadow: var(--glass-shadow), var(--glass-inset);
+}
+
+/* Watch rows drop the redundant per-row status badge. */
+.library-panel--watch {
+  --library-track-grid: 16px 36px minmax(0, 1fr) 68px 92px 44px;
 }
 
 /* Accent-tinted eyebrows and count pills. */
@@ -3337,30 +3311,9 @@ input::placeholder {
   white-space: nowrap;
 }
 
-.library-panel-actions {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 8px;
-  min-height: 36px;
-  flex-shrink: 0;
-}
-
-.library-bulk-actions {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
 .compact-button {
   min-height: 36px;
   padding: 0 12px;
-  font-size: 13px;
-}
-
-.library-panel-hint {
-  color: var(--text-muted);
   font-size: 13px;
 }
 
@@ -3396,7 +3349,7 @@ input::placeholder {
   gap: 10px;
   font-size: 12px;
   font-weight: 700;
-  color: var(--text-muted);
+  color: var(--text-secondary);
 }
 
 .library-transfer-progress-name {
@@ -3415,16 +3368,40 @@ input::placeholder {
 .library-transfer-progress-bar {
   height: 100%;
   border-radius: var(--radius-pill);
-  background: var(--accent, #3b82f6);
+  background: var(--accent-gradient);
+  box-shadow: 0 0 10px var(--accent-glow);
   transition: width 0.15s ease-out;
 }
 
 .library-panel-tools {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 10px;
   flex-shrink: 0;
+}
+
+.library-panel-cta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-height: 36px;
+  white-space: nowrap;
+}
+
+.library-pending-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid color-mix(in srgb, var(--accent-gold) 42%, transparent);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--accent-gold) 12%, transparent);
+  color: var(--accent-gold);
+  padding: 5px 10px;
+  font-size: 12px;
+  font-weight: 800;
+  white-space: nowrap;
 }
 
 .library-search-field {
@@ -3436,8 +3413,8 @@ input::placeholder {
   min-height: 36px;
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-sm);
-  background: var(--glass-bg);
-  color: var(--text-muted);
+  background: rgba(0, 0, 0, 0.22);
+  color: var(--text-secondary);
   padding: 0 10px;
   transition:
     border-color 0.15s ease,
@@ -3456,6 +3433,11 @@ input::placeholder {
   background: transparent;
   color: var(--text-primary);
   font-size: 13px;
+}
+
+.library-search-field input::placeholder {
+  color: var(--text-secondary);
+  opacity: 0.65;
 }
 
 .library-search-clear {
@@ -3500,7 +3482,7 @@ input::placeholder {
 }
 
 .library-filter-option small {
-  color: var(--text-muted);
+  color: var(--text-secondary);
   font-size: 11px;
   font-weight: 700;
 }
@@ -3517,52 +3499,75 @@ input::placeholder {
   opacity: 1;
 }
 
-.library-selection-bar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  flex-shrink: 0;
+.library-header-select {
+  display: grid;
+  place-items: center;
 }
 
-.library-select-all {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--text-secondary);
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.library-selection-meta {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-  color: var(--text-muted);
-  font-size: 12px;
-  font-weight: 600;
-}
-
-.library-select-all input {
+.library-header-select input {
+  width: 16px;
+  height: 16px;
+  margin: 0;
   accent-color: var(--accent);
 }
 
-.library-selection-clear {
-  min-height: 26px;
+/* Floating selection action bar, overlaid at the bottom of the track list. */
+.library-selection-fab {
+  position: absolute;
+  bottom: 16px;
+  left: 50%;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: calc(100% - 40px);
+  transform: translateX(-50%);
   border: 1px solid var(--glass-border);
-  border-radius: 6px;
-  background: rgba(255, 255, 255, 0.04);
-  color: var(--text-secondary);
-  padding: 0 8px;
-  font-size: 12px;
-  font-weight: 700;
+  border-radius: var(--radius-pill);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.05)),
+    rgba(13, 18, 22, 0.88);
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  backdrop-filter: blur(var(--glass-blur));
+  box-shadow:
+    0 18px 44px rgba(0, 0, 0, 0.42),
+    var(--glass-inset);
+  padding: 7px 8px 7px 14px;
+  animation: library-fab-enter 0.22s cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  white-space: nowrap;
 }
 
-.library-selection-clear:hover {
-  border-color: var(--glass-border);
-  background: var(--glass-bg-hover);
-  color: var(--text-primary);
+.library-selection-fab-meta {
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+}
+
+.library-selection-fab .compact-button {
+  min-height: 32px;
+  border-radius: var(--radius-pill);
+}
+
+.library-selection-fab-close {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+@keyframes library-fab-enter {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(8px) scale(0.97);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
 }
 
 .library-track-header {
@@ -3572,7 +3577,7 @@ input::placeholder {
   gap: 10px;
   flex-shrink: 0;
   padding: 0 10px;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   font-size: 12px;
   font-weight: 800;
   letter-spacing: 0.04em;
@@ -3591,7 +3596,7 @@ input::placeholder {
   min-width: 0;
   border: 0;
   background: transparent;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   padding: 0;
   font-size: 12px;
   font-weight: 800;
@@ -3614,8 +3619,13 @@ input::placeholder {
   overflow-y: auto;
   padding: 8px;
   border-radius: var(--radius-sm);
-  background: rgba(0, 0, 0, 0.14);
+  background: rgba(0, 0, 0, 0.24);
   scrollbar-gutter: stable;
+}
+
+/* Leave room for the floating selection bar so it never covers a row. */
+.library-track-stack.has-selection-fab {
+  padding-bottom: 64px;
 }
 
 .library-track-row {
@@ -3632,6 +3642,7 @@ input::placeholder {
   border: 1px solid var(--library-row-border);
   border-radius: var(--radius-sm);
   background: var(--library-row-bg);
+  cursor: pointer;
   padding: 8px 10px;
   transition:
     border-color 0.15s ease,
@@ -3639,7 +3650,7 @@ input::placeholder {
 }
 
 .library-track-row:hover:not(.is-selected) {
-  border-color: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.12);
   background: var(--library-row-bg-hover);
 }
 
@@ -3655,10 +3666,27 @@ input::placeholder {
   accent-color: var(--accent);
 }
 
+/* Library avatars derive a soft gradient from the per-track accent color. */
+.track-avatar.track-avatar--library {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--track-color, var(--accent)) 92%, #ffffff 8%),
+    color-mix(in srgb, var(--track-color, var(--accent)) 70%, #000000 30%)
+  );
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.16),
+    0 4px 10px rgba(0, 0, 0, 0.22);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.32);
+}
+
 .track-avatar.track-avatar--watch {
   background: var(--glass-bg);
   box-shadow: inset 0 0 0 1px var(--glass-border);
   color: var(--text-muted);
+}
+
+.track-avatar.track-avatar--watch svg {
+  opacity: 0.8;
 }
 
 .library-track-meta {
@@ -3682,7 +3710,7 @@ input::placeholder {
 
 .library-track-meta small {
   margin-top: 2px;
-  color: var(--text-muted);
+  color: var(--text-secondary);
   font-size: 12px;
   font-weight: 500;
 }
@@ -3696,15 +3724,40 @@ input::placeholder {
 }
 
 .library-track-date {
-  color: var(--text-muted);
+  color: var(--text-secondary);
   font-size: 12px;
   font-weight: 500;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 
-.library-track-status {
+/* Compact dot + label sync status for local tracks. */
+.library-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
   white-space: nowrap;
+}
+
+.library-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent-gold);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--accent-gold) 55%, transparent);
+  flex-shrink: 0;
+}
+
+.library-status.is-synced {
+  color: var(--success-text);
+}
+
+.library-status.is-synced .library-status-dot {
+  background: var(--success-dot);
+  box-shadow: 0 0 8px color-mix(in srgb, var(--success-dot) 55%, transparent);
 }
 
 .library-track-actions {
@@ -3738,21 +3791,114 @@ input::placeholder {
 }
 
 .library-connector-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-pill);
-  background: var(--glass-bg);
+  background: rgba(0, 0, 0, 0.24);
   color: var(--text-secondary);
   padding: 6px 10px;
   font-size: 11px;
   font-weight: 700;
   text-align: center;
   white-space: nowrap;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease,
+    color 0.2s ease;
 }
 
-.library-connector-pill.ready {
+.library-connector-pill--ready {
   border-color: var(--success-border);
   background: var(--success-bg);
   color: var(--success-text);
+}
+
+.library-connector-pill--syncing {
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.library-connector-pill--pending {
+  border-color: color-mix(in srgb, var(--accent-gold) 40%, transparent);
+  color: var(--accent-gold);
+}
+
+/* Animated flow toward the watch while a transfer batch is running. */
+.library-connector.is-syncing .library-connector-line {
+  background: linear-gradient(
+    180deg,
+    transparent,
+    var(--accent-soft),
+    var(--accent),
+    var(--accent-soft),
+    transparent
+  );
+  background-size: 100% 240%;
+  animation: library-connector-flow 1.3s linear infinite;
+}
+
+@keyframes library-connector-flow {
+  from {
+    background-position: 0 120%;
+  }
+
+  to {
+    background-position: 0 -120%;
+  }
+}
+
+/* Watch capacity meter shown under the "On watch" header. */
+.watch-storage {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.watch-storage-meta {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.watch-storage-meta svg {
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.watch-storage-meta span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.watch-storage-meta em {
+  margin-left: auto;
+  color: var(--text-secondary);
+  font-style: normal;
+  font-variant-numeric: tabular-nums;
+}
+
+.watch-storage-track {
+  height: 6px;
+  border-radius: var(--radius-pill);
+  background: var(--surface-muted, rgba(148, 163, 184, 0.25));
+  overflow: hidden;
+}
+
+.watch-storage-bar {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent-gradient);
+  box-shadow: 0 0 10px var(--accent-glow);
+  transition: width 0.4s ease;
 }
 
 .library-empty-state {
@@ -3767,6 +3913,22 @@ input::placeholder {
 
 .library-empty-state svg {
   opacity: 0.65;
+}
+
+.library-empty-icon {
+  display: grid;
+  width: 56px;
+  height: 56px;
+  place-items: center;
+  border: 1px solid var(--glass-border);
+  border-radius: 50%;
+  background: var(--accent-soft);
+  box-shadow: var(--glass-inset);
+  color: var(--accent-strong);
+}
+
+.library-empty-icon svg {
+  opacity: 0.9;
 }
 
 .library-empty-state strong {
@@ -3785,7 +3947,7 @@ input::placeholder {
 }
 
 .library-empty-subtitle {
-  color: var(--text-muted);
+  color: var(--text-secondary);
   font-size: 13px;
 }
 
@@ -3863,6 +4025,14 @@ input::placeholder {
   }
 
   .library-sync-panel {
+    animation: none;
+  }
+
+  .library-selection-fab {
+    animation: none;
+  }
+
+  .library-connector.is-syncing .library-connector-line {
     animation: none;
   }
 }
@@ -16796,14 +16966,13 @@ tr.data-intervals-row-missing {
     grid-template-rows: auto auto auto;
   }
 
-  .library-panel-actions,
-  .library-bulk-actions {
-    justify-content: flex-start;
-  }
-
   .library-panel-tools {
     grid-template-columns: minmax(0, 1fr);
     align-items: stretch;
+  }
+
+  .library-panel-cta {
+    justify-content: flex-start;
   }
 
   .library-filter-group {
@@ -16816,13 +16985,18 @@ tr.data-intervals-row-missing {
     justify-content: center;
   }
 
-  .library-selection-bar {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
   .library-panel {
     --library-track-grid: 16px 36px minmax(0, 1fr) 96px 44px;
+  }
+
+  .library-panel--watch {
+    --library-track-grid: 16px 36px minmax(0, 1fr) 44px;
+  }
+
+  .library-selection-fab {
+    bottom: 12px;
+    max-width: calc(100% - 24px);
+    padding-left: 12px;
   }
 
   .library-connector {
@@ -16845,6 +17019,29 @@ tr.data-intervals-row-missing {
       var(--bg-ambient-teal),
       transparent
     );
+  }
+
+  .library-connector.is-syncing .library-connector-line {
+    background: linear-gradient(
+      90deg,
+      transparent,
+      var(--accent-soft),
+      var(--accent),
+      var(--accent-soft),
+      transparent
+    );
+    background-size: 240% 100%;
+    animation: library-connector-flow-x 1.3s linear infinite;
+  }
+
+  @keyframes library-connector-flow-x {
+    from {
+      background-position: 120% 0;
+    }
+
+    to {
+      background-position: -120% 0;
+    }
   }
 
   .library-track-size {
@@ -21385,14 +21582,28 @@ tr.data-intervals-row-missing {
   box-shadow: var(--shadow-inset);
 }
 
-:root[data-theme="paper"] .library-selection-clear {
+:root[data-theme="paper"] .library-selection-fab {
   border-color: var(--glass-border);
-  background: rgba(38, 34, 28, 0.04);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0.45)),
+    var(--glass-bg-elevated);
+  box-shadow: var(--shadow-card);
 }
 
-:root[data-theme="paper"] .library-selection-clear:hover {
-  border-color: rgba(38, 34, 28, 0.14);
-  background: rgba(38, 34, 28, 0.08);
+:root[data-theme="paper"] .library-empty-icon {
+  border-color: var(--glass-border);
+  background: var(--accent-soft);
+}
+
+:root[data-theme="paper"] .watch-storage-track,
+:root[data-theme="paper"] .library-transfer-progress-track {
+  background: rgba(38, 34, 28, 0.1);
+}
+
+:root[data-theme="paper"] .track-avatar.track-avatar--library {
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.28),
+    0 2px 6px rgba(38, 34, 28, 0.18);
 }
 
 :root[data-theme="paper"] .library-panel {
@@ -21425,6 +21636,18 @@ tr.data-intervals-row-missing {
   background: rgba(38, 34, 28, 0.05);
 }
 
+:root[data-theme="paper"] .library-connector-pill--ready {
+  border-color: var(--success-border);
+  background: var(--success-bg);
+  color: var(--success-text);
+}
+
+:root[data-theme="paper"] .library-connector-pill--syncing {
+  border-color: color-mix(in srgb, var(--accent) 45%, transparent);
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
 :root[data-theme="paper"] .library-connector-line {
   background: linear-gradient(
     180deg,
@@ -21434,6 +21657,18 @@ tr.data-intervals-row-missing {
     var(--bg-ambient-teal),
     transparent
   );
+}
+
+:root[data-theme="paper"] .library-connector.is-syncing .library-connector-line {
+  background: linear-gradient(
+    180deg,
+    transparent,
+    var(--accent-soft),
+    var(--accent),
+    var(--accent-soft),
+    transparent
+  );
+  background-size: 100% 240%;
 }
 
 :root[data-theme="paper"] .watch-connect-note {

--- a/src/training-library/PlanEditor.tsx
+++ b/src/training-library/PlanEditor.tsx
@@ -42,8 +42,10 @@ import {
 import { formatWorkoutSport, WORKOUT_SPORTS } from "../../electron/workoutCapabilities";
 import type { CorosLinkApi } from "../coroslink-api";
 import { WorkoutEditorModal } from "../calendar/WorkoutEditorModal";
+import { SelectDropdown } from "../components/SelectDropdown";
 import { replaceTrainingPlanEntryWorkout } from "../../electron/planWorkoutEditor";
 import { Ridge } from "./Ridge";
+import { SportDot } from "./sportTheme";
 
 interface PlanEditorProps {
   api: CorosLinkApi;
@@ -58,18 +60,7 @@ interface PlanEditorProps {
 
 const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
-/** Entry cards and library rows carry a dot in the sport's own colour. */
-const SPORT_DOT_CATEGORY: Record<string, string> = {
-  run: "run",
-  bike: "bike",
-  strength: "strength"
-};
-
-function sportDotCategory(sport: WorkoutSport | undefined): string | undefined {
-  if (!sport) return undefined;
-  return SPORT_DOT_CATEGORY[sport] ?? "other";
-}
-
+/** Entry cards and library rows carry the sport's icon in its own colour. */
 function withDerivedSportMix(plan: TrainingPlanDocument): TrainingPlanDocument {
   const sports = plan.entries
     .map((entry) => entry.workout?.sport)
@@ -298,7 +289,21 @@ export function PlanEditor({ api, initialPlan, workouts, calendarEnabled, offlin
             <h3>Plan details</h3>
             <label><span>Description</span><textarea value={plan.description} onChange={(event) => patchPlan({ description: event.target.value })} /></label>
             <label><span>Goal</span><input value={plan.goal} onChange={(event) => patchPlan({ goal: event.target.value })} /></label>
-            <label><span>Difficulty</span><select value={plan.difficulty} onChange={(event) => patchPlan({ difficulty: event.target.value as TrainingPlanDocument["difficulty"] })}><option value="beginner">Beginner</option><option value="intermediate">Intermediate</option><option value="advanced">Advanced</option><option value="custom">Custom</option></select></label>
+            <label>
+              <span>Difficulty</span>
+              <SelectDropdown<TrainingPlanDocument["difficulty"]>
+                label="Plan difficulty"
+                value={plan.difficulty}
+                options={[
+                  { value: "beginner", label: "Beginner" },
+                  { value: "intermediate", label: "Intermediate" },
+                  { value: "advanced", label: "Advanced" },
+                  { value: "custom", label: "Custom" }
+                ]}
+                portal
+                onChange={(difficulty) => patchPlan({ difficulty })}
+              />
+            </label>
             <label><span>Week 1 Monday</span><span className="plan-editor-date"><CalendarRange size={15} /><input type="date" value={plan.startDate ?? ""} onChange={(event) => commit(shiftTrainingPlan(plan, mondayOf(event.target.value)))} /></span></label>
             <label><span>Notes</span><textarea value={plan.notes} onChange={(event) => patchPlan({ notes: event.target.value })} /></label>
           </section>
@@ -321,7 +326,19 @@ export function PlanEditor({ api, initialPlan, workouts, calendarEnabled, offlin
             </div>
             {showNewWorkout ? <div className="plan-editor-new-workout">
               <label><span>Name</span><input value={newWorkoutName} onChange={(event) => setNewWorkoutName(event.target.value)} /></label>
-              <label><span>Sport</span><select value={newWorkoutSport} onChange={(event) => setNewWorkoutSport(event.target.value as WorkoutSport)}>{WORKOUT_SPORTS.map((sport) => <option key={sport} value={sport}>{formatWorkoutSport(sport)}</option>)}</select></label>
+              <label>
+                <span>Sport</span>
+                <SelectDropdown<WorkoutSport>
+                  label="Workout sport"
+                  value={newWorkoutSport}
+                  options={WORKOUT_SPORTS.map((sport) => ({
+                    value: sport,
+                    label: formatWorkoutSport(sport)
+                  }))}
+                  portal
+                  onChange={setNewWorkoutSport}
+                />
+              </label>
               <label><span>Duration</span><span className="plan-editor-duration"><input type="number" min="1" value={newWorkoutMinutes} onChange={(event) => setNewWorkoutMinutes(event.target.value)} /><em>min</em></span></label>
               <button type="button" className="primary-button" disabled={!newWorkoutName.trim()} onClick={createWorkout}>Add to holding area</button>
             </div> : null}
@@ -331,7 +348,7 @@ export function PlanEditor({ api, initialPlan, workouts, calendarEnabled, offlin
               {libraryQuery ? <button type="button" aria-label="Clear workout filter" onClick={() => setLibraryQuery("")}><X size={13} /></button> : null}
             </div>
             <div className="plan-editor-library-list">
-              {libraryMatches.length === 0 ? <p className="plan-editor-empty-inline">No workouts match your filter.</p> : libraryMatches.map((workout) => <button type="button" key={workout.id} data-sport={sportDotCategory(workoutSportFromType(workout.sportType))} aria-label={`Add ${workout.name} to plan`} onClick={() => addLibraryWorkout(workout)}><span><strong>{workout.name}</strong><small>{formatWorkoutSport(workoutSportFromType(workout.sportType) ?? "run")}</small></span><span className="plan-editor-library-add" aria-hidden="true"><Plus size={14} /></span></button>)}
+              {libraryMatches.length === 0 ? <p className="plan-editor-empty-inline">No workouts match your filter.</p> : libraryMatches.map((workout) => <button type="button" key={workout.id} aria-label={`Add ${workout.name} to plan`} onClick={() => addLibraryWorkout(workout)}><SportDot sport={workoutSportFromType(workout.sportType)} /><span><strong>{workout.name}</strong><small>{formatWorkoutSport(workoutSportFromType(workout.sportType) ?? "run")}</small></span><span className="plan-editor-library-add" aria-hidden="true"><Plus size={14} /></span></button>)}
             </div>
           </section>
 
@@ -422,7 +439,8 @@ export function PlanEditor({ api, initialPlan, workouts, calendarEnabled, offlin
 }
 
 function PlanEntryCard({ entry, onEdit, onRemove }: { entry: TrainingPlanEntry; onEdit: () => void; onRemove: () => void }) {
-  return <article className={`plan-entry-card is-${entry.kind}`} data-sport={sportDotCategory(entry.workout?.sport)} draggable={entry.kind === "workout"} onDragStart={(event) => event.dataTransfer.setData("text/training-plan-entry", entry.id)}>
+  return <article className={`plan-entry-card is-${entry.kind}`} draggable={entry.kind === "workout"} onDragStart={(event) => event.dataTransfer.setData("text/training-plan-entry", entry.id)}>
+    {entry.kind === "workout" ? <SportDot sport={entry.workout?.sport} /> : null}
     <span><strong>{entry.title ?? (entry.kind === "rest" ? "Rest day" : "Note")}</strong>{entry.workout?.sport ? <small>{formatWorkoutSport(entry.workout.sport)}</small> : null}</span>
     <span className="plan-entry-actions">
       {entry.kind === "workout" ? <button type="button" aria-label={`Edit ${entry.title ?? "workout"}`} onClick={onEdit}><Pencil size={12} /></button> : null}

--- a/src/training-library/TrainingLibraryView.tsx
+++ b/src/training-library/TrainingLibraryView.tsx
@@ -44,6 +44,13 @@ import {
 } from "../../electron/trainingPlanDomain";
 import type { CorosLinkApi } from "../coroslink-api";
 import { formatWorkoutSport } from "../../electron/workoutCapabilities";
+import {
+  PlanSourceBadge,
+  SportMixDots,
+  dominantSport,
+  planSourceLabel,
+  sportAccentStyle
+} from "./sportTheme";
 import { SelectDropdown } from "../components/SelectDropdown";
 import { BulletRidge, Ridge, type BulletWeek } from "./Ridge";
 import { PlanCompare } from "./PlanCompare";
@@ -131,10 +138,7 @@ function planStartLabel(plan: TrainingPlanDocument): string {
 }
 
 function sourceLabel(source: TrainingPlanDocument["source"]): string {
-  if (source === "coros") return "COROS";
-  if (source === "coach") return "Coach";
-  if (source === "template") return "Template";
-  return "Local";
+  return planSourceLabel(source);
 }
 
 export function TrainingLibraryView({
@@ -532,7 +536,9 @@ function planView(
     context,
     sessions: summary?.workouts ?? 0,
     load: summary?.trainingLoad ? Math.round(summary.trainingLoad) : 0,
-    details: [context, planStartLabel(plan), sourceLabel(plan.source)],
+    details: [context, planStartLabel(plan)],
+    dominant: dominantSport(summary?.sportDistribution, plan.sportMix),
+    sportCounts: summary?.sportDistribution,
     ridge: {
       values: weekly.map((week) => (hasLoad ? week.trainingLoad : week.workouts)),
       peakWeek: hasLoad ? summary?.peakWeek : undefined,
@@ -848,14 +854,19 @@ function PlanIndex({
             const isSelected = selected.includes(plan.id);
 
             return (
-              <li className={`tl-card${isSelected ? " is-selected" : ""}`} key={plan.id}>
+              <li
+                className={`tl-card${isSelected ? " is-selected" : ""}`}
+                key={plan.id}
+                data-accent={view.dominant ?? undefined}
+                style={view.dominant ? sportAccentStyle(view.dominant) : undefined}
+              >
                 {selectMark(plan, isSelected)}
                 <button type="button" className="tl-card-open" onClick={() => onOpen(plan)}>
                   <span className="tl-card-top">
                     {plan.favorite ? (
                       <Heart size={11} fill="currentColor" strokeWidth={0} aria-label="Favorite" />
                     ) : null}
-                    <em>{sourceLabel(plan.source)}</em>
+                    <PlanSourceBadge source={plan.source} />
                     {UNSETTLED_SYNC.has(plan.syncState) ? (
                       <i className="tl-flag">{plan.syncState}</i>
                     ) : null}
@@ -865,6 +876,7 @@ function PlanIndex({
                   <span className="tl-card-note">
                     {view.context} · {planStartLabel(plan)}
                   </span>
+                  <SportMixDots sports={plan.sportMix} counts={view.sportCounts} />
                   <Ridge {...view.ridge} />
                   <span className="tl-card-figs">
                     <span>
@@ -921,7 +933,12 @@ function PlanIndex({
               const isSelected = selected.includes(plan.id);
 
               return (
-                <li className={`tl-plan-row tl-row${isSelected ? " is-selected" : ""}`} key={plan.id}>
+                <li
+                  className={`tl-plan-row tl-row${isSelected ? " is-selected" : ""}`}
+                  key={plan.id}
+                  data-accent={view.dominant ?? undefined}
+                  style={view.dominant ? sportAccentStyle(view.dominant) : undefined}
+                >
                   {selectMark(plan, isSelected)}
                   <button type="button" className="tl-row-open" onClick={() => onOpen(plan)}>
                     <span className="tl-row-name">
@@ -931,9 +948,11 @@ function PlanIndex({
                       {plan.name}
                     </span>
                     <span className="tl-row-sub">
+                      <SportMixDots sports={plan.sportMix} counts={view.sportCounts} />
                       {view.details.map((detail, index) => (
                         <em key={index}>{detail}</em>
                       ))}
+                      <PlanSourceBadge source={plan.source} />
                       {UNSETTLED_SYNC.has(plan.syncState) ? (
                         <i className="tl-flag">{plan.syncState}</i>
                       ) : null}

--- a/src/training-library/TrainingPlanGenerator.tsx
+++ b/src/training-library/TrainingPlanGenerator.tsx
@@ -1,26 +1,16 @@
 import {
   AlertTriangle,
   ArrowRight,
-  Bike,
   CalendarDays,
   Check,
-  Dumbbell,
-  Footprints,
-  Grip,
-  Hand,
   Info,
   LoaderCircle,
   Minus,
-  Mountain,
   Plus,
   RotateCw,
-  Snowflake,
   Sparkles,
-  Trophy,
-  Waves,
   X
 } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import type {
@@ -34,6 +24,7 @@ import { trainingPlanFromDraftPreview } from "../../electron/trainingPlanDomain"
 import { formatWorkoutSport, WORKOUT_SPORTS } from "../../electron/workoutCapabilities";
 import type { CorosLinkApi } from "../coroslink-api";
 import { useUnitSystem } from "../units/UnitSystemProvider";
+import { sportTheme } from "./sportTheme";
 
 interface TrainingPlanGeneratorProps {
   api: CorosLinkApi;
@@ -51,22 +42,8 @@ interface ProviderAvailability {
 const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const DAY_NAMES_FULL = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
 
-/**
- * Sport chip identity: an icon plus the user's customizable sport color token.
- * Mirrors BUILDER_SPORT_META in AddWorkoutModal.
- */
-const SPORT_META: Record<WorkoutSport, { Icon: LucideIcon; colorVar: string }> = {
-  run: { Icon: Footprints, colorVar: "var(--sport-run)" },
-  bike: { Icon: Bike, colorVar: "var(--sport-bike)" },
-  swim: { Icon: Waves, colorVar: "var(--sport-other)" },
-  strength: { Icon: Dumbbell, colorVar: "var(--sport-strength)" },
-  trailRun: { Icon: Mountain, colorVar: "var(--sport-trail)" },
-  indoorClimb: { Icon: Grip, colorVar: "var(--sport-other)" },
-  bouldering: { Icon: Hand, colorVar: "var(--sport-other)" },
-  xcSki: { Icon: Snowflake, colorVar: "var(--sport-other)" },
-  hyrox: { Icon: Trophy, colorVar: "var(--sport-strength)" }
-};
-
+/* Sport chip identity — icon plus colour — comes from ./sportTheme, so the
+   generator agrees with the library indexes about what a sport looks like. */
 const DIFFICULTY_OPTIONS: { value: TrainingPlanGenerationRequest["difficulty"]; label: string; hint: string }[] = [
   { value: "beginner", label: "Beginner", hint: "New to structured training" },
   { value: "intermediate", label: "Intermediate", hint: "Training consistently" },
@@ -385,19 +362,20 @@ export function TrainingPlanGenerator({ api, onClose, onGenerated, onOpenCoach }
               <legend>Sports</legend>
               <div className="plan-generator-sports">
                 {WORKOUT_SPORTS.map((sport) => {
-                  const meta = SPORT_META[sport];
+                  const theme = sportTheme(sport);
+                  const SportIcon = theme.icon;
                   const selected = sports.includes(sport);
                   return (
                     <button
                       type="button"
                       key={sport}
                       className={selected ? "is-selected" : ""}
-                      style={{ "--sport-accent": meta.colorVar } as CSSProperties}
+                      style={{ "--sport-accent": theme.color } as CSSProperties}
                       aria-pressed={selected}
                       disabled={generating}
                       onClick={() => toggleSport(sport)}
                     >
-                      <meta.Icon size={13} />
+                      <SportIcon size={13} />
                       {formatWorkoutSport(sport)}
                     </button>
                   );
@@ -500,10 +478,11 @@ export function TrainingPlanGenerator({ api, onClose, onGenerated, onOpenCoach }
                 {sports.length ? (
                   <span className="plan-generator-snapshot-sports">
                     {sports.map((sport) => {
-                      const meta = SPORT_META[sport];
+                      const theme = sportTheme(sport);
+                      const SportIcon = theme.icon;
                       return (
-                        <span key={sport} className="plan-generator-snapshot-sport" style={{ "--sport-accent": meta.colorVar } as CSSProperties} title={formatWorkoutSport(sport)}>
-                          <meta.Icon size={12} />
+                        <span key={sport} className="plan-generator-snapshot-sport" style={{ "--sport-accent": theme.color } as CSSProperties} title={formatWorkoutSport(sport)}>
+                          <SportIcon size={12} />
                         </span>
                       );
                     })}

--- a/src/training-library/WorkoutWorkspace.tsx
+++ b/src/training-library/WorkoutWorkspace.tsx
@@ -3,19 +3,22 @@ import {
   Copy,
   Download,
   Heart,
+  History,
+  Layers,
   LayoutGrid,
   Link2,
   List,
   LoaderCircle,
   Pencil,
   Plus,
+  Route,
   Search,
   Tag,
   Trash2,
   Unlink,
   X
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   RunWorkoutEditorNode,
   TrainingCollection,
@@ -25,9 +28,9 @@ import type {
 } from "../../electron/types";
 import type { CorosLinkApi } from "../coroslink-api";
 import { formatHappenDayLabel } from "../training/formatters";
-import { sportColorCategory } from "../training/sportColors";
 import { formatWorkoutSport } from "../../electron/workoutCapabilities";
 import { workoutSportFromType } from "../../electron/trainingPlanDomain";
+import { SportBadge, sportAccentStyle, sportChipStyle, sportTheme } from "./sportTheme";
 import { SelectDropdown } from "../components/SelectDropdown";
 import { WorkoutEditorModal } from "../calendar/WorkoutEditorModal";
 import { AddWorkoutModal } from "../calendar/AddWorkoutModal";
@@ -65,6 +68,15 @@ const WORKOUT_SORT_OPTIONS: Array<{ value: WorkoutColumn; label: string }> = [
 const UNSETTLED_SYNC = new Set(["pending", "conflicted", "failed", "stale"]);
 /** Enough segments to read an interval comb without drawing thousands of them. */
 const SHAPE_SEGMENT_LIMIT = 96;
+/*
+ * A tile's shape needs the step list, and COROS only ships that on
+ * /training/program/detail — one request per workout. So tiles ask for it only
+ * once they scroll into view, a few at a time, and never twice for the same
+ * workout. Browsing the library costs a handful of requests, not sixty.
+ */
+const SHAPE_BATCH = 3;
+/** Draws the comb a beat before the tile lands, so it is never seen filling in. */
+const SHAPE_PREFETCH_MARGIN = "160px";
 
 /** Legend wording for the step kinds the shape bar can draw, in session order. */
 const STEP_KIND_LABELS: Record<string, string> = {
@@ -93,6 +105,25 @@ function tomorrow(): string {
   const date = new Date();
   date.setDate(date.getDate() + 1);
   return date.toISOString().slice(0, 10);
+}
+
+/** How long ago a workout was last scheduled, short enough for a tile footer. */
+function sinceLabel(iso: string | undefined): string | null {
+  if (!iso) return null;
+  const then = new Date(iso).valueOf();
+  if (Number.isNaN(then)) return null;
+  const days = Math.max(0, Math.round((Date.now() - then) / 86_400_000));
+  if (days === 0) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 7) return `${days}d ago`;
+  if (days < 60) return `${Math.round(days / 7)}w ago`;
+  if (days < 365) return `${Math.round(days / 30)}mo ago`;
+  return `${Math.round(days / 365)}y ago`;
+}
+
+/** COROS reports volume as a distance or a set count; the icon says which. */
+function isSetVolume(volume: string | undefined): boolean {
+  return /set/i.test(volume ?? "");
 }
 
 function targetLabel(node: RunWorkoutEditorNode): string {
@@ -157,6 +188,25 @@ function workoutShape(nodes: RunWorkoutEditorNode[]): ShapeSegment[] {
   return segments.map((segment) => ({ ...segment, share: (segment.share / total) * 100 }));
 }
 
+/*
+ * The calendar's structure bar sizes its segments by flex-grow and floors the
+ * tiny ones, so a 20-second recovery between reps never collapses to nothing.
+ * The tile borrows the rule outright — the two bars should read as one idea.
+ */
+function combGrow(segments: ShapeSegment[]): number[] {
+  const largest = Math.max(0, ...segments.map((segment) => segment.share));
+  if (largest <= 0) return segments.map(() => 1);
+  const floor = largest * 0.035;
+  return segments.map((segment) => Math.max(segment.share, floor));
+}
+
+/*
+ * Past this many steps the gapped pills stop fitting a tile's width, so the
+ * comb closes up into a striped band instead of overflowing. A 20 × 30s set
+ * genuinely looks like that.
+ */
+const COMB_DENSE_AT = 30;
+
 function downloadSelection(workouts: TrainingLibraryWorkout[]) {
   const blob = new Blob([JSON.stringify({ exportedAt: new Date().toISOString(), workouts }, null, 2)], {
     type: "application/json"
@@ -193,6 +243,12 @@ export function WorkoutWorkspace({
   const [pendingDelete, setPendingDelete] = useState<string[]>([]);
   const [duplicateSport, setDuplicateSport] = useState<number | undefined>();
   const [creating, setCreating] = useState(false);
+  /** Step structure per workout id; an empty array means "asked, none to draw". */
+  const [shapes, setShapes] = useState<Record<string, ShapeSegment[]>>({});
+  const [shapeQueue, setShapeQueue] = useState<string[]>([]);
+  const requestedShapes = useRef(new Set<string>());
+  const shapeBusy = useRef(false);
+  const shapeObserver = useRef<IntersectionObserver | null>(null);
 
   const scopes = useMemo(() => {
     const options = [{ id: "all", label: "All" }];
@@ -244,6 +300,93 @@ export function WorkoutWorkspace({
     });
   }, [workouts, query, scope, sort]);
 
+  /*
+   * The tile meter is self-referential: a bar reads as a share of the heaviest
+   * workout in the library, so it stays honest without asserting thresholds
+   * COROS never publishes. The whole library, not the filtered set, so the bars
+   * do not resize under the reader when a filter changes.
+   */
+  const heaviestLoad = useMemo(
+    () => workouts.reduce((most, workout) => Math.max(most, workout.trainingLoad ?? 0), 0),
+    [workouts]
+  );
+
+  /*
+   * The observer is built on the first tile that mounts rather than in an
+   * effect, so the tiles already on screen at first paint are watched too.
+   */
+  const observeTile = useCallback((node: HTMLLIElement | null) => {
+    if (!node) return;
+    if (!shapeObserver.current) {
+      shapeObserver.current = new IntersectionObserver(
+        (entries, observer) => {
+          const seen: string[] = [];
+          for (const entry of entries) {
+            const id = entry.isIntersecting ? (entry.target as HTMLElement).dataset.workoutId : null;
+            if (!id || requestedShapes.current.has(id)) continue;
+            requestedShapes.current.add(id);
+            seen.push(id);
+            observer.unobserve(entry.target);
+          }
+          if (seen.length) setShapeQueue((current) => [...current, ...seen]);
+        },
+        { rootMargin: SHAPE_PREFETCH_MARGIN }
+      );
+    }
+    shapeObserver.current.observe(node);
+  }, []);
+
+  useEffect(
+    () => () => {
+      shapeObserver.current?.disconnect();
+      shapeObserver.current = null;
+    },
+    []
+  );
+
+  /* One batch in flight at a time; finishing it trims the queue and re-runs. */
+  useEffect(() => {
+    if (shapeBusy.current || !shapeQueue.length) return;
+    shapeBusy.current = true;
+    const batch = shapeQueue.slice(0, SHAPE_BATCH);
+    let cancelled = false;
+
+    void Promise.all(
+      batch.map(async (id) => {
+        let segments: ShapeSegment[] = [];
+        try {
+          const document = await api.getWorkoutForEdit({ kind: "library", programId: id }, "metric");
+          segments = workoutShape(document.draft.nodes);
+        } catch {
+          /* A tile that cannot draw its shape falls back to its load bar. */
+        }
+        if (!cancelled) setShapes((current) => ({ ...current, [id]: segments }));
+      })
+    ).finally(() => {
+      shapeBusy.current = false;
+      if (!cancelled) setShapeQueue((current) => current.slice(batch.length));
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [api, shapeQueue]);
+
+  /*
+   * An edit rewrites one workout's steps. Queue that id directly rather than
+   * waiting on the observer — the tile is already on screen and will not cross
+   * the viewport edge again to announce itself.
+   */
+  const redrawShape = useCallback((id: string) => {
+    setShapes((current) => {
+      const next = { ...current };
+      delete next[id];
+      return next;
+    });
+    requestedShapes.current.add(id);
+    setShapeQueue((current) => (current.includes(id) ? current : [...current, id]));
+  }, []);
+
   const active = workouts.find((workout) => workout.id === activeId);
   const shape = useMemo(
     () => (previewDocument ? workoutShape(previewDocument.draft.nodes) : []),
@@ -270,6 +413,9 @@ export function WorkoutWorkspace({
       .then(async (document) => {
         if (cancelled) return;
         setPreviewDocument(document);
+        /* The reader just paid for this workout's steps; its tile draws for free. */
+        requestedShapes.current.add(activeId);
+        setShapes((current) => ({ ...current, [activeId]: workoutShape(document.draft.nodes) }));
         try {
           const metrics = await api.previewWorkoutEdit(
             document.ref,
@@ -414,6 +560,8 @@ export function WorkoutWorkspace({
   const readerLoadSource = previewMetrics?.trainingLoad || active?.trainingLoad;
   const readerLoad = readerLoadSource ? Math.round(readerLoadSource) : null;
   const readerSteps = previewDocument?.draft.nodes.length ?? null;
+  const activeSport = workoutSportFromType(active?.sportType);
+  const ActiveSportIcon = sportTheme(activeSport).icon;
 
   return (
     <div className="tl-panel tl-split">
@@ -514,6 +662,16 @@ export function WorkoutWorkspace({
             {filtered.slice(0, visibleCount).map((workout) => {
               const isSelected = selected.includes(workout.id);
               const references = workout.usedByPlanIds.length + workout.scheduledCount;
+              const sport = workoutSportFromType(workout.sportType);
+              const SportGlyph = sportTheme(sport).icon;
+              const VolumeIcon = isSetVolume(workout.volume) ? Layers : Route;
+              const load = workout.trainingLoad ? Math.round(workout.trainingLoad) : null;
+              /* A sliver of fill so the lightest session still draws something. */
+              const loadShare = load && heaviestLoad ? Math.max(3, (load / heaviestLoad) * 100) : 0;
+              const lastUsed = sinceLabel(workout.lastUsedAt);
+              const tags = workout.tags.slice(0, 3);
+              const tileShape = shapes[workout.id];
+              const hasShape = Boolean(tileShape?.length);
 
               return (
                 <li
@@ -521,6 +679,10 @@ export function WorkoutWorkspace({
                     isSelected ? " is-selected" : ""
                   }`}
                   key={workout.id}
+                  ref={observeTile}
+                  data-workout-id={workout.id}
+                  data-accent={sport ?? "other"}
+                  style={sportAccentStyle(sport)}
                 >
                   {workoutMark(workout.id, workout.name, isSelected)}
                   <button
@@ -528,31 +690,88 @@ export function WorkoutWorkspace({
                     className="tl-card-open"
                     onClick={() => setActiveId(workout.id)}
                   >
+                    <SportGlyph className="tl-wk-glyph" size={132} strokeWidth={1} aria-hidden="true" />
                     <span className="tl-card-top">
                       {workout.favorite ? (
                         <Heart size={11} fill="currentColor" strokeWidth={0} aria-label="Favorite" />
                       ) : null}
-                      <em>{formatWorkoutSport(workoutSportFromType(workout.sportType) ?? "run")}</em>
+                      <SportBadge sport={sport ?? "run"} />
                       {UNSETTLED_SYNC.has(workout.syncState) ? (
                         <i className="tl-flag">{workout.syncState}</i>
                       ) : null}
                     </span>
                     <span className="tl-card-name">{workout.name}</span>
-                    <span className="tl-card-figs">
+                    {tags.length ? (
+                      <span className="tl-wk-tags">
+                        {tags.map((tag) => (
+                          <em key={tag}>{tag}</em>
+                        ))}
+                        {workout.tags.length > tags.length ? (
+                          <em className="is-more">+{workout.tags.length - tags.length}</em>
+                        ) : null}
+                      </span>
+                    ) : null}
+                    <span className="tl-wk-meter">
+                      <span className="tl-wk-meter-head">
+                        <small>{hasShape ? "Session shape" : "Training load"}</small>
+                        <span className="tl-wk-load">
+                          <b className={load ? "" : "is-nil"}>{load ?? "—"}</b>
+                          <em>load</em>
+                        </span>
+                      </span>
+                      {hasShape ? (
+                        <span
+                          className="tl-wk-shape"
+                          data-dense={tileShape.length > COMB_DENSE_AT ? "true" : undefined}
+                          role="img"
+                          aria-label={`Workout structure: ${tileShape
+                            .map((segment) => segment.label)
+                            .join(", ")}`}
+                        >
+                          {combGrow(tileShape).map((grow, index) => (
+                            <i
+                              key={index}
+                              className={`is-${tileShape[index].kind}`}
+                              style={{ flexGrow: grow }}
+                              title={tileShape[index].label}
+                            />
+                          ))}
+                        </span>
+                      ) : (
+                        <span
+                          className={`tl-wk-track${load ? "" : " is-nil"}`}
+                          aria-hidden="true"
+                          title={
+                            load
+                              ? `${load} training load — ${Math.round((load / heaviestLoad) * 100)}% of the heaviest workout in your library`
+                              : "COROS has not reported a training load for this workout"
+                          }
+                        >
+                          {load ? <i style={{ width: `${loadShare}%` }} /> : null}
+                        </span>
+                      )}
+                    </span>
+                    <span className="tl-wk-foot">
                       <span>
-                        <b className={workout.volume ? "" : "is-nil"}>{workout.volume ?? "—"}</b>
-                        <small>total</small>
+                        <VolumeIcon size={11} aria-hidden="true" />
+                        <b>{workout.volume ?? "No volume"}</b>
                       </span>
                       <span>
-                        <b className={workout.trainingLoad ? "" : "is-nil"}>
-                          {workout.trainingLoad ? Math.round(workout.trainingLoad) : "—"}
-                        </b>
-                        <small>load</small>
+                        <Link2 size={11} aria-hidden="true" />
+                        {references ? (
+                          <>
+                            <b>{references}</b> {references === 1 ? "use" : "uses"}
+                          </>
+                        ) : (
+                          "Unused"
+                        )}
                       </span>
-                      <span>
-                        <b className={references ? "" : "is-nil"}>{references || "—"}</b>
-                        <small>used</small>
-                      </span>
+                      {lastUsed ? (
+                        <span>
+                          <History size={11} aria-hidden="true" />
+                          {lastUsed}
+                        </span>
+                      ) : null}
                     </span>
                   </button>
                 </li>
@@ -600,10 +819,8 @@ export function WorkoutWorkspace({
               {filtered.slice(0, visibleCount).map((workout) => {
                 const isSelected = selected.includes(workout.id);
                 const references = workout.usedByPlanIds.length + workout.scheduledCount;
-                const details = [
-                  formatWorkoutSport(workoutSportFromType(workout.sportType) ?? "run"),
-                  ...workout.tags.slice(0, 2)
-                ];
+                const sport = workoutSportFromType(workout.sportType);
+                const details = workout.tags.slice(0, 2);
 
                 return (
                   <li
@@ -611,6 +828,8 @@ export function WorkoutWorkspace({
                       isSelected ? " is-selected" : ""
                     }`}
                     key={workout.id}
+                    data-accent={sport ?? "other"}
+                    style={sportAccentStyle(sport)}
                   >
                     {workoutMark(workout.id, workout.name, isSelected)}
                     <button type="button" className="tl-row-open" onClick={() => setActiveId(workout.id)}>
@@ -621,6 +840,7 @@ export function WorkoutWorkspace({
                         {workout.name}
                       </span>
                       <span className="tl-row-sub">
+                        <SportBadge sport={sport ?? "run"} compact />
                         {details.map((detail, index) => (
                           <em key={index}>{detail}</em>
                         ))}
@@ -664,11 +884,9 @@ export function WorkoutWorkspace({
           <>
             <div className="tl-reader-scroll">
               <header>
-                <p
-                  className="tl-eyebrow tl-reader-sport"
-                  data-sport={sportColorCategory(active.sportType)}
-                >
-                  {formatWorkoutSport(workoutSportFromType(active.sportType) ?? "run")}
+                <p className="tl-eyebrow tl-reader-sport has-icon" style={sportChipStyle(activeSport)}>
+                  <ActiveSportIcon size={12} strokeWidth={2.2} aria-hidden="true" />
+                  {formatWorkoutSport(activeSport ?? "run")}
                 </p>
                 <h2>{active.name}</h2>
                 {active.tags.length ? (
@@ -715,14 +933,18 @@ export function WorkoutWorkspace({
             </dl>
 
             {shape.length ? (
-              <figure className="tl-shape">
-                <div role="img" aria-label={`Step structure of ${active.name}, ${shape.length} steps`}>
-                  {shape.map((segment, index) => (
+              <figure className="tl-shape" style={sportAccentStyle(activeSport)}>
+                <div
+                  role="img"
+                  data-dense={shape.length > COMB_DENSE_AT ? "true" : undefined}
+                  aria-label={`Step structure of ${active.name}, ${shape.length} steps`}
+                >
+                  {combGrow(shape).map((grow, index) => (
                     <span
                       key={index}
-                      className={`is-${segment.kind}`}
-                      style={{ width: `${segment.share}%` }}
-                      title={segment.label}
+                      className={`is-${shape[index].kind}`}
+                      style={{ flexGrow: grow }}
+                      title={shape[index].label}
                     />
                   ))}
                 </div>
@@ -937,6 +1159,7 @@ export function WorkoutWorkspace({
           editRef={{ kind: "library", programId: editId }}
           onClose={() => setEditId(null)}
           onSaved={(result) => {
+            redrawShape(editId);
             setEditId(null);
             onMessage(result.verified ? "Workout saved and verified." : (result.warning ?? "Workout saved."));
             void onRefresh();

--- a/src/training-library/sportTheme.tsx
+++ b/src/training-library/sportTheme.tsx
@@ -1,0 +1,162 @@
+/**
+ * One sport identity for the whole training library: every workout sport gets
+ * its own colour and icon. Sports that Settings → Activity colors can recolour
+ * read the customizable --sport-* tokens; the rest use fixed hues so swim,
+ * ski, the climbs, and HYROX no longer share the "other" teal.
+ */
+import {
+  Activity,
+  Bike,
+  Dumbbell,
+  Flame,
+  Footprints,
+  Hand,
+  HandGrab,
+  Mountain,
+  Snowflake,
+  Waves,
+  type LucideIcon
+} from "lucide-react";
+import type { CSSProperties } from "react";
+import type { TrainingPlanDocument, WorkoutSport } from "../../electron/types";
+import { formatWorkoutSport } from "../../electron/workoutCapabilities";
+
+export interface SportTheme {
+  /** CSS colour — a customizable --sport-* token where one exists. */
+  color: string;
+  icon: LucideIcon;
+}
+
+export const WORKOUT_SPORT_THEME: Record<WorkoutSport, SportTheme> = {
+  run: { color: "var(--sport-run)", icon: Footprints },
+  trailRun: { color: "var(--sport-trail)", icon: Mountain },
+  bike: { color: "var(--sport-bike)", icon: Bike },
+  swim: { color: "#38b6e8", icon: Waves },
+  strength: { color: "var(--sport-strength)", icon: Dumbbell },
+  xcSki: { color: "#8ab4f8", icon: Snowflake },
+  indoorClimb: { color: "#f59e0b", icon: HandGrab },
+  bouldering: { color: "#a78bfa", icon: Hand },
+  hyrox: { color: "#ec4899", icon: Flame }
+};
+
+/** Unknown or missing sports still get a quiet identity, never a crash. */
+const FALLBACK_SPORT_THEME: SportTheme = { color: "var(--sport-other)", icon: Activity };
+
+export function sportTheme(sport: WorkoutSport | undefined): SportTheme {
+  return (sport ? WORKOUT_SPORT_THEME[sport] : undefined) ?? FALLBACK_SPORT_THEME;
+}
+
+/**
+ * The sport a plan is mostly made of. `distribution` counts workouts per
+ * sport (from summarizeTrainingPlan); ties keep the first sport seen, and an
+ * empty distribution falls back to the plan's declared mix.
+ */
+export function dominantSport(
+  distribution: Partial<Record<WorkoutSport, number>> | undefined,
+  fallback: readonly WorkoutSport[] = []
+): WorkoutSport | undefined {
+  let best: WorkoutSport | undefined;
+  let bestCount = 0;
+  if (distribution) {
+    for (const [sport, count] of Object.entries(distribution) as Array<[WorkoutSport, number]>) {
+      if (count > bestCount) {
+        best = sport;
+        bestCount = count;
+      }
+    }
+  }
+  return best ?? fallback[0];
+}
+
+/** Sets --tl-sport-accent: recolours a tile/row and everything sport-tinted inside it. */
+export function sportAccentStyle(sport: WorkoutSport | undefined): CSSProperties {
+  return { "--tl-sport-accent": sportTheme(sport).color } as CSSProperties;
+}
+
+/** Sets --tl-sport: tints a single chip, dot, or badge. */
+export function sportChipStyle(sport: WorkoutSport | undefined): CSSProperties {
+  return { "--tl-sport": sportTheme(sport).color } as CSSProperties;
+}
+
+interface SportBadgeProps {
+  sport: WorkoutSport | undefined;
+  /** Overrides the formatted sport name. */
+  label?: string;
+  /** Compact drops the pill chrome for dense list rows. */
+  compact?: boolean;
+}
+
+/** Pill with the sport's icon and name, tinted in the sport's own colour. */
+export function SportBadge({ sport, label, compact }: SportBadgeProps) {
+  const theme = sportTheme(sport);
+  const Icon = theme.icon;
+  return (
+    <span className={`tl-sport-badge${compact ? " is-compact" : ""}`} style={sportChipStyle(sport)}>
+      <Icon size={11} strokeWidth={2.2} aria-hidden="true" />
+      <span>{label ?? (sport ? formatWorkoutSport(sport) : "Workout")}</span>
+    </span>
+  );
+}
+
+/** A single sport as a mini icon chip. */
+export function SportDot({ sport }: { sport: WorkoutSport | undefined }) {
+  const theme = sportTheme(sport);
+  const Icon = theme.icon;
+  return (
+    <span
+      className="tl-sport-dot"
+      style={sportChipStyle(sport)}
+      title={sport ? formatWorkoutSport(sport) : undefined}
+    >
+      <Icon size={10} strokeWidth={2.2} aria-hidden="true" />
+    </span>
+  );
+}
+
+interface SportMixDotsProps {
+  sports: readonly WorkoutSport[];
+  /** Per-sport workout counts; sports sort most-first when provided. */
+  counts?: Partial<Record<WorkoutSport, number>>;
+}
+
+/** A row of mini icon chips, one per sport in a plan's mix. */
+export function SportMixDots({ sports, counts }: SportMixDotsProps) {
+  if (!sports.length) return null;
+  const ordered = counts
+    ? [...sports].sort((left, right) => (counts[right] ?? 0) - (counts[left] ?? 0))
+    : [...sports];
+  const visible = ordered.slice(0, 4);
+  const overflow = ordered.length - visible.length;
+  return (
+    <span
+      className="tl-sport-dots"
+      role="img"
+      aria-label={ordered.map((sport) => formatWorkoutSport(sport)).join(", ")}
+    >
+      {visible.map((sport) => <SportDot key={sport} sport={sport} />)}
+      {overflow > 0 ? <b>+{overflow}</b> : null}
+    </span>
+  );
+}
+
+type PlanSource = TrainingPlanDocument["source"];
+
+const PLAN_SOURCE_LABELS: Record<PlanSource, string> = {
+  coros: "COROS",
+  local: "Local",
+  template: "Template",
+  coach: "Coach"
+};
+
+export function planSourceLabel(source: PlanSource): string {
+  return PLAN_SOURCE_LABELS[source] ?? "Local";
+}
+
+/** Colour-coded provenance — where a plan came from, not what it contains. */
+export function PlanSourceBadge({ source }: { source: PlanSource }) {
+  return (
+    <em className="tl-source" data-source={source}>
+      {planSourceLabel(source)}
+    </em>
+  );
+}

--- a/src/training-library/trainingLibrary.css
+++ b/src/training-library/trainingLibrary.css
@@ -6,9 +6,11 @@
  * panels over ambient accent washes, one segmented control for the sections,
  * and the accent gradient reserved for moments of emphasis.
  *
- * The dark theme is layered charcoal, never pure black, and the gate shares
- * the same ground. The accent stays the app's signature green; red and
- * yellow stay reserved for danger and caution.
+ * The library is layered charcoal, never pure black — in *both* app themes.
+ * It is the one surface that does not follow the paper reskin: a dark room
+ * for the training record. The gate shares the same ground. The accent stays
+ * the app's signature green; red and yellow stay reserved for danger and
+ * caution.
  *
  * Only one thing is ever drawn — the ridge of weekly training load (Ridge.tsx),
  * small on an index row and at reading size on the adherence lede. It keeps to
@@ -18,9 +20,9 @@
  * settle, then ridges draw themselves. Everything sits under
  * prefers-reduced-motion, which the guard at the end of this file honours.
  *
- * Values derive from the app tokens in styles.css, so both themes reskin this
- * file by overriding tokens rather than restyling rules. Token blocks follow
- * the root: charcoal for the dark theme, and warm shadows for paper.
+ * Values derive from the app tokens in styles.css. The charcoal block below
+ * pins the dark token set on the view itself, so the paper theme's light
+ * values never reach the ledger.
  */
 
 .training-library-view {
@@ -62,73 +64,71 @@
 }
 
 /*
- * Charcoal, dark theme only. The dark theme is the *absence* of a data-theme
- * attribute (see theme.ts applyTheme), so this cannot leak into paper.
+ * Charcoal, always — the library is a dark room in both app themes.
  *
- * It works by overriding the app tokens rather than inventing new ones, which
- * is how the paper theme reskins too: everything downstream — this file, plus
- * shared pieces like .app-select and .primary-button — follows for free. The
- * modals the workspace opens render inside the view, so they inherit all of
- * this without a rule of their own.
+ * It works by pinning the dark token set on the view itself rather than
+ * inventing new tokens: everything downstream — this file, plus shared
+ * pieces like .app-select and .primary-button — follows for free. The
+ * pinned set is the dark theme's palette from styles.css, so the paper
+ * theme's light values (darkened accent, brown-tinted shadows, white
+ * glass) never reach the ledger. The modals the editor renders inline
+ * inherit all of this without a rule of their own.
  *
  * The gate shares the block so the connect screen sits on the same charcoal.
  */
-:root:not([data-theme]) .training-library-view,
-:root:not([data-theme]) .training-library-gate {
+.training-library-view,
+.training-library-gate {
+  color-scheme: dark;
+
   --tl-ground: #16171b;
   --tl-panel-bg: #1d1f25;
   --tl-card: #23262e;
   --tl-card-hover: #2b2f38;
   --tl-reader-bg: #1a1c21;
 
+  --bg-base: #16171b;
+  --bg-ambient-green: rgba(47, 190, 145, 0.1);
+  --bg-ambient-teal: rgba(31, 182, 166, 0.07);
+  --bg-ambient-gold: rgba(216, 155, 34, 0.04);
+  --bg-ambient-white: rgba(255, 255, 255, 0.035);
+
   --surface: #23262e;
   --glass-bg: rgba(255, 255, 255, 0.04);
   --glass-bg-hover: rgba(255, 255, 255, 0.07);
   --glass-bg-elevated: rgba(255, 255, 255, 0.09);
   --glass-border: rgba(255, 255, 255, 0.1);
+  --glass-inset: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 
   --text-primary: #edeef0;
   --text-secondary: #a9adb2;
   --text-muted: #7b8085;
 
+  --accent: #2fbe91;
+  --accent-strong: #4fd6a6;
+  --accent-2: #1fb6a6;
+  --accent-hover: #26a37c;
+  --accent-glow: rgba(47, 190, 145, 0.32);
+  --accent-soft: rgba(47, 190, 145, 0.12);
+  --accent-gradient: linear-gradient(135deg, #2fbe91 0%, #1fb6a6 100%);
+  --accent-gold: #d89b22;
+
+  --success-bg: rgba(47, 190, 145, 0.15);
+  --success-border: rgba(110, 231, 168, 0.28);
+  --success-text: #6ee7a8;
+  --success-dot: #34d399;
+
+  --warning-bg: rgba(216, 155, 34, 0.15);
+  --warning-border: rgba(251, 191, 36, 0.25);
+  --warning-text: #fbbf24;
+
+  --error-bg: rgba(194, 65, 12, 0.15);
+  --error-border: rgba(248, 113, 113, 0.25);
+  --error-text: #f87171;
+  --error-dot: #f87171;
+
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.28), 0 14px 32px rgba(0, 0, 0, 0.26);
   --shadow-elevated: 0 20px 44px rgba(0, 0, 0, 0.42);
-}
-
-/* Crisp white tiles read better than translucent ones on the warm paper panel. */
-:root[data-theme="paper"] .training-library-view {
-  --tl-card: #ffffff;
-  --tl-card-hover: #fffdf9;
-}
-
-/* Black-alpha shadows go warm on paper, matching the theme's brown tints. */
-:root[data-theme="paper"] .tl-card {
-  box-shadow:
-    0 1px 2px rgba(60, 50, 35, 0.05),
-    0 10px 26px rgba(60, 50, 35, 0.07);
-}
-
-:root[data-theme="paper"] .tl-card:hover {
-  box-shadow:
-    0 2px 4px rgba(60, 50, 35, 0.06),
-    0 18px 38px rgba(60, 50, 35, 0.11),
-    0 0 0 1px color-mix(in srgb, var(--accent) 14%, transparent);
-}
-
-:root[data-theme="paper"] .tl-card.is-selected,
-:root[data-theme="paper"] .tl-card.is-active {
-  box-shadow:
-    0 1px 2px rgba(60, 50, 35, 0.05),
-    0 12px 28px rgba(60, 50, 35, 0.09),
-    0 0 0 1px color-mix(in srgb, var(--accent) 26%, transparent);
-}
-
-:root[data-theme="paper"] .training-library-view .ghost-button:hover:not(:disabled) {
-  box-shadow: 0 4px 14px rgba(60, 50, 35, 0.1);
-}
-
-:root[data-theme="paper"] .plan-week {
-  box-shadow: 0 1px 2px rgba(60, 50, 35, 0.05), 0 8px 22px rgba(60, 50, 35, 0.07);
+  --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .training-library-view :is(button, input, select, textarea) {
@@ -939,6 +939,116 @@
   font-weight: 500;
 }
 
+/*
+ * Sport identity chips. --tl-sport is set inline from sportTheme, so the
+ * customizable --sport-* tokens reach every badge, dot, and icon.
+ */
+.tl-sport-badge {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 5px;
+  padding: 2.5px 8px;
+  border: 1px solid color-mix(in srgb, var(--tl-sport, var(--accent)) 34%, transparent);
+  border-radius: var(--radius-pill);
+  color: color-mix(in srgb, var(--tl-sport, var(--accent-strong)) 82%, var(--text-primary));
+  background: color-mix(in srgb, var(--tl-sport, var(--accent)) 10%, transparent);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  line-height: 1.5;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.tl-sport-badge svg {
+  flex: none;
+  color: var(--tl-sport, var(--accent));
+}
+
+.tl-sport-badge > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Dense rows keep the colour and the icon but drop the pill chrome. */
+.tl-sport-badge.is-compact {
+  padding: 0;
+  border: 0;
+  color: color-mix(in srgb, var(--tl-sport, var(--accent)) 74%, var(--text-secondary));
+  background: none;
+  font-size: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
+  text-transform: none;
+}
+
+/* One mini icon chip per sport — plan mixes, editor entries, pickers. */
+.tl-sport-dots {
+  display: inline-flex;
+  min-width: 0;
+  flex: none;
+  align-items: center;
+  gap: 4px;
+}
+
+.tl-sport-dot {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in srgb, var(--tl-sport, var(--accent)) 30%, transparent);
+  border-radius: 50%;
+  color: var(--tl-sport, var(--accent));
+  background: color-mix(in srgb, var(--tl-sport, var(--accent)) 10%, transparent);
+}
+
+.tl-sport-dots > b {
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+/* Provenance labels: colour says where a plan came from. */
+.tl-source {
+  font-style: normal;
+}
+
+.tl-source[data-source="coros"] {
+  color: var(--accent-strong);
+}
+
+.tl-source[data-source="coach"] {
+  color: #c084fc;
+}
+
+.tl-source[data-source="template"] {
+  color: #eab308;
+}
+
+.tl-source[data-source="local"] {
+  color: var(--text-secondary);
+}
+
+/* On tiles the source gets a dot; list rows keep their "·" separators. */
+.tl-card-top .tl-source {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.tl-card-top .tl-source::before {
+  width: 5px;
+  height: 5px;
+  flex: none;
+  border-radius: 50%;
+  background: currentColor;
+  content: "";
+}
+
 .tl-fig.is-quiet {
   color: var(--text-muted);
   font-size: 12px;
@@ -1292,20 +1402,376 @@
   }
 }
 
-/* Workout tiles carry no weekly data, so they stay shorter and text-only. */
+/* ------------------------------------------------------- Workout tiles */
+
+/*
+ * A plan tile draws its ridge; a workout tile draws its load meter — one
+ * figure each, and nothing else on the tile is drawn. The meter reads as a
+ * share of the heaviest workout in the library, filled in the sport's own
+ * hue, so a grid of tiles sorts itself into light and heavy days by bar
+ * length alone. Everything below it is provenance: how much, how often, and
+ * how long since the session was last used.
+ *
+ * Tracks auto-fill rather than a fixed four, so the tiles keep a readable
+ * width when the reader takes its 392px and when it collapses away.
+ */
 .tl-catalog .tl-grid {
-  grid-template-columns: repeat(auto-fill, minmax(196px, 1fr));
-}
+  --tl-tile: #131418;
+  --tl-tile-hover: #191b20;
 
-.tl-catalog .tl-card {
-  min-height: 120px;
-}
-
-/* With no ridge to push them down, the figures take the auto margin instead so
-   they still land on the tile floor when a name wraps to two lines. */
-.tl-catalog .tl-card-figs {
+  grid-template-columns: repeat(auto-fill, minmax(246px, 1fr));
   gap: 14px;
+  padding: 18px;
+}
+
+/*
+ * The tile is a dark plate, sunk below the panel rather than raised over it:
+ * near-black charcoal, one hairline, and no accent stripe, wash, or glow. All
+ * the colour a tile carries is the sport's, and only where the sport is the
+ * information — the badge, the load bar, the glyph behind them.
+ */
+.tl-catalog .tl-card {
+  min-height: 190px;
+  border-color: var(--tl-rule-soft);
+  background: var(--tl-tile);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.028),
+    0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+/* ::before is the accent wash, ::after the sport stripe. Neither survives. */
+.tl-catalog .tl-card::before,
+.tl-catalog .tl-card[data-accent]::before,
+.tl-catalog .tl-card[data-accent]::after {
+  content: none;
+}
+
+.tl-catalog .tl-card:hover,
+.tl-catalog .tl-card[data-accent]:hover {
+  border-color: color-mix(in srgb, var(--text-muted) 48%, transparent);
+  background: var(--tl-tile-hover);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.045),
+    0 2px 5px rgba(0, 0, 0, 0.34),
+    0 14px 30px rgba(0, 0, 0, 0.28);
+  transform: translateY(-2px);
+}
+
+/* Reading and selection read as light on the edge, never as hue. */
+.tl-catalog .tl-card.is-active,
+.tl-catalog .tl-card[data-accent].is-active {
+  border-color: color-mix(in srgb, var(--text-primary) 40%, transparent);
+  background: var(--tl-tile-hover);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 0 0 1px color-mix(in srgb, var(--text-primary) 14%, transparent),
+    0 2px 5px rgba(0, 0, 0, 0.32);
+}
+
+.tl-catalog .tl-card.is-selected,
+.tl-catalog .tl-card[data-accent].is-selected {
+  border-color: color-mix(in srgb, var(--text-primary) 58%, transparent);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 0 0 1px color-mix(in srgb, var(--text-primary) 24%, transparent),
+    0 2px 5px rgba(0, 0, 0, 0.32);
+}
+
+.tl-catalog .tl-card-open {
+  gap: 9px;
+  padding: 15px 16px 14px;
+}
+
+/* Everything on the tile sits over the sport glyph behind it. */
+.tl-catalog .tl-card-open > :not(.tl-wk-glyph) {
+  position: relative;
+  z-index: 1;
+}
+
+.tl-catalog .tl-card-name {
+  font-size: 16.5px;
+  line-height: 1.24;
+}
+
+/* Centred on the sport badge opposite it, not on the tile corner. */
+.tl-catalog .tl-card > .tl-mark {
+  top: 17px;
+  right: 16px;
+}
+
+/*
+ * The sport's own icon at reading size, cropped by the tile corner: sport
+ * recognition from the corner of the eye, held at an alpha that never
+ * competes with the name or the meter. The mask fades it out towards the
+ * text, so a busy glyph — the dumbbell, the swimmer — never reads as noise
+ * behind the footer.
+ */
+.tl-wk-glyph {
+  position: absolute;
+  right: -30px;
+  bottom: -24px;
+  z-index: 0;
+  color: var(--tl-sport-accent, var(--accent));
+  opacity: 0.09;
+  pointer-events: none;
+  mask-image: radial-gradient(circle at 78% 78%, #000, transparent 72%);
+  transition:
+    opacity 260ms var(--tl-ease-out),
+    transform 320ms var(--tl-ease-out);
+}
+
+.tl-card:hover .tl-wk-glyph,
+.tl-card.is-active .tl-wk-glyph {
+  opacity: 0.15;
+  transform: translate(-5px, -5px);
+}
+
+.tl-wk-tags {
+  display: flex;
+  min-width: 0;
+  max-height: 20px;
+  flex-wrap: wrap;
+  gap: 4px;
+  overflow: hidden;
+}
+
+.tl-wk-tags em {
+  padding: 1.5px 7px;
+  border: 1px solid var(--tl-rule-soft);
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-style: normal;
+  line-height: 1.5;
+  white-space: nowrap;
+}
+
+.tl-wk-tags em.is-more {
+  border-style: dashed;
+  color: var(--text-muted);
+}
+
+/* The auto margin lands the meter and the footer on the tile floor, so bars
+   line up across a row however far a name wraps. */
+.tl-wk-meter {
+  display: flex;
+  flex-direction: column;
   margin-top: auto;
+  gap: 6px;
+  padding-top: 4px;
+}
+
+.tl-wk-meter-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.tl-wk-meter-head small {
+  color: var(--text-muted);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.tl-wk-meter-head b {
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: 19px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+  line-height: 1;
+}
+
+.tl-wk-meter-head b.is-nil {
+  color: var(--text-muted);
+  font-size: 15px;
+  font-weight: 500;
+}
+
+.tl-wk-load {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.tl-wk-load em {
+  color: var(--text-muted);
+  font-size: 9.5px;
+  font-style: normal;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+/*
+ * The session drawn as it is run: one segment per step, sized by how long the
+ * step lasts, repeats expanded so an interval set reads as a comb.
+ *
+ * This is the calendar's structure bar (.sched-bar in styles.css), brought
+ * over intact — same framed track, same 2px gaps and rounded pills, same
+ * phase hues, same hatched rest. The two views show the same thing, so they
+ * should look like the same thing. Only the height and the work colour differ:
+ * the tile is shorter, and work takes the tile's own sport accent.
+ */
+.tl-wk-shape {
+  --step-warmup: #f0a72e;
+  --step-rest: #9099aa;
+  --step-cooldown: #27c2e5;
+  --step-sendoff: #b48cff;
+
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  height: 22px;
+  padding: 3px;
+  border: 1px solid var(--tl-rule-soft);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.028);
+  animation: tl-wk-fill 460ms var(--tl-ease-out) backwards;
+  transform-origin: left;
+}
+
+.tl-wk-shape i {
+  min-width: 4px;
+  flex-basis: 0;
+  border-radius: 3px;
+  background: var(--tl-sport-accent, var(--accent));
+  transition: filter 150ms ease;
+}
+
+/* A long interval set has more steps than a tile has pixels for pills, so the
+   comb closes up and reads as a striped band instead of overflowing. */
+.tl-wk-shape[data-dense] {
+  gap: 1px;
+  padding: 2px;
+}
+
+.tl-wk-shape[data-dense] i {
+  min-width: 1px;
+  border-radius: 1px;
+}
+
+/*
+ * Warm-up and cool-down keep the calendar's hues but sit back a step in value.
+ * At tile size hue alone is not enough to separate them from the work blocks:
+ * the bike accent (#e6b800) and the warm-up amber (#f0a72e) are near neighbours,
+ * as are the trail blue and the cool-down cyan. Recessing the framing phases
+ * keeps work reading as work whatever sport the tile is.
+ */
+.tl-wk-shape i.is-warmup {
+  background: color-mix(in srgb, var(--step-warmup) 68%, transparent);
+}
+
+.tl-wk-shape i.is-training {
+  background: var(--tl-sport-accent, var(--accent));
+}
+
+.tl-wk-shape i.is-cooldown {
+  background: color-mix(in srgb, var(--step-cooldown) 68%, transparent);
+}
+
+.tl-wk-shape i.is-sendOff {
+  background: var(--step-sendoff);
+}
+
+.tl-wk-shape i.is-rest {
+  background: repeating-linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--step-rest) 62%, transparent) 0 4px,
+    color-mix(in srgb, var(--step-rest) 28%, transparent) 4px 8px
+  );
+}
+
+.tl-wk-shape i:hover,
+.tl-card:hover .tl-wk-shape i {
+  filter: brightness(1.18);
+}
+
+/*
+ * The load bar stands in until the steps arrive — same frame, same height, so
+ * the tile never reflows when the comb replaces it. Workouts COROS gives no
+ * structure for keep it for good.
+ */
+.tl-wk-track {
+  display: block;
+  height: 22px;
+  padding: 3px;
+  border: 1px solid var(--tl-rule-soft);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.028);
+}
+
+/* A hatched fill says COROS reported no load, which is not the same as none. */
+.tl-wk-track.is-nil {
+  background:
+    repeating-linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--text-muted) 26%, transparent) 0 4px,
+      transparent 4px 8px
+    ),
+    rgba(255, 255, 255, 0.028);
+}
+
+.tl-wk-track i {
+  display: block;
+  height: 100%;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--tl-sport-accent, var(--accent)) 78%, transparent);
+  transform-origin: left;
+  animation: tl-wk-fill 560ms var(--tl-ease-out) backwards;
+  transition: filter 200ms ease;
+}
+
+.tl-card:hover .tl-wk-track i {
+  filter: brightness(1.16) saturate(1.08);
+}
+
+@keyframes tl-wk-fill {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+.tl-wk-foot {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 3px 11px;
+  padding-top: 10px;
+  border-top: 1px solid var(--tl-rule-soft);
+  color: var(--text-muted);
+  font-size: 10.5px;
+  line-height: 1.5;
+}
+
+.tl-wk-foot > span {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tl-wk-foot svg {
+  flex: none;
+  opacity: 0.7;
+}
+
+.tl-wk-foot b {
+  color: var(--text-secondary);
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
 /* -------------------------------------------------------- Layout switch */
@@ -1410,6 +1876,85 @@
 
 .tl-row:hover .tl-ridge-bar.is-peak {
   filter: brightness(1.1);
+}
+
+/*
+ * Sport accent. A tile or row with [data-accent] carries --tl-sport-accent
+ * inline (see sportTheme): the tile borrows the sport's hue for its top
+ * stripe, hover glow, and load ridge; the row gets a quiet leading edge.
+ * Grey session-count ridges stay grey so they are never mistaken for load.
+ */
+.tl-card[data-accent]::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 2.5px;
+  background: linear-gradient(90deg, var(--tl-sport-accent), color-mix(in srgb, var(--tl-sport-accent) 22%, transparent));
+  content: "";
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.tl-card[data-accent]::before {
+  background:
+    radial-gradient(ellipse 120% 70% at 50% -18%, color-mix(in srgb, var(--tl-sport-accent) 14%, transparent), transparent 62%);
+}
+
+.tl-card[data-accent]:hover {
+  border-color: color-mix(in srgb, var(--tl-sport-accent) 42%, var(--glass-border));
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.18),
+    0 18px 38px rgba(0, 0, 0, 0.2),
+    0 0 0 1px color-mix(in srgb, var(--tl-sport-accent) 14%, transparent),
+    0 10px 30px color-mix(in srgb, var(--tl-sport-accent) 12%, transparent);
+}
+
+.tl-card[data-accent].is-selected {
+  border-color: color-mix(in srgb, var(--tl-sport-accent) 62%, transparent);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.16),
+    0 12px 28px rgba(0, 0, 0, 0.15),
+    0 0 0 1px color-mix(in srgb, var(--tl-sport-accent) 30%, transparent),
+    0 8px 26px color-mix(in srgb, var(--tl-sport-accent) 16%, transparent);
+}
+
+.tl-card[data-accent].is-active {
+  border-color: color-mix(in srgb, var(--tl-sport-accent) 58%, var(--glass-border));
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.16),
+    0 12px 28px rgba(0, 0, 0, 0.15),
+    0 0 0 1px color-mix(in srgb, var(--tl-sport-accent) 22%, transparent);
+}
+
+.tl-card[data-accent] .tl-card-top > svg {
+  color: var(--tl-sport-accent);
+}
+
+.tl-row[data-accent] {
+  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--tl-sport-accent) 72%, transparent);
+}
+
+.tl-row[data-accent].is-selected {
+  background: color-mix(in srgb, var(--tl-sport-accent) 10%, transparent);
+}
+
+.tl-row[data-accent] .tl-row-name > svg {
+  color: var(--tl-sport-accent);
+}
+
+.tl-card[data-accent] .tl-ridge:not(.is-count) .tl-ridge-bar:not(.is-empty),
+.tl-row[data-accent] .tl-ridge:not(.is-count) .tl-ridge-bar:not(.is-empty) {
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--tl-sport-accent) 86%, transparent), color-mix(in srgb, var(--tl-sport-accent) 52%, transparent));
+}
+
+.tl-card[data-accent] .tl-ridge:not(.is-count) .tl-ridge-bar.is-peak,
+.tl-row[data-accent] .tl-ridge:not(.is-count) .tl-ridge-bar.is-peak {
+  background: var(--tl-sport-accent);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    0 0 10px color-mix(in srgb, var(--tl-sport-accent) 46%, transparent);
 }
 
 /* The same axis at reading size: planned load pale, completed load solid. */
@@ -1587,24 +2132,14 @@
   content: "";
 }
 
-.tl-reader-sport[data-sport="strength"] {
-  --tl-sport: var(--sport-strength);
+/* With the sport's own icon inside, the generic dot steps aside. */
+.tl-reader-sport.has-icon::before {
+  content: none;
 }
 
-.tl-reader-sport[data-sport="trail"] {
-  --tl-sport: var(--sport-trail);
-}
-
-.tl-reader-sport[data-sport="run"] {
-  --tl-sport: var(--sport-run);
-}
-
-.tl-reader-sport[data-sport="bike"] {
-  --tl-sport: var(--sport-bike);
-}
-
-.tl-reader-sport[data-sport="other"] {
-  --tl-sport: var(--sport-other);
+.tl-reader-sport svg {
+  flex: none;
+  color: var(--tl-sport, var(--accent));
 }
 
 .tl-reader-favorite {
@@ -1734,39 +2269,75 @@
   box-shadow: var(--shadow-inset);
 }
 
-/* Time is continuous, so the segments abut: only the fill marks a boundary. */
+/*
+ * The bar is the calendar's structure bar (.sched-bar in styles.css) at reading
+ * size: discrete pills over a framed track, one per step, sized by how long the
+ * step runs. The tile comb, this bar, and the calendar's all draw the same
+ * thing the same way — see the .tl-wk-shape block for the phase palette.
+ */
 .tl-shape > div {
+  --step-warmup: #f0a72e;
+  --step-rest: #9099aa;
+  --step-cooldown: #27c2e5;
+  --step-sendoff: #b48cff;
+
   display: flex;
+  align-items: stretch;
+  gap: 3px;
   height: 36px;
-  border: 1px solid color-mix(in srgb, var(--accent) 16%, transparent);
+  padding: 4px;
+  border: 1px solid var(--tl-rule-soft);
   border-radius: 8px;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.07);
-  overflow: hidden;
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 /* Segment fills scope to the bar itself, never the caption or legend spans. */
 .tl-shape > div > span {
-  min-width: 1px;
-  background: color-mix(in srgb, var(--accent) 30%, transparent);
+  min-width: 5px;
+  flex-basis: 0;
+  border-radius: 4px;
+  background: var(--tl-sport-accent, var(--accent));
   transition: filter 160ms ease;
 }
 
+/* A long interval set closes the pills up rather than overflowing the panel. */
+.tl-shape > div[data-dense] {
+  gap: 1.5px;
+  padding: 3px;
+}
+
+.tl-shape > div[data-dense] > span {
+  min-width: 1px;
+  border-radius: 2px;
+}
+
 .tl-shape > div > span:hover {
-  filter: brightness(1.25);
+  filter: brightness(1.18);
 }
 
 .tl-shape > div > span.is-training {
-  background: linear-gradient(180deg, var(--accent-strong), var(--accent));
+  background: var(--tl-sport-accent, var(--accent));
 }
 
-.tl-shape > div > span.is-warmup,
+.tl-shape > div > span.is-warmup {
+  background: color-mix(in srgb, var(--step-warmup) 68%, transparent);
+}
+
 .tl-shape > div > span.is-cooldown {
-  background: color-mix(in srgb, var(--accent) 28%, transparent);
+  background: color-mix(in srgb, var(--step-cooldown) 68%, transparent);
 }
 
-.tl-shape > div > span.is-rest,
 .tl-shape > div > span.is-sendOff {
-  background: color-mix(in srgb, var(--text-secondary) 26%, transparent);
+  background: var(--step-sendoff);
+}
+
+.tl-shape > div > span.is-rest {
+  background: repeating-linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--step-rest) 62%, transparent) 0 4px,
+    color-mix(in srgb, var(--step-rest) 28%, transparent) 4px 8px
+  );
 }
 
 .tl-shape figcaption,
@@ -1814,19 +2385,36 @@
   border-radius: 2.5px;
 }
 
+/* The legend keys the bar, so every swatch repeats a fill from it exactly. */
+.tl-shape-legend em {
+  --step-warmup: #f0a72e;
+  --step-rest: #9099aa;
+  --step-cooldown: #27c2e5;
+  --step-sendoff: #b48cff;
+}
+
 .tl-shape-legend em.is-training {
-  background: linear-gradient(180deg, var(--accent-strong), var(--accent));
-  box-shadow: 0 0 5px color-mix(in srgb, var(--accent) 40%, transparent);
+  background: var(--tl-sport-accent, var(--accent));
 }
 
-.tl-shape-legend em.is-warmup,
+.tl-shape-legend em.is-warmup {
+  background: color-mix(in srgb, var(--step-warmup) 68%, transparent);
+}
+
 .tl-shape-legend em.is-cooldown {
-  background: color-mix(in srgb, var(--accent) 32%, transparent);
+  background: color-mix(in srgb, var(--step-cooldown) 68%, transparent);
 }
 
-.tl-shape-legend em.is-rest,
 .tl-shape-legend em.is-sendOff {
-  background: color-mix(in srgb, var(--text-secondary) 26%, transparent);
+  background: var(--step-sendoff);
+}
+
+.tl-shape-legend em.is-rest {
+  background: repeating-linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--step-rest) 62%, transparent) 0 3px,
+    color-mix(in srgb, var(--step-rest) 28%, transparent) 3px 6px
+  );
 }
 
 /* The list and its eyebrow label travel as one zone, apart from the shape card. */
@@ -2752,10 +3340,6 @@
   }
 }
 
-:root[data-theme="paper"] .tl-skeleton {
-  --tl-shimmer: rgba(38, 34, 28, 0.07);
-}
-
 .tl-dialog-backdrop {
   position: fixed;
   inset: 0;
@@ -3072,6 +3656,17 @@
   font-size: 12.5px;
 }
 
+.plan-editor-sidebar .app-select {
+  width: 100%;
+}
+
+.plan-editor-sidebar .app-select-trigger {
+  min-height: 32px;
+  padding: 6px 9px;
+  font-size: 12.5px;
+  font-weight: 500;
+}
+
 .plan-editor-sidebar textarea {
   min-height: 58px;
   resize: vertical;
@@ -3246,20 +3841,11 @@
   transform: scale(0.99);
 }
 
-/* The row answers in the sport's own colour; the plus wakes on hover. */
-.plan-editor-library-list button[data-sport]::before {
-  width: 6px;
-  height: 6px;
-  flex: none;
-  border-radius: 50%;
-  background: var(--tl-sport, var(--accent));
-  content: "";
+/* The row answers with the sport's icon chip; the plus wakes on hover. */
+.plan-editor-library-list button > .tl-sport-dot {
+  width: 20px;
+  height: 20px;
 }
-
-.plan-editor-library-list button[data-sport="run"] { --tl-sport: var(--sport-run); }
-.plan-editor-library-list button[data-sport="bike"] { --tl-sport: var(--sport-bike); }
-.plan-editor-library-list button[data-sport="strength"] { --tl-sport: var(--sport-strength); }
-.plan-editor-library-list button[data-sport="other"] { --tl-sport: var(--sport-other); }
 
 .plan-editor-library-list button > .plan-editor-library-add {
   display: inline-flex;
@@ -3559,21 +4145,11 @@
   transform: none;
 }
 
-/* Workout cards carry the sport's colour as a small dot; rest and notes
-   stay quiet. */
-.plan-entry-card[data-sport]::before {
-  width: 6px;
-  height: 6px;
-  flex: none;
-  border-radius: 50%;
-  background: var(--tl-sport, var(--accent));
-  content: "";
+/* Workout cards carry the sport's icon chip; rest and notes stay quiet. */
+.plan-entry-card > .tl-sport-dot {
+  width: 17px;
+  height: 17px;
 }
-
-.plan-entry-card[data-sport="run"] { --tl-sport: var(--sport-run); }
-.plan-entry-card[data-sport="bike"] { --tl-sport: var(--sport-bike); }
-.plan-entry-card[data-sport="strength"] { --tl-sport: var(--sport-strength); }
-.plan-entry-card[data-sport="other"] { --tl-sport: var(--sport-other); }
 
 .plan-entry-card > span {
   display: flex;
@@ -4085,6 +4661,10 @@
 @media (max-width: 900px) {
   .training-library-view {
     padding: 22px 16px 16px;
+  }
+
+  .tl-catalog .tl-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .tl-masthead {
@@ -4873,6 +5453,10 @@
 }
 
 @media (max-width: 560px) {
+  .tl-catalog .tl-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .plan-generator-backdrop,
   .plan-calendar-backdrop { padding: 0; }
   .plan-generator,

--- a/src/training-library/trainingLibrary.css
+++ b/src/training-library/trainingLibrary.css
@@ -6,11 +6,11 @@
  * panels over ambient accent washes, one segmented control for the sections,
  * and the accent gradient reserved for moments of emphasis.
  *
- * The library is layered charcoal, never pure black — in *both* app themes.
- * It is the one surface that does not follow the paper reskin: a dark room
- * for the training record. The gate shares the same ground. The accent stays
- * the app's signature green; red and yellow stay reserved for danger and
- * caution.
+ * The library is its own room in either theme: layered charcoal, never pure
+ * black, when the app is dark; a deeper paper than the shell, panels lifted
+ * off it in near-white, when the app is paper. The gate shares that ground.
+ * The accent stays the app's signature green; red and yellow stay reserved
+ * for danger and caution.
  *
  * Only one thing is ever drawn — the ridge of weekly training load (Ridge.tsx),
  * small on an index row and at reading size on the adherence lede. It keeps to
@@ -20,9 +20,8 @@
  * settle, then ridges draw themselves. Everything sits under
  * prefers-reduced-motion, which the guard at the end of this file honours.
  *
- * Values derive from the app tokens in styles.css. The charcoal block below
- * pins the dark token set on the view itself, so the paper theme's light
- * values never reach the ledger.
+ * Values derive from the app tokens in styles.css; the two blocks below state
+ * only where the library departs from them, once per theme.
  */
 
 .training-library-view {
@@ -64,33 +63,34 @@
 }
 
 /*
- * Charcoal, always — the library is a dark room in both app themes.
+ * The library's own materials, stated once per theme.
  *
- * It works by pinning the dark token set on the view itself rather than
- * inventing new tokens: everything downstream — this file, plus shared
- * pieces like .app-select and .primary-button — follows for free. The
- * pinned set is the dark theme's palette from styles.css, so the paper
- * theme's light values (darkened accent, brown-tinted shadows, white
- * glass) never reach the ledger. The modals the editor renders inline
- * inherit all of this without a rule of their own.
+ * Both blocks work by pinning tokens on the view itself rather than inventing
+ * new names, so everything downstream — this file, plus shared pieces like
+ * .app-select and .primary-button — follows for free, and the modals the
+ * editor and the workspace render inline inherit it all without a rule of
+ * their own. Only what the library departs from is listed; the accent, the
+ * status hues, and the ambient washes come from the app theme untouched.
  *
- * The gate shares the block so the connect screen sits on the same charcoal.
+ * The two blocks are the same room lit from the same side. Dark stacks value
+ * upward — ground, panel, tile — and paper stacks it the same way with the
+ * range turned over: a deeper paper for the ground, near-white panels lifted
+ * off it, white tiles. Depth is a sheen and a lit top edge on dark, where the
+ * ground can still take light; on paper it is carried by the shadows instead,
+ * which is why every raised recipe is a token rather than a literal.
+ *
+ * The gate shares both blocks so the connect screen sits on the same ground.
  */
-.training-library-view,
-.training-library-gate {
+:root:not([data-theme="paper"]) :is(.training-library-view, .training-library-gate) {
   color-scheme: dark;
 
   --tl-ground: #16171b;
   --tl-panel-bg: #1d1f25;
   --tl-card: #23262e;
-  --tl-card-hover: #2b2f38;
   --tl-reader-bg: #1a1c21;
-
-  --bg-base: #16171b;
-  --bg-ambient-green: rgba(47, 190, 145, 0.1);
-  --bg-ambient-teal: rgba(31, 182, 166, 0.07);
-  --bg-ambient-gold: rgba(216, 155, 34, 0.04);
-  --bg-ambient-white: rgba(255, 255, 255, 0.035);
+  /* Catalog plates sit a step below the panel; hovering lifts them back to it. */
+  --tl-tile: #131418;
+  --tl-tile-hover: #191b20;
 
   --surface: #23262e;
   --glass-bg: rgba(255, 255, 255, 0.04);
@@ -103,32 +103,102 @@
   --text-secondary: #a9adb2;
   --text-muted: #7b8085;
 
-  --accent: #2fbe91;
-  --accent-strong: #4fd6a6;
-  --accent-2: #1fb6a6;
-  --accent-hover: #26a37c;
-  --accent-glow: rgba(47, 190, 145, 0.32);
-  --accent-soft: rgba(47, 190, 145, 0.12);
-  --accent-gradient: linear-gradient(135deg, #2fbe91 0%, #1fb6a6 100%);
-  --accent-gold: #d89b22;
+  /* Light from above: a sheen down a raised surface, a lit hairline on its
+     top edge, and a well for anything recessed into it. */
+  --tl-sheen: rgba(255, 255, 255, 0.05);
+  --tl-sheen-lit: rgba(255, 255, 255, 0.075);
+  --tl-sheen-fade: rgba(255, 255, 255, 0.014);
+  --tl-edge-light: rgba(255, 255, 255, 0.09);
+  --tl-well: rgba(255, 255, 255, 0.028);
+  --tl-shimmer: rgba(255, 255, 255, 0.09);
+  --tl-scrim: rgba(22, 23, 27, 0.76);
 
-  --success-bg: rgba(47, 190, 145, 0.15);
-  --success-border: rgba(110, 231, 168, 0.28);
-  --success-text: #6ee7a8;
-  --success-dot: #34d399;
+  --tl-shadow-card: 0 1px 2px rgba(0, 0, 0, 0.16), 0 10px 26px rgba(0, 0, 0, 0.14);
+  --tl-shadow-card-hover: 0 2px 4px rgba(0, 0, 0, 0.18), 0 18px 38px rgba(0, 0, 0, 0.2);
+  --tl-shadow-card-held: 0 1px 2px rgba(0, 0, 0, 0.16), 0 12px 28px rgba(0, 0, 0, 0.15);
+  --tl-shadow-plate: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --tl-shadow-plate-hover: 0 2px 5px rgba(0, 0, 0, 0.34), 0 14px 30px rgba(0, 0, 0, 0.28);
+  --tl-shadow-plate-held: 0 2px 5px rgba(0, 0, 0, 0.32);
+  --tl-shadow-week: 0 1px 2px rgba(0, 0, 0, 0.14), 0 8px 22px rgba(0, 0, 0, 0.12);
+  --tl-shadow-lift: 0 4px 14px rgba(0, 0, 0, 0.14);
 
-  --warning-bg: rgba(216, 155, 34, 0.15);
-  --warning-border: rgba(251, 191, 36, 0.25);
-  --warning-text: #fbbf24;
+  /* Provenance: where a plan came from, never what it contains. */
+  --tl-source-coach: #c084fc;
+  --tl-source-template: #eab308;
 
-  --error-bg: rgba(194, 65, 12, 0.15);
-  --error-border: rgba(248, 113, 113, 0.25);
-  --error-text: #f87171;
-  --error-dot: #f87171;
+  /* The calendar's phase hues (--step-* on .sched-detail), brought over so the
+     structure bar reads the same in both views. */
+  --step-warmup: #f0a72e;
+  --step-rest: #9099aa;
+  --step-cooldown: #27c2e5;
+  --step-sendoff: #b48cff;
 
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.28), 0 14px 32px rgba(0, 0, 0, 0.26);
   --shadow-elevated: 0 20px 44px rgba(0, 0, 0, 0.42);
   --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+:root[data-theme="paper"] :is(.training-library-view, .training-library-gate) {
+  color-scheme: light;
+
+  --tl-ground: #efebe1;
+  --tl-panel-bg: #fdfcf8;
+  --tl-card: #ffffff;
+  --tl-reader-bg: #f4f1e9;
+  --tl-tile: #f5f2ea;
+  --tl-tile-hover: #fbf9f4;
+
+  /*
+   * Controls take an ink wash rather than the app's white glass: the library's
+   * panels are already near-white, and a white-on-white fill leaves hover
+   * states with nothing to say.
+   */
+  --surface: #ffffff;
+  --glass-bg: rgba(38, 34, 28, 0.045);
+  --glass-bg-hover: rgba(38, 34, 28, 0.08);
+  --glass-bg-elevated: rgba(38, 34, 28, 0.1);
+  --glass-border: rgba(38, 34, 28, 0.14);
+  --glass-inset: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+
+  --text-primary: #26251f;
+  --text-secondary: #55524a;
+  --text-muted: #857f74;
+
+  /*
+   * The sheen survives only where paper is not already white — the reader
+   * dock, the week frames, the glass cards over a tinted ground. Recesses
+   * invert: a well is an ink wash, and its top edge darkens instead of lights.
+   */
+  --tl-sheen: rgba(255, 255, 255, 0.6);
+  --tl-sheen-lit: rgba(255, 255, 255, 0.85);
+  --tl-sheen-fade: rgba(255, 255, 255, 0);
+  --tl-edge-light: rgba(255, 255, 255, 0.8);
+  --tl-well: rgba(38, 34, 28, 0.055);
+  --tl-shimmer: rgba(255, 255, 255, 0.9);
+  --tl-scrim: rgba(38, 34, 28, 0.34);
+
+  --tl-shadow-card: 0 1px 2px rgba(60, 50, 35, 0.07), 0 10px 26px rgba(60, 50, 35, 0.09);
+  --tl-shadow-card-hover: 0 2px 4px rgba(60, 50, 35, 0.09), 0 18px 38px rgba(60, 50, 35, 0.14);
+  --tl-shadow-card-held: 0 1px 2px rgba(60, 50, 35, 0.07), 0 12px 28px rgba(60, 50, 35, 0.11);
+  /* Sunk, so the plate's shadow falls inward — until hover lifts it clear. */
+  --tl-shadow-plate: inset 0 1px 3px rgba(60, 50, 35, 0.07);
+  --tl-shadow-plate-hover: 0 2px 5px rgba(60, 50, 35, 0.08), 0 14px 30px rgba(60, 50, 35, 0.11);
+  --tl-shadow-plate-held: 0 2px 6px rgba(60, 50, 35, 0.1);
+  --tl-shadow-week: 0 1px 2px rgba(60, 50, 35, 0.05), 0 8px 22px rgba(60, 50, 35, 0.07);
+  --tl-shadow-lift: 0 4px 14px rgba(60, 50, 35, 0.1);
+
+  --tl-source-coach: #7c3aed;
+  --tl-source-template: #a16207;
+
+  /*
+   * The phase hues darken for paper. They are recessed by mixing toward
+   * transparent, which pales them against a light track rather than sinking
+   * them into it, so the dark-theme values would arrive here washed out.
+   */
+  --step-warmup: #c2740c;
+  --step-rest: #6f6a61;
+  --step-cooldown: #0f7f9c;
+  --step-sendoff: #7c4dd8;
 }
 
 .training-library-view :is(button, input, select, textarea) {
@@ -203,7 +273,7 @@
   border-color: color-mix(in srgb, var(--accent) 34%, var(--glass-border));
   color: var(--text-primary);
   background: var(--glass-bg-hover);
-  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.14);
+  box-shadow: var(--tl-shadow-lift);
   transform: translateY(-1px);
 }
 
@@ -491,7 +561,7 @@
   border-radius: var(--radius-lg);
   background:
     radial-gradient(ellipse 90% 62% at 14% 0%, var(--bg-ambient-green), transparent 58%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012) 42%),
+    linear-gradient(180deg, var(--tl-sheen), var(--tl-sheen-fade) 42%),
     var(--tl-panel-bg);
   box-shadow: var(--shadow-card), var(--glass-inset);
   backdrop-filter: blur(var(--glass-blur));
@@ -1022,11 +1092,11 @@
 }
 
 .tl-source[data-source="coach"] {
-  color: #c084fc;
+  color: var(--tl-source-coach);
 }
 
 .tl-source[data-source="template"] {
-  color: #eab308;
+  color: var(--tl-source-template);
 }
 
 .tl-source[data-source="local"] {
@@ -1185,11 +1255,9 @@
   border: 1px solid var(--tl-rule);
   border-radius: var(--radius-md);
   background:
-    linear-gradient(158deg, rgba(255, 255, 255, 0.055), rgba(255, 255, 255, 0.014) 46%),
+    linear-gradient(158deg, var(--tl-sheen), var(--tl-sheen-fade) 46%),
     var(--tl-card, var(--glass-bg));
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.16),
-    0 10px 26px rgba(0, 0, 0, 0.14);
+  box-shadow: var(--tl-shadow-card);
   overflow: hidden;
   transition:
     border-color 190ms ease,
@@ -1213,8 +1281,7 @@
 .tl-card:hover {
   border-color: color-mix(in srgb, var(--accent) 38%, var(--glass-border));
   box-shadow:
-    0 2px 4px rgba(0, 0, 0, 0.18),
-    0 18px 38px rgba(0, 0, 0, 0.2),
+    var(--tl-shadow-card-hover),
     0 0 0 1px color-mix(in srgb, var(--accent) 12%, transparent),
     0 10px 30px color-mix(in srgb, var(--accent) 10%, transparent);
   transform: translateY(-3px);
@@ -1228,8 +1295,7 @@
 .tl-card.is-selected {
   border-color: color-mix(in srgb, var(--accent) 62%, transparent);
   box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.16),
-    0 12px 28px rgba(0, 0, 0, 0.15),
+    var(--tl-shadow-card-held),
     0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent),
     0 8px 26px color-mix(in srgb, var(--accent) 16%, transparent);
 }
@@ -1237,8 +1303,7 @@
 .tl-card.is-active {
   border-color: color-mix(in srgb, var(--accent) 58%, var(--glass-border));
   box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.16),
-    0 12px 28px rgba(0, 0, 0, 0.15),
+    var(--tl-shadow-card-held),
     0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent);
 }
 
@@ -1416,27 +1481,25 @@
  * width when the reader takes its 392px and when it collapses away.
  */
 .tl-catalog .tl-grid {
-  --tl-tile: #131418;
-  --tl-tile-hover: #191b20;
-
   grid-template-columns: repeat(auto-fill, minmax(246px, 1fr));
   gap: 14px;
   padding: 18px;
 }
 
 /*
- * The tile is a dark plate, sunk below the panel rather than raised over it:
- * near-black charcoal, one hairline, and no accent stripe, wash, or glow. All
- * the colour a tile carries is the sport's, and only where the sport is the
- * information — the badge, the load bar, the glyph behind them.
+ * The tile is a plate sunk below the panel rather than raised over it: one
+ * step back from the panel's value in either theme, one hairline, and no
+ * accent stripe, wash, or glow. All the colour a tile carries is the sport's,
+ * and only where the sport is the information — the badge, the load bar, the
+ * glyph behind them.
  */
 .tl-catalog .tl-card {
   min-height: 190px;
   border-color: var(--tl-rule-soft);
   background: var(--tl-tile);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.028),
-    0 1px 2px rgba(0, 0, 0, 0.3);
+    inset 0 1px 0 var(--tl-well),
+    var(--tl-shadow-plate);
 }
 
 /* ::before is the accent wash, ::after the sport stripe. Neither survives. */
@@ -1451,9 +1514,8 @@
   border-color: color-mix(in srgb, var(--text-muted) 48%, transparent);
   background: var(--tl-tile-hover);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.045),
-    0 2px 5px rgba(0, 0, 0, 0.34),
-    0 14px 30px rgba(0, 0, 0, 0.28);
+    inset 0 1px 0 var(--tl-well),
+    var(--tl-shadow-plate-hover);
   transform: translateY(-2px);
 }
 
@@ -1463,18 +1525,18 @@
   border-color: color-mix(in srgb, var(--text-primary) 40%, transparent);
   background: var(--tl-tile-hover);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    inset 0 1px 0 var(--tl-well),
     0 0 0 1px color-mix(in srgb, var(--text-primary) 14%, transparent),
-    0 2px 5px rgba(0, 0, 0, 0.32);
+    var(--tl-shadow-plate-held);
 }
 
 .tl-catalog .tl-card.is-selected,
 .tl-catalog .tl-card[data-accent].is-selected {
   border-color: color-mix(in srgb, var(--text-primary) 58%, transparent);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    inset 0 1px 0 var(--tl-well),
     0 0 0 1px color-mix(in srgb, var(--text-primary) 24%, transparent),
-    0 2px 5px rgba(0, 0, 0, 0.32);
+    var(--tl-shadow-plate-held);
 }
 
 .tl-catalog .tl-card-open {
@@ -1618,11 +1680,6 @@
  * the tile is shorter, and work takes the tile's own sport accent.
  */
 .tl-wk-shape {
-  --step-warmup: #f0a72e;
-  --step-rest: #9099aa;
-  --step-cooldown: #27c2e5;
-  --step-sendoff: #b48cff;
-
   display: flex;
   align-items: stretch;
   gap: 2px;
@@ -1630,7 +1687,7 @@
   padding: 3px;
   border: 1px solid var(--tl-rule-soft);
   border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.028);
+  background: var(--tl-well);
   animation: tl-wk-fill 460ms var(--tl-ease-out) backwards;
   transform-origin: left;
 }
@@ -1702,7 +1759,7 @@
   padding: 3px;
   border: 1px solid var(--tl-rule-soft);
   border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.028);
+  background: var(--tl-well);
 }
 
 /* A hatched fill says COROS reported no load, which is not the same as none. */
@@ -1713,7 +1770,7 @@
       color-mix(in srgb, var(--text-muted) 26%, transparent) 0 4px,
       transparent 4px 8px
     ),
-    rgba(255, 255, 255, 0.028);
+    var(--tl-well);
 }
 
 .tl-wk-track i {
@@ -1904,8 +1961,7 @@
 .tl-card[data-accent]:hover {
   border-color: color-mix(in srgb, var(--tl-sport-accent) 42%, var(--glass-border));
   box-shadow:
-    0 2px 4px rgba(0, 0, 0, 0.18),
-    0 18px 38px rgba(0, 0, 0, 0.2),
+    var(--tl-shadow-card-hover),
     0 0 0 1px color-mix(in srgb, var(--tl-sport-accent) 14%, transparent),
     0 10px 30px color-mix(in srgb, var(--tl-sport-accent) 12%, transparent);
 }
@@ -1913,8 +1969,7 @@
 .tl-card[data-accent].is-selected {
   border-color: color-mix(in srgb, var(--tl-sport-accent) 62%, transparent);
   box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.16),
-    0 12px 28px rgba(0, 0, 0, 0.15),
+    var(--tl-shadow-card-held),
     0 0 0 1px color-mix(in srgb, var(--tl-sport-accent) 30%, transparent),
     0 8px 26px color-mix(in srgb, var(--tl-sport-accent) 16%, transparent);
 }
@@ -1922,8 +1977,7 @@
 .tl-card[data-accent].is-active {
   border-color: color-mix(in srgb, var(--tl-sport-accent) 58%, var(--glass-border));
   box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.16),
-    0 12px 28px rgba(0, 0, 0, 0.15),
+    var(--tl-shadow-card-held),
     0 0 0 1px color-mix(in srgb, var(--tl-sport-accent) 22%, transparent);
 }
 
@@ -2264,7 +2318,7 @@
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-md);
   background:
-    linear-gradient(160deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.012) 48%),
+    linear-gradient(160deg, var(--tl-sheen), var(--tl-sheen-fade) 48%),
     var(--glass-bg);
   box-shadow: var(--shadow-inset);
 }
@@ -2276,11 +2330,6 @@
  * thing the same way — see the .tl-wk-shape block for the phase palette.
  */
 .tl-shape > div {
-  --step-warmup: #f0a72e;
-  --step-rest: #9099aa;
-  --step-cooldown: #27c2e5;
-  --step-sendoff: #b48cff;
-
   display: flex;
   align-items: stretch;
   gap: 3px;
@@ -2288,8 +2337,8 @@
   padding: 4px;
   border: 1px solid var(--tl-rule-soft);
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.03);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  background: var(--tl-well);
+  box-shadow: inset 0 1px 0 var(--tl-well);
 }
 
 /* Segment fills scope to the bar itself, never the caption or legend spans. */
@@ -2386,13 +2435,6 @@
 }
 
 /* The legend keys the bar, so every swatch repeats a fill from it exactly. */
-.tl-shape-legend em {
-  --step-warmup: #f0a72e;
-  --step-rest: #9099aa;
-  --step-cooldown: #27c2e5;
-  --step-sendoff: #b48cff;
-}
-
 .tl-shape-legend em.is-training {
   background: var(--tl-sport-accent, var(--accent));
 }
@@ -2612,10 +2654,10 @@
   border-top: 1px solid color-mix(in srgb, var(--accent) 18%, var(--tl-rule));
   background:
     radial-gradient(ellipse 105% 100% at 0% 0%, color-mix(in srgb, var(--accent) 11%, transparent), transparent 64%),
-    linear-gradient(145deg, rgba(255, 255, 255, 0.075), rgba(255, 255, 255, 0.018) 54%),
+    linear-gradient(145deg, var(--tl-sheen-lit), var(--tl-sheen-fade) 54%),
     color-mix(in srgb, var(--tl-reader-bg, var(--surface)) 86%, transparent);
   box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.11),
+    inset 0 1px 0 var(--tl-edge-light),
     0 -18px 42px color-mix(in srgb, var(--tl-reader-bg, var(--surface)) 72%, transparent);
   backdrop-filter: blur(24px) saturate(145%);
   -webkit-backdrop-filter: blur(24px) saturate(145%);
@@ -2641,8 +2683,8 @@
   position: absolute;
   z-index: -1;
   inset: 1px 0 0;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  background: linear-gradient(105deg, rgba(255, 255, 255, 0.035), transparent 42%);
+  border-top: 1px solid var(--tl-edge-light);
+  background: linear-gradient(105deg, var(--tl-sheen), transparent 42%);
   content: "";
   pointer-events: none;
 }
@@ -2671,7 +2713,7 @@
   border-radius: var(--radius-sm);
   color: var(--accent-strong);
   background: color-mix(in srgb, var(--accent) 10%, var(--glass-bg));
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  box-shadow: inset 0 1px 0 var(--tl-edge-light);
 }
 
 .tl-reader-schedule-heading > span:last-child {
@@ -2746,7 +2788,7 @@
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--glass-bg) 78%, transparent);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.055);
+  box-shadow: inset 0 1px 0 var(--tl-edge-light);
 }
 
 .tl-reader-duplicate > .ghost-button {
@@ -3198,7 +3240,7 @@
   border-radius: 50%;
   color: var(--accent-strong);
   background:
-    radial-gradient(circle at 32% 26%, rgba(255, 255, 255, 0.12), transparent 52%),
+    radial-gradient(circle at 32% 26%, var(--tl-edge-light), transparent 52%),
     var(--glass-bg);
   box-shadow:
     var(--glass-inset),
@@ -3320,7 +3362,7 @@
   background: linear-gradient(
     100deg,
     transparent 22%,
-    var(--tl-shimmer, rgba(255, 255, 255, 0.09)) 50%,
+    var(--tl-shimmer) 50%,
     transparent 78%
   );
   content: "";
@@ -3346,7 +3388,7 @@
   z-index: 110;
   display: grid;
   padding: 24px;
-  background: color-mix(in srgb, var(--bg-base) 76%, transparent);
+  background: var(--tl-scrim);
   backdrop-filter: blur(8px);
   place-items: center;
   animation: tl-fade-in 200ms ease both;
@@ -3487,7 +3529,7 @@
   position: fixed;
   inset: 0;
   z-index: -1;
-  background: color-mix(in srgb, var(--bg-base) 72%, transparent);
+  background: var(--tl-scrim);
   backdrop-filter: blur(10px);
   content: "";
   animation: tl-fade-in 240ms ease both;
@@ -3981,9 +4023,9 @@
   border: 1px solid var(--tl-rule);
   border-radius: var(--radius-md);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.03), transparent 30%),
+    linear-gradient(180deg, var(--tl-sheen), transparent 30%),
     color-mix(in srgb, var(--surface) 30%, transparent);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.14), 0 8px 22px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--tl-shadow-week);
   overflow: hidden;
 }
 
@@ -4773,7 +4815,7 @@
   z-index: 120;
   display: grid;
   padding: 20px;
-  background: color-mix(in srgb, var(--bg-base) 78%, transparent);
+  background: var(--tl-scrim);
   backdrop-filter: blur(10px);
   place-items: center;
   animation: tl-fade-in 180ms ease both;


### PR DESCRIPTION
## What changed

- adds development-only COROS gear management, including account queries, validation, and gear creation
- refreshes the training-library workout cards, sport theming, structure previews, and editor controls
- improves shared navigation, select controls, and calendar workout-builder styling
- expands COROS mobile service coverage and tests for gear payload parsing and validation

## Why

This brings gear tracking into CorosLink and makes workout planning and browsing clearer and more consistent across sports.

## Impact

Developers can test gear management from Dev view. Training Library and workout creation now provide richer visual structure and more consistent sport-aware controls.

## Validation

- `npm run build`
- `npm run test:coros-watchfaces`
- `npm run test:training-library`
