### PR TITLE
Improve chat, training insights, navigation, and saved views

### DIFF
--- a/electron/chatModels.ts
+++ b/electron/chatModels.ts
@@ -1,0 +1,51 @@
+export interface ChatModelOption {
+  value: string;
+  label: string;
+}
+
+export const CHATGPT_MODEL_OPTIONS: ChatModelOption[] = [
+  { value: "", label: "Auto" },
+  { value: "gpt-5.6-sol", label: "GPT-5.6 Sol" },
+  { value: "gpt-5.6-terra", label: "GPT-5.6 Terra" },
+  { value: "gpt-5.6-luna", label: "GPT-5.6 Luna" },
+  { value: "gpt-5.5", label: "GPT-5.5" },
+  { value: "gpt-5.4", label: "GPT-5.4" }
+];
+
+export const CLAUDE_MODEL_OPTIONS: ChatModelOption[] = [
+  { value: "", label: "Account default" },
+  { value: "opus", label: "Claude Opus" },
+  { value: "sonnet", label: "Claude Sonnet" },
+  { value: "haiku", label: "Claude Haiku" }
+];
+
+const CHATGPT_AUTO_MODEL_IDS = [
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+  "gpt-5.5",
+  "gpt-5.4",
+  "gpt-5.4-mini",
+  "gpt-5-codex"
+];
+
+export function getChatGptModelCandidates(
+  selectedModel?: string,
+  cachedModel?: string
+): string[] {
+  const selected = selectedModel?.trim();
+  if (selected) {
+    return [selected];
+  }
+
+  const cached = cachedModel?.trim();
+  return cached
+    ? [cached, ...CHATGPT_AUTO_MODEL_IDS.filter((model) => model !== cached)]
+    : [...CHATGPT_AUTO_MODEL_IDS];
+}
+
+export function getChatModelOptions(provider: string): ChatModelOption[] {
+  return provider === "claude-code"
+    ? CLAUDE_MODEL_OPTIONS
+    : CHATGPT_MODEL_OPTIONS;
+}

--- a/electron/chatService.ts
+++ b/electron/chatService.ts
@@ -69,6 +69,7 @@ import {
   type ChatApiKeyStore,
   type ChatSettingsStore
 } from "./chatSettingsStore";
+import { getChatGptModelCandidates } from "./chatModels";
 import {
   createChatSession,
   deleteChatSession,
@@ -128,17 +129,6 @@ const LOOPBACK_PORT = 1455;
 const LOOPBACK_REDIRECT_URI = `http://localhost:${LOOPBACK_PORT}/auth/callback`;
 
 const RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
-// Models offered to ChatGPT-plan users via the codex endpoint. OpenAI rotates
-// these often and availability is plan-dependent, so we try them in order and
-// cache the first the account accepts (see resolveModelAndOpenStream). Ordered
-// best-broadly-available first. Adjust here as OpenAI's lineup changes.
-const CHAT_MODEL_CANDIDATES = [
-  "gpt-5.5",
-  "gpt-5.4",
-  "gpt-5.4-mini",
-  "gpt-5-codex"
-];
-
 // Max agent rounds: each round is one model response; if it calls COROS tools
 // we execute them and loop, until it answers with no further tool calls.
 const MAX_TOOL_ROUNDS = 10;
@@ -807,7 +797,8 @@ export async function streamChat(
         effectiveInstructions,
         input,
         tools,
-        controller.signal
+        controller.signal,
+        settings.chatgpt.model
       );
       if ("error" in opened) {
         send("chat:streamError", {
@@ -1180,9 +1171,9 @@ function findChatTool(name: string): CorosMcpTool | undefined {
 // ----- Provider request/response shape (isolated) -----
 
 /**
- * Sends the request, trying candidate models until the account accepts one
- * (the ChatGPT-plan codex endpoint rejects unsupported models with a 400 before
- * any streaming). Caches the working model so later calls skip the probing.
+ * Sends the request with the selected model. Auto mode tries candidates until
+ * the account accepts one (the ChatGPT-plan codex endpoint rejects unsupported
+ * models with a 400 before streaming), then caches the working model.
  */
 async function resolveModelAndOpenStream(
   token: StoredChatToken,
@@ -1190,12 +1181,11 @@ async function resolveModelAndOpenStream(
   instructions: string,
   input: Record<string, unknown>[],
   tools: Record<string, unknown>[],
-  signal: AbortSignal
+  signal: AbortSignal,
+  selectedModel?: string
 ): Promise<{ response: Response } | { error: string; authError: boolean }> {
   const cached = getSetting(SETTINGS.model);
-  const candidates = cached
-    ? [cached, ...CHAT_MODEL_CANDIDATES.filter((model) => model !== cached)]
-    : [...CHAT_MODEL_CANDIDATES];
+  const candidates = getChatGptModelCandidates(selectedModel, cached);
 
   let lastDetail = "";
   for (const model of candidates) {
@@ -1262,7 +1252,9 @@ async function resolveModelAndOpenStream(
   }
 
   return {
-    error: `No supported chat model for this ChatGPT account. ${truncate(lastDetail, 600)}`,
+    error: selectedModel?.trim()
+      ? `The selected model (${selectedModel.trim()}) is not available for this ChatGPT account. ${truncate(lastDetail, 600)}`
+      : `No supported chat model for this ChatGPT account. ${truncate(lastDetail, 600)}`,
     authError: false
   };
 }

--- a/electron/chatSettingsStore.ts
+++ b/electron/chatSettingsStore.ts
@@ -6,6 +6,7 @@ import {
 
 export const CHAT_SETTINGS_KEYS = {
   provider: "chat.provider",
+  chatgptModel: "chat.chatgpt.model",
   claudeExecutablePath: "chat.claudeCode.executablePath",
   claudeModel: "chat.claudeCode.model",
   claudeLastConnectionStatus: "chat.claudeCode.lastConnectionStatus",
@@ -41,6 +42,9 @@ export function readChatSettingsFromStore(
 ): ChatSettings {
   return {
     provider: normalizeProvider(store.get(CHAT_SETTINGS_KEYS.provider)),
+    chatgpt: {
+      model: store.get(CHAT_SETTINGS_KEYS.chatgptModel) || undefined
+    },
     claudeCode: {
       executablePath:
         store.get(CHAT_SETTINGS_KEYS.claudeExecutablePath) || undefined,
@@ -82,6 +86,12 @@ export function saveChatSettingsToStore(
   settings: ChatSettings
 ): ChatSettings {
   store.set(CHAT_SETTINGS_KEYS.provider, normalizeProvider(settings.provider));
+  const chatgptModel = settings.chatgpt?.model?.trim();
+  if (chatgptModel) {
+    store.set(CHAT_SETTINGS_KEYS.chatgptModel, chatgptModel);
+  } else {
+    store.delete([CHAT_SETTINGS_KEYS.chatgptModel]);
+  }
   const executablePath = settings.claudeCode?.executablePath?.trim();
   if (executablePath) {
     store.set(CHAT_SETTINGS_KEYS.claudeExecutablePath, executablePath);

--- a/electron/corosWorkoutBuilder.ts
+++ b/electron/corosWorkoutBuilder.ts
@@ -943,8 +943,11 @@ export function buildWorkoutPayload(
       : {}),
     estimatedTime: totalTime,
     estimatedDistance: totalDistance,
-    distanceDisplayUnit:
-      context?.distanceUnit === "imperial"
+    distanceDisplayUnit: sport === "swim"
+      ? context?.distanceUnit === "imperial"
+        ? COROS_DISTANCE_UNIT_YARDS
+        : COROS_DISTANCE_UNIT_METERS
+      : context?.distanceUnit === "imperial"
         ? COROS_DISTANCE_UNIT_MILES
         : COROS_DISTANCE_UNIT_KILOMETERS,
     estimatedType: totalDistance > 0 ? 6 : 0,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1533,7 +1533,8 @@ function registerIpcHandlers(): void {
   );
   ipcMain.handle(
     "trainingLibrary:addPlanToCalendar",
-    (_event, previewId: string, confirmed: boolean) => addTrainingPlanToCalendar(previewId, confirmed)
+    (_event, previewId: string, confirmed: boolean, unitSystem?: UnitSystem) =>
+      addTrainingPlanToCalendar(previewId, confirmed, normalizeUnitSystem(unitSystem))
   );
   ipcMain.handle(
     "trainingLibrary:previewPlanCalendarRemoval",

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -558,8 +558,12 @@ const api = {
     ipcRenderer.invoke("trainingLibrary:deletePlan", id, confirmed),
   previewTrainingPlanCalendar: (planId: string, startDate: string): Promise<TrainingPlanCalendarPreview> =>
     ipcRenderer.invoke("trainingLibrary:previewPlanCalendar", planId, startDate),
-  addTrainingPlanToCalendar: (previewId: string, confirmed: boolean): Promise<TrainingPlanCalendarMutationResult> =>
-    ipcRenderer.invoke("trainingLibrary:addPlanToCalendar", previewId, confirmed),
+  addTrainingPlanToCalendar: (
+    previewId: string,
+    confirmed: boolean,
+    unitSystem: UnitSystem
+  ): Promise<TrainingPlanCalendarMutationResult> =>
+    ipcRenderer.invoke("trainingLibrary:addPlanToCalendar", previewId, confirmed, unitSystem),
   previewTrainingPlanCalendarRemoval: (planId: string): Promise<TrainingPlanCalendarPreview> =>
     ipcRenderer.invoke("trainingLibrary:previewPlanCalendarRemoval", planId),
   removeTrainingPlanFromCalendar: (previewId: string, confirmed: boolean): Promise<TrainingPlanCalendarMutationResult> =>

--- a/electron/trainingLibraryService.ts
+++ b/electron/trainingLibraryService.ts
@@ -53,6 +53,7 @@ import type {
   TrainingPlanMetadataPatch,
   TrainingPlanWriteCapabilities,
   TrainingWorkoutMetadata,
+  UnitSystem,
   WorkoutMetadataPatch,
   WorkoutSport
 } from "./types";
@@ -693,7 +694,8 @@ async function captureScheduledIdentity(
 
 export async function addTrainingPlanToCalendar(
   previewId: string,
-  confirmed: boolean
+  confirmed: boolean,
+  unitSystem: UnitSystem
 ): Promise<TrainingPlanCalendarMutationResult> {
   const { record, plan } = await requireCurrentCalendarPreview(previewId, "install", confirmed);
   const projectedPlan = shiftTrainingPlan(plan, record.preview.startDate);
@@ -735,7 +737,7 @@ export async function addTrainingPlanToCalendar(
         await trainingPlanCalendarAdapter.createAndSchedule(
           { ...planEntry.workout, schedule_date: previewEntry.happenDay, save_to_library: false },
           previewEntry.happenDay,
-          "metric",
+          unitSystem,
           false
         );
       } else {

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -2416,8 +2416,14 @@ export interface LocalChatConfig {
   toolsEnabled: boolean;
 }
 
+export interface ChatGptConfig {
+  /** Optional model id. Empty uses the best model available to the account. */
+  model?: string;
+}
+
 export interface ChatSettings {
   provider: ChatProvider;
+  chatgpt: ChatGptConfig;
   claudeCode: ClaudeCodeConfig;
   local: LocalChatConfig;
   sidebarOpen?: boolean;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:sketch": "npm run build:electron && node scripts/test-sketch-geometry.mjs",
     "test:greetings": "node --experimental-strip-types scripts/test-greetings.mjs",
     "test:sport-colors": "node --experimental-strip-types scripts/test-sport-colors.mjs",
+    "test:selection-preferences": "node --experimental-strip-types scripts/test-selection-preferences.mjs",
     "test:calendar-drag": "node --experimental-strip-types scripts/test-calendar-drag.mjs",
     "test:scheduled-structure": "node --experimental-strip-types --import ./scripts/register-ts-ext.mjs scripts/test-scheduled-structure.mjs",
     "test:rpe-load": "node --experimental-strip-types scripts/test-rpe-load.mjs",

--- a/scripts/test-chat-service.mjs
+++ b/scripts/test-chat-service.mjs
@@ -479,6 +479,18 @@ globalThis.fetch = originalFetch;
 const { readChatSettingsFromStore, saveChatSettingsToStore } = await import(
   `${distUrl("chatSettingsStore.js")}?cacheBust=${Date.now()}`
 );
+const { getChatGptModelCandidates } = await import(
+  `${distUrl("chatModels.js")}?cacheBust=${Date.now()}`
+);
+
+assert.deepEqual(
+  getChatGptModelCandidates("gpt-5.6-terra", "gpt-5.5"),
+  ["gpt-5.6-terra"]
+);
+assert.deepEqual(
+  getChatGptModelCandidates(undefined, "gpt-5.5").slice(0, 2),
+  ["gpt-5.5", "gpt-5.6-sol"]
+);
 
 const settingsValues = new Map();
 let storedApiKey = "";
@@ -503,7 +515,11 @@ const fakeApiKeyStore = {
 
 const saved = saveChatSettingsToStore(fakeStore, fakeApiKeyStore, {
   provider: "claude-code",
+  chatgpt: {
+    model: "gpt-5.6-terra"
+  },
   claudeCode: {
+    model: "sonnet",
     executablePath: "/opt/claude/bin/claude",
     lastConnectionStatus: "connected",
     lastCheckedAt: "2026-07-10T12:00:00.000Z",
@@ -524,7 +540,9 @@ const saved = saveChatSettingsToStore(fakeStore, fakeApiKeyStore, {
   }
 });
 assert.equal(saved.provider, "claude-code");
+assert.equal(saved.chatgpt.model, "gpt-5.6-terra");
 assert.equal(saved.claudeCode.executablePath, "/opt/claude/bin/claude");
+assert.equal(saved.claudeCode.model, "sonnet");
 assert.equal(saved.claudeCode.lastConnectionStatus, "connected");
 assert.deepEqual(saved.claudeCode.permissions, {
   recentActivities: true,

--- a/scripts/test-coros-workout-builder.mjs
+++ b/scripts/test-coros-workout-builder.mjs
@@ -182,6 +182,7 @@ const imperialSwim = buildWorkoutPayload(
 );
 assert.equal(imperialSwim.poolLength, 2286);
 assert.equal(imperialSwim.poolLengthUnit, 4);
+assert.equal(imperialSwim.distanceDisplayUnit, 4);
 assert.equal(imperialSwim.exercises[0].targetValue, 9144);
 assert.equal(imperialSwim.exercises[0].targetDisplayUnit, 4);
 

--- a/scripts/test-selection-preferences.mjs
+++ b/scripts/test-selection-preferences.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const moduleUrl = pathToFileURL(
+  path.join(repoRoot, "src", "preferences", "selectionPreferences.ts")
+);
+const {
+  defineSelectionPreference,
+  readSelectionPreference,
+  selectionIsArrayOf,
+  selectionIsBoolean,
+  selectionIsOneOf,
+  selectionPreferenceStorageKey,
+  writeSelectionPreference
+} = await import(`${moduleUrl.href}?cacheBust=${Date.now()}`);
+
+class MemoryStorage {
+  values = new Map();
+
+  getItem(key) {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key, value) {
+    this.values.set(key, value);
+  }
+}
+
+const storage = new MemoryStorage();
+const tabPreference = defineSelectionPreference({
+  key: "test.tab",
+  defaultValue: "overview",
+  validate: selectionIsOneOf(["overview", "strength"])
+});
+
+assert.deepEqual(readSelectionPreference(tabPreference, storage), {
+  value: "overview",
+  restored: false
+});
+
+writeSelectionPreference(tabPreference, "strength", storage);
+assert.equal(
+  storage.getItem(selectionPreferenceStorageKey("test.tab")),
+  '"strength"'
+);
+assert.deepEqual(readSelectionPreference(tabPreference, storage), {
+  value: "strength",
+  restored: true
+});
+
+const filterPreference = defineSelectionPreference({
+  key: "test.filter",
+  defaultValue: { landscape: true, topo: true },
+  validate: (value) =>
+    typeof value === "object" &&
+    value !== null &&
+    selectionIsBoolean(value.landscape) &&
+    selectionIsBoolean(value.topo)
+});
+writeSelectionPreference(
+  filterPreference,
+  { landscape: false, topo: true },
+  storage
+);
+assert.deepEqual(readSelectionPreference(filterPreference, storage), {
+  value: { landscape: false, topo: true },
+  restored: true
+});
+
+const metricPreference = defineSelectionPreference({
+  key: "test.metrics",
+  defaultValue: ["distance"],
+  validate: selectionIsArrayOf(
+    selectionIsOneOf(["distance", "duration", "trainingLoad"]),
+    { minLength: 1, unique: true }
+  )
+});
+writeSelectionPreference(
+  metricPreference,
+  ["distance", "trainingLoad"],
+  storage
+);
+assert.deepEqual(readSelectionPreference(metricPreference, storage).value, [
+  "distance",
+  "trainingLoad"
+]);
+
+storage.setItem(selectionPreferenceStorageKey("test.tab"), "{broken");
+assert.deepEqual(readSelectionPreference(tabPreference, storage), {
+  value: "overview",
+  restored: false
+});
+
+storage.setItem(
+  selectionPreferenceStorageKey("test.tab"),
+  JSON.stringify("obsolete-tab")
+);
+assert.deepEqual(readSelectionPreference(tabPreference, storage), {
+  value: "overview",
+  restored: false
+});
+
+storage.setItem(
+  selectionPreferenceStorageKey("test.metrics"),
+  JSON.stringify(["distance", "distance"])
+);
+assert.equal(readSelectionPreference(metricPreference, storage).restored, false);
+
+const throwingStorage = {
+  getItem() {
+    throw new Error("read blocked");
+  },
+  setItem() {
+    throw new Error("write blocked");
+  }
+};
+assert.deepEqual(readSelectionPreference(tabPreference, throwingStorage), {
+  value: "overview",
+  restored: false
+});
+assert.doesNotThrow(() =>
+  writeSelectionPreference(tabPreference, "strength", throwingStorage)
+);
+
+console.log("selection-preference tests passed");

--- a/scripts/test-training-library.mjs
+++ b/scripts/test-training-library.mjs
@@ -359,6 +359,7 @@ assert.throws(() => library.deleteLocalTrainingPlan(installedPlan.id, true), /fu
 let mockCalendar = [];
 let mockIdentity = 0;
 const writeOrder = [];
+const embeddedUnitSystems = [];
 const appendMockOccurrence = (name, happenDay) => {
   mockIdentity += 1;
   mockCalendar.push({
@@ -375,8 +376,10 @@ library.setTrainingPlanCalendarAdapterForTests({
     writeOrder.push(`library:${happenDay}`);
     appendMockOccurrence("Uphill repeats", happenDay);
   },
-  createAndSchedule: async (entry, happenDay) => {
+  createAndSchedule: async (entry, happenDay, unitSystem, saveToLibrary) => {
     writeOrder.push(`embedded:${happenDay}`);
+    embeddedUnitSystems.push(unitSystem);
+    assert.equal(saveToLibrary, false, "plan installs keep embedded workouts out of the library");
     appendMockOccurrence(entry.name, happenDay);
     return {};
   },
@@ -397,8 +400,9 @@ databaseModule.saveTrainingPlanDocument(mutationPlan);
 mockCalendar.push({ planId: "preexisting", idInPlan: "morning", planProgramId: "morning-program", happenDay: "20990803", name: "Morning recovery" });
 const installPreview = await library.previewTrainingPlanCalendar(mutationPlan.id, "2099-08-03");
 assert.equal(installPreview.conflicts[0].existing[0].name, "Morning recovery");
-const installResult = await library.addTrainingPlanToCalendar(installPreview.previewId, true);
+const installResult = await library.addTrainingPlanToCalendar(installPreview.previewId, true, "imperial");
 assert.deepEqual(writeOrder.slice(0, 2), ["library:20990803", "embedded:20990805"], "calendar writes remain serialized in plan order");
+assert.deepEqual(embeddedUnitSystems, ["imperial"], "only embedded workouts are rebuilt with the selected units");
 assert.equal(installResult.scheduledCount, 2);
 assert.equal(installResult.failures.length, 0);
 assert.equal(installResult.plan.calendarInstalls[0].occurrences.length, 2);
@@ -426,14 +430,14 @@ stalePlan.calendarInstalls = [];
 databaseModule.saveTrainingPlanDocument(stalePlan);
 const stalePreview = await library.previewTrainingPlanCalendar(stalePlan.id, "2099-08-03");
 mockCalendar.push({ planId: "calendar-change", idInPlan: "new", planProgramId: "new-program", happenDay: "20990805", name: "Changed elsewhere" });
-await assert.rejects(library.addTrainingPlanToCalendar(stalePreview.previewId, true), /calendar changed/i);
+await assert.rejects(library.addTrainingPlanToCalendar(stalePreview.previewId, true, "imperial"), /calendar changed/i);
 const revisionStalePlan = structuredClone(stalePlan);
 revisionStalePlan.id = "plan:revision-stale-preview";
 databaseModule.saveTrainingPlanDocument(revisionStalePlan);
 const revisionStalePreview = await library.previewTrainingPlanCalendar(revisionStalePlan.id, "2099-08-03");
 revisionStalePlan.entries[0].title = "Changed after preview";
 databaseModule.saveTrainingPlanDocument(revisionStalePlan);
-await assert.rejects(library.addTrainingPlanToCalendar(revisionStalePreview.previewId, true), /plan changed/i);
+await assert.rejects(library.addTrainingPlanToCalendar(revisionStalePreview.previewId, true, "imperial"), /plan changed/i);
 
 mockCalendar = [];
 const partialPlan = structuredClone(generated);
@@ -445,7 +449,8 @@ partialPlan.calendarInstalls = [];
 databaseModule.saveTrainingPlanDocument(partialPlan);
 library.setTrainingPlanCalendarAdapterForTests({
   listScheduled: async (startDay, endDay) => mockCalendar.filter((entry) => entry.happenDay >= startDay && entry.happenDay <= endDay),
-  createAndSchedule: async (entry, happenDay) => {
+  createAndSchedule: async (entry, happenDay, unitSystem) => {
+    assert.equal(unitSystem, "metric", "metric plan installs preserve the selected units");
     if (entry.name === "Trail strength") throw new Error("mock write failure");
     appendMockOccurrence(entry.name, happenDay);
     return {};
@@ -455,7 +460,7 @@ library.setTrainingPlanCalendarAdapterForTests({
   }
 });
 const partialPreview = await library.previewTrainingPlanCalendar(partialPlan.id, "2099-08-03");
-const partialResult = await library.addTrainingPlanToCalendar(partialPreview.previewId, true);
+const partialResult = await library.addTrainingPlanToCalendar(partialPreview.previewId, true, "metric");
 assert.equal(partialResult.scheduledCount, 1);
 assert.equal(partialResult.failures.length, 1);
 assert.equal(partialResult.plan.calendarInstalls[0].state, "partial");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,6 +117,11 @@ import {
 import { trackAvatarColor, trackInitial } from "./media/trackAvatar";
 import { useTimeOfDayGreeting } from "./hooks/useTimeOfDayGreeting";
 import {
+  defineSelectionPreference,
+  selectionIsOneOf,
+  useSelectionPreference,
+} from "./preferences/selectionPreferences";
+import {
   getWatchPresentation,
   type WatchFeatureIcon,
   type WatchPresentation,
@@ -132,6 +137,19 @@ type MediaTab =
   | "spotify"
   | "apple-music"
   | "apple-podcasts";
+
+const MEDIA_TAB_PREFERENCE = defineSelectionPreference<MediaTab>({
+  key: "media.activeTab",
+  defaultValue: "library",
+  validate: selectionIsOneOf([
+    "library",
+    "youtube",
+    "youtube-music",
+    "spotify",
+    "apple-music",
+    "apple-podcasts",
+  ]),
+});
 
 const YOUTUBE_HOME_URL = "https://www.youtube.com/";
 const YOUTUBE_DOWNLOAD_CONSOLE_PREFIX = "__COROSLINK_YOUTUBE_DOWNLOAD__";
@@ -322,7 +340,9 @@ export default function App() {
   const [coachPrefill, setCoachPrefill] = useState<string | null>(null);
   const [pendingCoachPlan, setPendingCoachPlan] = useState<TrainingPlanDocument | null>(null);
   const [calendarRefreshToken, setCalendarRefreshToken] = useState(0);
-  const [activeMediaTab, setActiveMediaTab] = useState<MediaTab>("library");
+  const [activeMediaTab, setActiveMediaTab] = useSelectionPreference(
+    MEDIA_TAB_PREFERENCE,
+  );
   const [watchStatus, setWatchStatus] = useState<WatchStatus | null>(null);
   const [transferProgress, setTransferProgress] =
     useState<TrackTransferProgress | null>(null);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2294,7 +2294,6 @@ export default function App() {
                 onTransfer={handleTransfer}
                 onDeleteDownload={handleDeleteDownload}
                 onOpenLibrary={() => openMediaTab("library")}
-                onOpenTraining={() => setActiveView("training")}
                 onSelectTrainingActivity={handleTrainingHubActivityDetail}
               />
             ) : null}
@@ -2851,7 +2850,6 @@ interface MediaOverviewTabProps {
   onTransfer: (id: string) => void;
   onDeleteDownload: (track: LocalTrack) => void;
   onOpenLibrary: () => void;
-  onOpenTraining: () => void;
   onSelectTrainingActivity: (activity: TrainingHubActivity) => void;
 }
 
@@ -2867,7 +2865,6 @@ function MediaOverviewTab({
   onTransfer,
   onDeleteDownload,
   onOpenLibrary,
-  onOpenTraining,
   onSelectTrainingActivity,
 }: MediaOverviewTabProps) {
   const greeting = useTimeOfDayGreeting();
@@ -3046,8 +3043,6 @@ function MediaOverviewTab({
             activities={trainingActivities}
             connected={trainingConnected}
             detail={trainingActivityDetail}
-            loading={busy?.startsWith("training-detail:") ?? false}
-            onOpenTraining={onOpenTraining}
             onSelectActivity={onSelectTrainingActivity}
           />
         </Suspense>

--- a/src/calendar/CalendarGrid.tsx
+++ b/src/calendar/CalendarGrid.tsx
@@ -2,6 +2,7 @@ import type {
   TrainingHubActivity,
   TrainingHubScheduledWorkoutEntry
 } from "../../electron/types";
+import { useLayoutEffect, useRef } from "react";
 import {
   scheduledWorkoutKey,
   type CalendarDay,
@@ -16,6 +17,7 @@ import { WeekStatsCell } from "./WeekStatsCell";
 interface CalendarGridProps {
   weeks: CalendarWeek[];
   mode: CalendarMode;
+  loading: boolean;
   busy: boolean;
   selectionMode: boolean;
   selectedWorkoutKeys: ReadonlySet<string>;
@@ -30,6 +32,7 @@ interface CalendarGridProps {
 export function CalendarGrid({
   weeks,
   mode,
+  loading,
   busy,
   selectionMode,
   selectedWorkoutKeys,
@@ -40,6 +43,39 @@ export function CalendarGrid({
   onDropEntry,
   onAskCoachWeek
 }: CalendarGridProps) {
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const todayRowRef = useRef<HTMLDivElement>(null);
+  const todayWeekKey = weeks.find((week) =>
+    week.days.some((day) => day.isToday)
+  )?.key;
+
+  useLayoutEffect(() => {
+    if (loading || !todayWeekKey) {
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      const body = bodyRef.current;
+      const todayRow = todayRowRef.current;
+      if (!body || !todayRow) {
+        return;
+      }
+
+      const bodyRect = body.getBoundingClientRect();
+      const rowRect = todayRow.getBoundingClientRect();
+      const rowTop = body.scrollTop + rowRect.top - bodyRect.top;
+      const centeredTop = rowTop - (body.clientHeight - rowRect.height) / 2;
+      const maxScrollTop = Math.max(0, body.scrollHeight - body.clientHeight);
+
+      body.scrollTo({
+        top: Math.min(maxScrollTop, Math.max(0, centeredTop)),
+        behavior: "auto"
+      });
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [loading, mode, todayWeekKey]);
+
   return (
     <div
       className={`calendar-grid ${mode === "week" ? "calendar-grid-week" : ""}`}
@@ -56,29 +92,39 @@ export function CalendarGrid({
         </div>
       </div>
 
-      <div className="calendar-grid-body">
-        {weeks.map((week) => (
-          <div key={week.key} className="calendar-grid-row">
-            {week.days.map((day) => (
-              <DayCell
-                key={day.dateKey}
-                day={day}
-                mode={mode}
-                busy={busy}
-                selectionMode={selectionMode}
-                isScheduledSelected={(entry) =>
-                  selectedWorkoutKeys.has(scheduledWorkoutKey(entry))
-                }
-                onSelectScheduled={(entry) => onSelectScheduled(day, entry)}
-                onSelectActivity={(activity) => onSelectActivity(day, activity)}
-                onToggleScheduled={onToggleScheduled}
-                onAdd={onAdd}
-                onDropEntry={onDropEntry}
+      <div ref={bodyRef} className="calendar-grid-body">
+        {weeks.map((week) => {
+          const containsToday = week.key === todayWeekKey;
+          return (
+            <div
+              key={week.key}
+              ref={containsToday ? todayRowRef : undefined}
+              className="calendar-grid-row"
+            >
+              {week.days.map((day) => (
+                <DayCell
+                  key={day.dateKey}
+                  day={day}
+                  mode={mode}
+                  busy={busy}
+                  selectionMode={selectionMode}
+                  isScheduledSelected={(entry) =>
+                    selectedWorkoutKeys.has(scheduledWorkoutKey(entry))
+                  }
+                  onSelectScheduled={(entry) => onSelectScheduled(day, entry)}
+                  onSelectActivity={(activity) => onSelectActivity(day, activity)}
+                  onToggleScheduled={onToggleScheduled}
+                  onAdd={onAdd}
+                  onDropEntry={onDropEntry}
+                />
+              ))}
+              <WeekStatsCell
+                stats={week.stats}
+                onAskCoach={() => onAskCoachWeek(week)}
               />
-            ))}
-            <WeekStatsCell stats={week.stats} onAskCoach={() => onAskCoachWeek(week)} />
-          </div>
-        ))}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/calendar/CalendarView.tsx
+++ b/src/calendar/CalendarView.tsx
@@ -49,6 +49,17 @@ import {
 import { useCalendarData } from "./useCalendarData";
 import { WorkoutEditorModal } from "./WorkoutEditorModal";
 import { WorkoutLibraryModal } from "./WorkoutLibraryModal";
+import {
+  defineSelectionPreference,
+  selectionIsOneOf,
+  useSelectionPreference
+} from "../preferences/selectionPreferences";
+
+const CALENDAR_MODE_PREFERENCE = defineSelectionPreference<CalendarMode>({
+  key: "calendar.mode",
+  defaultValue: "month",
+  validate: selectionIsOneOf(["month", "week"])
+});
 
 interface CalendarViewProps {
   api: CorosLinkApi;
@@ -142,7 +153,7 @@ export function CalendarView({
   onOpenCoach
 }: CalendarViewProps) {
   const { unitSystem } = useUnitSystem();
-  const [mode, setMode] = useState<CalendarMode>("month");
+  const [mode, setMode] = useSelectionPreference(CALENDAR_MODE_PREFERENCE);
   const [anchor, setAnchor] = useState(() => new Date());
   const [selection, setSelection] = useState<CalendarSelection | null>(null);
   const [addTarget, setAddTarget] = useState<string | null>(null);

--- a/src/calendar/CalendarView.tsx
+++ b/src/calendar/CalendarView.tsx
@@ -619,6 +619,7 @@ export function CalendarView({
       <CalendarGrid
         weeks={weeks}
         mode={mode}
+        loading={loading}
         busy={mutating}
         selectionMode={selectionMode}
         selectedWorkoutKeys={selectedWorkoutKeys}

--- a/src/chat/ChatHistoryPanel.tsx
+++ b/src/chat/ChatHistoryPanel.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Loader2, Plus, Search } from "lucide-react";
+import { Loader2, PanelLeftClose, Plus, Search } from "lucide-react";
 import type { ChatSessionSummary } from "../../electron/types";
 import { ChatSessionRow } from "./ChatSessionRow";
 import { groupChatSessions } from "./chatSessionGroups";
@@ -8,6 +8,7 @@ export function ChatHistoryPanel({
   sessions,
   activeSessionId,
   busy,
+  onCollapse,
   onNewChat,
   onSelectSession,
   onDeleteSession
@@ -15,6 +16,7 @@ export function ChatHistoryPanel({
   sessions: ChatSessionSummary[];
   activeSessionId: string | null;
   busy?: boolean;
+  onCollapse: () => void;
   onNewChat: () => void;
   onSelectSession: (sessionId: string) => void;
   onDeleteSession: (sessionId: string) => void;
@@ -43,6 +45,17 @@ export function ChatHistoryPanel({
       <div className="chat-history-toolbar">
         <div className="chat-history-header">
           <p className="eyebrow">Conversations</p>
+          <button
+            type="button"
+            className="chat-history-collapse-button"
+            onClick={onCollapse}
+            aria-expanded="true"
+            aria-controls="chat-conversation-sidebar"
+            aria-label="Collapse conversations"
+            title="Collapse conversations"
+          >
+            <PanelLeftClose size={16} aria-hidden="true" />
+          </button>
         </div>
         <button
           type="button"

--- a/src/chat/ChatSidebar.tsx
+++ b/src/chat/ChatSidebar.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { PanelLeft } from "lucide-react";
 import { ChatHistoryPanel } from "./ChatHistoryPanel";
 import type { ChatSessionSummary } from "../../electron/types";
 
@@ -9,6 +10,7 @@ export function ChatSidebar({
   activeSessionId,
   busy,
   onClose,
+  onOpen,
   onNewChat,
   onSelectSession,
   onDeleteSession
@@ -19,6 +21,7 @@ export function ChatSidebar({
   activeSessionId: string | null;
   busy?: boolean;
   onClose: () => void;
+  onOpen: () => void;
   onNewChat: () => void;
   onSelectSession: (sessionId: string) => void;
   onDeleteSession: (sessionId: string) => void;
@@ -66,6 +69,7 @@ export function ChatSidebar({
           .join(" ")}
       >
         <aside
+          id="chat-conversation-sidebar"
           className={[
             "chat-sidebar",
             open ? "is-open" : "",
@@ -80,6 +84,7 @@ export function ChatSidebar({
               sessions={sessions}
               activeSessionId={activeSessionId}
               busy={busy}
+              onCollapse={onClose}
               onNewChat={onNewChat}
               onSelectSession={onSelectSession}
               onDeleteSession={onDeleteSession}
@@ -87,6 +92,19 @@ export function ChatSidebar({
           </div>
         </aside>
       </div>
+      {!open && !overlay ? (
+        <button
+          type="button"
+          className="chat-sidebar-expand-button"
+          onClick={onOpen}
+          aria-expanded="false"
+          aria-controls="chat-conversation-sidebar"
+          aria-label="Expand conversations"
+          title="Expand conversations"
+        >
+          <PanelLeft size={17} aria-hidden="true" />
+        </button>
+      ) : null}
     </>
   );
 }

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -15,6 +15,7 @@ import {
   Loader2,
   LogOut,
   MessageCircle,
+  Plus,
   RefreshCw,
   Send,
   Settings2,
@@ -72,6 +73,7 @@ import { FitnessTrendCard } from "./FitnessTrendCard";
 import { HrZoneCard } from "./HrZoneCard";
 import { ChatSettingsModal } from "./ChatSettingsModal";
 import { ChatSidebar } from "./ChatSidebar";
+import { ModelSwitch } from "./ModelSwitch";
 import { ProviderSwitch } from "./ProviderSwitch";
 import {
   fromPersistedEntries,
@@ -90,6 +92,7 @@ import {
 
 const DEFAULT_CHAT_SETTINGS: ChatSettings = {
   provider: "chatgpt",
+  chatgpt: {},
   claudeCode: {
     permissions: {
       recentActivities: true,
@@ -1703,6 +1706,43 @@ export function ChatView({
     }
   };
 
+  const handleModelChange = async (model: string) => {
+    if (!api || chatSettings.provider === "local") return;
+    const normalizedModel = model.trim() || undefined;
+    const nextSettings: ChatSettings =
+      chatSettings.provider === "claude-code"
+        ? {
+            ...chatSettings,
+            claudeCode: {
+              ...chatSettings.claudeCode,
+              model: normalizedModel
+            }
+          }
+        : {
+            ...chatSettings,
+            chatgpt: {
+              ...chatSettings.chatgpt,
+              model: normalizedModel
+            }
+          };
+
+    setChatSettings(nextSettings);
+    setSavingSettings(true);
+    onError(null);
+    try {
+      const saved = await api.saveChatSettings(nextSettings);
+      setChatSettings(saved);
+    } catch (caught) {
+      onError(
+        caught instanceof Error
+          ? caught.message
+          : "Could not save the selected model."
+      );
+    } finally {
+      setSavingSettings(false);
+    }
+  };
+
   const updateLocalDraft = (patch: Partial<ChatSettings["local"]>) => {
     setChatSettings((current) => ({
       ...current,
@@ -2268,6 +2308,21 @@ export function ChatView({
       onChange={(provider) => void handleProviderChange(provider)}
     />
   );
+  const selectedModel =
+    chatSettings.provider === "claude-code"
+      ? chatSettings.claudeCode.model ?? ""
+      : chatSettings.chatgpt.model ?? "";
+  const providerControls = (
+    <div className="chat-provider-controls">
+      {providerSwitch}
+      <ModelSwitch
+        provider={chatSettings.provider}
+        model={selectedModel}
+        disabled={savingSettings || isBusy}
+        onChange={(model) => void handleModelChange(model)}
+      />
+    </div>
+  );
 
   const conversationSidebarOpen = chatSettings.sidebarOpen !== false;
   const sidebarProps = {
@@ -2414,7 +2469,7 @@ export function ChatView({
               </p>
             </div>
             <div className="chat-composer-toolbar chat-composer-toolbar-login">
-              {providerSwitch}
+              {providerControls}
             </div>
           </div>
         </div>
@@ -2472,7 +2527,7 @@ export function ChatView({
               </p>
             </div>
             <div className="chat-composer-toolbar chat-composer-toolbar-login">
-              {providerSwitch}
+              {providerControls}
             </div>
           </div>
         </div>
@@ -2841,7 +2896,20 @@ export function ChatView({
       </div>
 
           <div className="chat-composer">
-            <div className="chat-composer-toolbar">{providerSwitch}</div>
+            <div className="chat-composer-toolbar">
+              {providerControls}
+              <button
+                type="button"
+                className="chat-new-chat chat-composer-new-chat"
+                onClick={() => void handleNewChat()}
+                disabled={!api || isBusy}
+                aria-label="Start a new chat"
+                title="Start a new chat"
+              >
+                <Plus size={14} aria-hidden="true" />
+                <span>New chat</span>
+              </button>
+            </div>
             <div className="chat-composer-inner">
               <textarea
                 ref={inputRef}

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -1,10 +1,17 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type CSSProperties } from "react";
 import {
   BookOpen,
+  Bookmark,
+  CalendarDays,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  CircleCheck,
   Database,
   ExternalLink,
   FileDown,
   FileText,
+  Info,
   Loader2,
   LogOut,
   MessageCircle,
@@ -15,6 +22,7 @@ import {
   Square,
   Terminal,
   Trash2,
+  TriangleAlert,
   Upload,
   User
 } from "lucide-react";
@@ -46,6 +54,7 @@ import type {
   CorosMcpStatus,
   McpServerStatus,
   PlanDraftPreview,
+  PlanDraftPreviewEntry,
   PlanWorkoutEntryInput,
   TrainingPlanDocument,
   TrainingPlanDestination,
@@ -57,6 +66,7 @@ import type {
 } from "../../electron/types";
 import { formatWorkoutSport } from "../../electron/workoutCapabilities";
 import { trainingPlanFromCoachDraftPreview } from "../../electron/trainingPlanDomain";
+import { sportTheme } from "../training-library/sportTheme";
 import { ActivityVisualCard } from "./ActivityVisualCard";
 import { FitnessTrendCard } from "./FitnessTrendCard";
 import { HrZoneCard } from "./HrZoneCard";
@@ -98,6 +108,22 @@ const DEFAULT_CHAT_SETTINGS: ChatSettings = {
   sidebarOpen: true,
   visualizationsEnabled: false
 };
+
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() =>
+    typeof window === "undefined" ? false : window.matchMedia(query).matches
+  );
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    const handleChange = () => setMatches(media.matches);
+    handleChange();
+    media.addEventListener("change", handleChange);
+    return () => media.removeEventListener("change", handleChange);
+  }, [query]);
+
+  return matches;
+}
 
 function AssistantMarkdown({
   content,
@@ -339,6 +365,126 @@ function formatLegacyPlanPace(
   return formatPlanPaceRange(low, high, unitSystem);
 }
 
+const PLAN_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+function planDateFromSchedule(scheduleDate: string): Date | undefined {
+  const match = scheduleDate.match(PLAN_DATE_RE);
+  if (!match) return undefined;
+  return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
+}
+
+/** Calendar-badge parts for a scheduled date: weekday / day number / month. */
+function planDateParts(
+  scheduleDate?: string
+): { weekday: string; day: string; month: string } | undefined {
+  if (!scheduleDate) return undefined;
+  const date = planDateFromSchedule(scheduleDate);
+  if (!date) return undefined;
+  return {
+    weekday: new Intl.DateTimeFormat(undefined, { weekday: "short" }).format(date),
+    day: String(date.getDate()),
+    month: new Intl.DateTimeFormat(undefined, { month: "short" }).format(date)
+  };
+}
+
+/** One-line localized label, e.g. "Tue, Aug 4". Falls back to the raw value. */
+function formatPlanDateLabel(scheduleDate: string): string {
+  const date = planDateFromSchedule(scheduleDate);
+  if (!date) return scheduleDate;
+  return new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric"
+  }).format(date);
+}
+
+function planEntryScheduleDate(entry: PlanDraftPreviewEntry): string | undefined {
+  if (entry.scheduleDate) return entry.scheduleDate;
+  const sourceDate = entry.source?.schedule_date;
+  if (!sourceDate || !/^\d{8}$/.test(sourceDate)) return undefined;
+  return `${sourceDate.slice(0, 4)}-${sourceDate.slice(4, 6)}-${sourceDate.slice(6, 8)}`;
+}
+
+function localPlanDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function planWeekStart(date: Date): Date {
+  const start = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const daysSinceMonday = (start.getDay() + 6) % 7;
+  start.setDate(start.getDate() - daysSinceMonday);
+  return start;
+}
+
+function formatPlanWeekRange(start: Date): string {
+  const end = new Date(start.getFullYear(), start.getMonth(), start.getDate() + 6);
+  const month = new Intl.DateTimeFormat(undefined, { month: "short" });
+  if (start.getMonth() === end.getMonth()) {
+    return `${month.format(start)} ${start.getDate()}-${end.getDate()}`;
+  }
+  return `${month.format(start)} ${start.getDate()}-${month.format(end)} ${end.getDate()}`;
+}
+
+interface PlanWeekGroup {
+  id: string;
+  label: string;
+  dateRange: string;
+  entries: PlanDraftPreviewEntry[];
+}
+
+function groupPlanEntriesByWeek(entries: PlanDraftPreviewEntry[]): PlanWeekGroup[] {
+  const groups = new Map<string, { start: Date; entries: PlanDraftPreviewEntry[] }>();
+  const unscheduled: PlanDraftPreviewEntry[] = [];
+  const sortedEntries = [...entries].sort((left, right) => {
+    const leftDate = planEntryScheduleDate(left) ?? "9999-99-99";
+    const rightDate = planEntryScheduleDate(right) ?? "9999-99-99";
+    return leftDate.localeCompare(rightDate);
+  });
+
+  for (const entry of sortedEntries) {
+    const scheduleDate = planEntryScheduleDate(entry);
+    const date = scheduleDate ? planDateFromSchedule(scheduleDate) : undefined;
+    if (!date) {
+      unscheduled.push(entry);
+      continue;
+    }
+    const start = planWeekStart(date);
+    const id = localPlanDateKey(start);
+    const existing = groups.get(id);
+    if (existing) {
+      existing.entries.push(entry);
+    } else {
+      groups.set(id, { start, entries: [entry] });
+    }
+  }
+
+  const weeks = [...groups.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([id, group], index) => ({
+      id,
+      label: `Week ${index + 1}`,
+      dateRange: formatPlanWeekRange(group.start),
+      entries: group.entries
+    }));
+  if (unscheduled.length > 0) {
+    weeks.push({
+      id: "unscheduled",
+      label: "Unscheduled",
+      dateRange: "No calendar date",
+      entries: unscheduled
+    });
+  }
+  return weeks;
+}
+
+/** Inline style hook that tints a row/chip with the sport's own colour. */
+function planSportStyle(sport: PlanDraftPreviewEntry["sport"]): CSSProperties {
+  return { "--chat-plan-sport": sportTheme(sport).color } as CSSProperties;
+}
+
 function PlanPreviewCard({
   draft,
   uploading,
@@ -353,9 +499,11 @@ function PlanPreviewCard({
   onReview?: () => void;
 }) {
   const { unitSystem } = useUnitSystem();
-  const [destination, setDestination] = useState<TrainingPlanDestination>(
-    "workoutLibrary"
-  );
+  const [destination, setDestination] = useState<
+    Extract<TrainingPlanDestination, "workoutLibrary" | "calendar">
+  >("workoutLibrary");
+  const [selectedWeekId, setSelectedWeekId] = useState<string | null>(null);
+  const weekTabsRef = useRef<HTMLDivElement>(null);
   const uploadedResult =
     uploaded ??
     (draft.uploadResult
@@ -367,37 +515,27 @@ function PlanPreviewCard({
         }
       : undefined);
   const isUploaded = Boolean(uploadedResult || draft.uploadedAt);
-  const rawDates = draft.entries
-    .map((entry) => entry.source?.schedule_date?.replace(/-/g, ""))
-    .filter((date): date is string => Boolean(date && /^\d{8}$/.test(date)))
-    .sort();
-  const firstDate = rawDates[0];
-  const lastDate = rawDates[rawDates.length - 1];
-  const planWeeks = firstDate && lastDate
-    ? Math.max(
-        1,
-        Math.ceil(
-          (new Date(`${lastDate.slice(0, 4)}-${lastDate.slice(4, 6)}-${lastDate.slice(6, 8)}T12:00:00`).valueOf() -
-            new Date(`${firstDate.slice(0, 4)}-${firstDate.slice(4, 6)}-${firstDate.slice(6, 8)}T12:00:00`).valueOf()) /
-            604_800_000 +
-            1 / 7
-        )
-      )
-    : Math.max(1, Math.ceil(draft.entries.length / 7));
+  const planWeeks = groupPlanEntriesByWeek(draft.entries);
+  const scheduledWeekCount = planWeeks.filter(
+    (week) => week.id !== "unscheduled"
+  ).length;
+  const selectedWeek =
+    planWeeks.find((week) => week.id === selectedWeekId) ?? planWeeks[0];
+  const selectedWeekIndex = selectedWeek
+    ? planWeeks.findIndex((week) => week.id === selectedWeek.id)
+    : -1;
   const sports = [
     ...new Set(draft.entries.map((entry) => formatWorkoutSport(entry.sport ?? "run")))
   ];
-  const unavailableNative =
-    destination === "nativePlan" || destination === "nativePlanAndCalendar";
-  const remoteWrites = destination === "localTemplate"
-    ? []
-    : destination === "workoutLibrary"
-      ? draft.entries.map((entry) => `Create workout “${entry.name}” in COROS`)
-      : destination === "calendar"
-        ? draft.entries
-            .filter((entry) => entry.scheduleDate)
-            .map((entry) => `Schedule “${entry.name}” on ${entry.scheduleDate}`)
-        : [];
+  const sportKinds = [...new Set(draft.entries.map((entry) => entry.sport))];
+  const startDate = draft.entries
+    .map(planEntryScheduleDate)
+    .filter((date): date is string => Boolean(date))
+    .sort()[0];
+  const scheduledWorkoutCount = draft.entries.filter((entry) =>
+    Boolean(planEntryScheduleDate(entry))
+  ).length;
+  const unscheduledWorkoutCount = draft.entries.length - scheduledWorkoutCount;
   const destinationLabel: Record<TrainingPlanDestination, string> = {
     workoutLibrary: "COROS Workout Library",
     calendar: "COROS Calendar",
@@ -406,128 +544,388 @@ function PlanPreviewCard({
     nativePlanAndCalendar: "COROS plan + Calendar"
   };
 
+  useEffect(() => {
+    setSelectedWeekId(null);
+  }, [draft.draftId]);
+
+  useEffect(() => {
+    const activeTab = weekTabsRef.current?.querySelector<HTMLElement>(
+      '[role="tab"][aria-selected="true"]'
+    );
+    activeTab?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }, [selectedWeek?.id]);
+
+  const selectAdjacentWeek = (offset: number) => {
+    const nextWeek = planWeeks[selectedWeekIndex + offset];
+    if (nextWeek) setSelectedWeekId(nextWeek.id);
+  };
+
   return (
     <div className="chat-plan-card">
       <div className="chat-plan-card-header">
-        <h4>{draft.name}</h4>
-        <span className="chat-plan-card-summary">{draft.summary}</span>
+        <div className="chat-plan-card-title">
+          <h4>{draft.name}</h4>
+          <span className="chat-plan-card-summary">{draft.summary}</span>
+        </div>
+        {sportKinds.length > 0 ? (
+          <span
+            className="chat-plan-sports"
+            role="img"
+            aria-label={sports.join(", ")}
+          >
+            {sportKinds.slice(0, 4).map((sport, index) => {
+              const SportIcon = sportTheme(sport).icon;
+              return (
+                <span
+                  key={`${sport ?? "unknown"}-${index}`}
+                  className="chat-plan-sport-dot"
+                  style={planSportStyle(sport)}
+                  title={sport ? formatWorkoutSport(sport) : "Workout"}
+                >
+                  <SportIcon size={10} strokeWidth={2.2} aria-hidden="true" />
+                </span>
+              );
+            })}
+          </span>
+        ) : null}
       </div>
-      <div className="chat-plan-table-wrap">
-        <table className="chat-plan-table">
-          <thead>
-            <tr>
-              <th>Date</th>
-              <th>Workout</th>
-              <th>Sport</th>
-              <th>Volume</th>
-              <th>Type</th>
-              <th>Steps</th>
-            </tr>
-          </thead>
-          <tbody>
-            {draft.entries.map((entry) => (
-              <tr key={entry.key}>
-                <td>{entry.scheduleDate ?? "Library"}</td>
-                <td>{entry.name}</td>
-                <td>{formatWorkoutSport(entry.sport ?? "run")}</td>
-                <td>
-                  {(entry.source
-                    ? formatPlanSourceVolume(entry.source, unitSystem)
-                    : entry.volume) ?? "—"}
-                </td>
-                <td>{entry.workoutType}</td>
-                <td>
-                  {(entry.source
-                    ? formatPlanSourceSteps(entry.source, unitSystem)
-                    : entry.stepsSummary) ?? "—"}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <div className="chat-plan-overview" aria-label="Plan overview">
+        <div className="chat-plan-overview-item">
+          <span>Weeks</span>
+          <strong>{scheduledWeekCount}</strong>
+        </div>
+        <div className="chat-plan-overview-item">
+          <span>Workouts</span>
+          <strong>{draft.entries.length}</strong>
+        </div>
+        <div className="chat-plan-overview-item">
+          <span>Sports</span>
+          <strong title={sports.join(", ")}>{sports.join(", ")}</strong>
+        </div>
+        <div className="chat-plan-overview-item">
+          <span>Starts</span>
+          <strong>{startDate ? formatPlanDateLabel(startDate) : "Not set"}</strong>
+        </div>
       </div>
+      {selectedWeek ? (
+        <section
+          className="chat-plan-week"
+          aria-labelledby={`chat-plan-week-${draft.draftId}-${selectedWeek.id}`}
+        >
+          <div className="chat-plan-week-header">
+            <div>
+              <span>{selectedWeek.label}</span>
+              <h5 id={`chat-plan-week-${draft.draftId}-${selectedWeek.id}`}>
+                {selectedWeek.dateRange}
+              </h5>
+              <small>
+                {selectedWeek.entries.length}{" "}
+                {selectedWeek.entries.length === 1 ? "workout" : "workouts"}
+              </small>
+            </div>
+            {planWeeks.length > 1 ? (
+              <div className="chat-plan-week-stepper" aria-label="Change week">
+                <button
+                  type="button"
+                  onClick={() => selectAdjacentWeek(-1)}
+                  disabled={selectedWeekIndex <= 0}
+                  aria-label="Previous week"
+                  title="Previous week"
+                >
+                  <ChevronLeft size={15} aria-hidden="true" />
+                </button>
+                <span>{selectedWeekIndex + 1} of {planWeeks.length}</span>
+                <button
+                  type="button"
+                  onClick={() => selectAdjacentWeek(1)}
+                  disabled={selectedWeekIndex >= planWeeks.length - 1}
+                  aria-label="Next week"
+                  title="Next week"
+                >
+                  <ChevronRight size={15} aria-hidden="true" />
+                </button>
+              </div>
+            ) : null}
+          </div>
+          {planWeeks.length > 1 ? (
+            <div
+              ref={weekTabsRef}
+              className="chat-plan-week-tabs"
+              role="tablist"
+              aria-label="Plan weeks"
+            >
+              {planWeeks.map((week) => (
+                <button
+                  key={week.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={week.id === selectedWeek.id}
+                  className={week.id === selectedWeek.id ? "is-active" : ""}
+                  onClick={() => setSelectedWeekId(week.id)}
+                >
+                  <strong>{week.label}</strong>
+                  <span>{week.dateRange}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+          <ul className="chat-plan-entries">
+            {selectedWeek.entries.map((entry) => {
+              const SportIcon = sportTheme(entry.sport).icon;
+              const scheduleDate = planEntryScheduleDate(entry);
+              const dateParts = planDateParts(scheduleDate);
+              const volume =
+                (entry.source
+                  ? formatPlanSourceVolume(entry.source, unitSystem)
+                  : undefined) ?? entry.volume ?? "Not set";
+              const steps =
+                (entry.source
+                  ? formatPlanSourceSteps(entry.source, unitSystem)
+                  : undefined) ?? entry.stepsSummary ?? "No structure provided";
+              return (
+                <li
+                  key={entry.key}
+                  className="chat-plan-entry"
+                  style={planSportStyle(entry.sport)}
+                >
+                  <span
+                    className={`chat-plan-entry-date${dateParts ? "" : " is-undated"}`}
+                    title={scheduleDate ?? "Saved to library only"}
+                  >
+                    {dateParts ? (
+                      <>
+                        <span className="chat-plan-entry-weekday">
+                          {dateParts.weekday}
+                        </span>
+                        <span className="chat-plan-entry-day">{dateParts.day}</span>
+                        <span className="chat-plan-entry-month">
+                          {dateParts.month}
+                        </span>
+                      </>
+                    ) : (
+                      <Bookmark size={14} aria-hidden="true" />
+                    )}
+                  </span>
+                  <span className="chat-plan-entry-main">
+                    <span className="chat-plan-entry-name">{entry.name}</span>
+                    <span className="chat-plan-entry-steps">{steps}</span>
+                  </span>
+                  <span className="chat-plan-entry-meta">
+                    <span className="chat-plan-entry-volume">{volume}</span>
+                    <span className="chat-plan-entry-tags">
+                      <span className="chat-plan-entry-type">
+                        {entry.workoutType}
+                      </span>
+                      <span className="chat-plan-entry-sport">
+                        <SportIcon size={11} strokeWidth={2.2} aria-hidden="true" />
+                        {formatWorkoutSport(entry.sport ?? "run")}
+                      </span>
+                    </span>
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : (
+        <div className="chat-plan-empty-week">
+          <Bookmark size={16} aria-hidden="true" />
+          <span>This plan does not contain any workouts yet.</span>
+        </div>
+      )}
       {draft.conflicts.length > 0 ? (
-        <ul className="chat-plan-warnings">
-          {draft.conflicts.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ul>
+        <details
+          className="chat-plan-issues"
+          data-tone="alert"
+          open={draft.conflicts.length <= 3}
+        >
+          <summary>
+            <span>
+              <TriangleAlert size={13} aria-hidden="true" />
+              <strong>
+                {draft.conflicts.length}{" "}
+                {draft.conflicts.length === 1
+                  ? "scheduling conflict"
+                  : "scheduling conflicts"}
+              </strong>
+            </span>
+            <small>Review before saving</small>
+            <ChevronDown size={14} aria-hidden="true" />
+          </summary>
+          <ul className="chat-plan-warnings">
+            {draft.conflicts.map((item) => (
+              <li key={item}>
+                <TriangleAlert size={12} aria-hidden="true" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </details>
       ) : null}
       {draft.warnings.length > 0 ? (
-        <ul className="chat-plan-notes">
-          {draft.warnings.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ul>
+        <details
+          className="chat-plan-issues"
+          data-tone="note"
+          open={draft.warnings.length <= 3}
+        >
+          <summary>
+            <span>
+              <Info size={13} aria-hidden="true" />
+              <strong>
+                {draft.warnings.length}{" "}
+                {draft.warnings.length === 1 ? "plan note" : "plan notes"}
+              </strong>
+            </span>
+            <small>Additional plan details</small>
+            <ChevronDown size={14} aria-hidden="true" />
+          </summary>
+          <ul className="chat-plan-notes">
+            {draft.warnings.map((item) => (
+              <li key={item}>
+                <Info size={12} aria-hidden="true" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </details>
       ) : null}
       {!isUploaded ? (
-        <div className="chat-plan-confirmation">
-          <label>
-            <span>Destination</span>
-            <select
-              value={destination}
-              onChange={(event) =>
-                setDestination(event.target.value as TrainingPlanDestination)
-              }
-              disabled={uploading}
+        <fieldset className="chat-plan-confirmation" disabled={uploading}>
+          <legend>Where should this plan go?</legend>
+          <div className="chat-plan-destination-options">
+            <label
+              className={`chat-plan-destination-option${
+                destination === "workoutLibrary" ? " is-selected" : ""
+              }`}
             >
-              <option value="workoutLibrary">Workout Library</option>
-              <option value="calendar">Calendar</option>
-              <option value="nativePlan">Plan Library — unavailable</option>
-              <option value="localTemplate">Local template</option>
-              <option value="nativePlanAndCalendar">Plan + Calendar — unavailable</option>
-            </select>
-          </label>
-          <dl className="chat-plan-facts">
-            <div><dt>Weeks</dt><dd>{planWeeks}</dd></div>
-            <div><dt>Workouts</dt><dd>{draft.entries.length}</dd></div>
-            <div><dt>Sports</dt><dd>{sports.join(", ")}</dd></div>
-            <div><dt>Start</dt><dd>{draft.entries.find((entry) => entry.scheduleDate)?.scheduleDate ?? "Not set"}</dd></div>
-            <div><dt>Conflicts</dt><dd>{draft.conflicts.length}</dd></div>
-            <div><dt>Reused</dt><dd>0</dd></div>
-            <div><dt>Grouped COROS plan</dt><dd>{unavailableNative ? "Unavailable" : "No"}</dd></div>
-          </dl>
-          <div className="chat-plan-write-preview">
-            <strong>Writes after confirmation</strong>
-            {unavailableNative ? (
-              <p>Native plan writes remain gated until COROS create/update payloads can be live-verified safely.</p>
-            ) : remoteWrites.length > 0 ? (
-              <ul>
-                {remoteWrites.map((write, index) => <li key={`${write}-${index}`}>{write}</li>)}
-              </ul>
-            ) : (
-              <p>Local database only. No COROS write.</p>
-            )}
+              <input
+                className="sr-only"
+                type="radio"
+                name={`plan-destination-${draft.draftId}`}
+                value="workoutLibrary"
+                checked={destination === "workoutLibrary"}
+                onChange={() => setDestination("workoutLibrary")}
+              />
+              <span className="chat-plan-destination-icon">
+                <BookOpen size={16} aria-hidden="true" />
+              </span>
+              <span className="chat-plan-destination-copy">
+                <strong>Workout Library</strong>
+                <small>Save reusable workouts without adding dates.</small>
+              </span>
+              <CircleCheck
+                className="chat-plan-destination-check"
+                size={16}
+                aria-hidden="true"
+              />
+            </label>
+            <label
+              className={`chat-plan-destination-option${
+                destination === "calendar" ? " is-selected" : ""
+              }${unscheduledWorkoutCount > 0 ? " is-disabled" : ""}`}
+            >
+              <input
+                className="sr-only"
+                type="radio"
+                name={`plan-destination-${draft.draftId}`}
+                value="calendar"
+                checked={destination === "calendar"}
+                onChange={() => setDestination("calendar")}
+                disabled={unscheduledWorkoutCount > 0}
+              />
+              <span className="chat-plan-destination-icon">
+                <CalendarDays size={16} aria-hidden="true" />
+              </span>
+              <span className="chat-plan-destination-copy">
+                <strong>Calendar</strong>
+                <small>
+                  {unscheduledWorkoutCount > 0
+                    ? `${unscheduledWorkoutCount} ${
+                        unscheduledWorkoutCount === 1 ? "workout needs" : "workouts need"
+                      } a date.`
+                    : "Schedule workouts on the dates shown above."}
+                </small>
+              </span>
+              <CircleCheck
+                className="chat-plan-destination-check"
+                size={16}
+                aria-hidden="true"
+              />
+            </label>
           </div>
-        </div>
+          <p
+            className="chat-plan-destination-summary"
+            data-tone={
+              destination === "calendar" && draft.conflicts.length > 0
+                ? "alert"
+                : "ok"
+            }
+          >
+            {destination === "calendar" && draft.conflicts.length > 0 ? (
+              <TriangleAlert size={13} aria-hidden="true" />
+            ) : (
+              <CircleCheck size={13} aria-hidden="true" />
+            )}
+            <span>
+              {destination === "calendar"
+                ? `${scheduledWorkoutCount} ${
+                    scheduledWorkoutCount === 1 ? "workout" : "workouts"
+                  } will be added to your COROS Calendar.`
+                : `${draft.entries.length} ${
+                    draft.entries.length === 1 ? "workout" : "workouts"
+                  } will be saved to your COROS Workout Library.`}
+              {destination === "workoutLibrary"
+                ? " Dates will not be added to Calendar."
+                : draft.conflicts.length > 0
+                  ? ` Review ${draft.conflicts.length} ${
+                      draft.conflicts.length === 1 ? "conflict" : "conflicts"
+                    } before adding.`
+                  : " No scheduling conflicts."}
+            </span>
+          </p>
+        </fieldset>
       ) : null}
       {uploadedResult || isUploaded ? (
         <p className="chat-plan-success">
-          Saved to {destinationLabel[uploadedResult?.destination ?? draft.uploadResult?.destination ?? destination]} —{" "}
-          {uploadedResult?.workoutsScheduled ??
-            draft.uploadResult?.workoutsScheduled ??
-            0}{" "}
-          scheduled,{" "}
-          {uploadedResult?.workoutsCreated ??
-            draft.uploadResult?.workoutsCreated ??
-            0}{" "}
-          saved to library.
+          <CircleCheck size={15} aria-hidden="true" />
+          <span>
+            Saved to {destinationLabel[uploadedResult?.destination ?? draft.uploadResult?.destination ?? destination]}.{" "}
+            {uploadedResult?.workoutsScheduled ??
+              draft.uploadResult?.workoutsScheduled ??
+              0}{" "}
+            scheduled,{" "}
+            {uploadedResult?.workoutsCreated ??
+              draft.uploadResult?.workoutsCreated ??
+              0}{" "}
+            saved to library.
+          </span>
         </p>
       ) : (
         <div className="chat-plan-actions">
-          {onReview ? <button type="button" className="chat-plan-review" onClick={onReview} disabled={uploading}><BookOpen size={14} aria-hidden="true" /> Review &amp; save in Training Library</button> : null}
+          {onReview ? (
+            <button
+              type="button"
+              className="chat-plan-review"
+              onClick={onReview}
+              disabled={uploading}
+              title="Open this plan in the Training Library editor"
+            >
+              <BookOpen size={14} aria-hidden="true" />
+              Edit plan first
+            </button>
+          ) : null}
           <button
             type="button"
             className="chat-plan-upload"
             onClick={() => onUpload(destination)}
-            disabled={uploading || unavailableNative}
+            disabled={uploading}
           >
             {uploading ? (
               <Loader2 className="chat-spinner" size={14} aria-hidden="true" />
             ) : (
               <Upload size={14} aria-hidden="true" />
             )}
-            Confirm {destinationLabel[destination]}
+            {destination === "calendar" ? "Add to Calendar" : "Save to Library"}
           </button>
         </div>
       )}
@@ -692,6 +1090,13 @@ export function ChatView({
   const [mcpRefreshVersion, setMcpRefreshVersion] = useState(0);
   const [mcpBusy, setMcpBusy] = useState(false);
   const [showTools, setShowTools] = useState(false);
+  const [selectedPlanDraftId, setSelectedPlanDraftId] = useState<
+    string | null
+  >(null);
+  const [planPanelExpanded, setPlanPanelExpanded] = useState(false);
+  const [highlightedChatEntryIndex, setHighlightedChatEntryIndex] = useState<
+    number | null
+  >(null);
   const [uploadingDraftId, setUploadingDraftId] = useState<string | null>(null);
   const [uploadedPlans, setUploadedPlans] = useState<
     Record<string, UploadPlanResult>
@@ -721,6 +1126,9 @@ export function ChatView({
   const scrollRef = useRef<HTMLDivElement>(null);
   const mcpRef = useRef<HTMLDivElement>(null);
   const persistTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const chatHighlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -860,6 +1268,10 @@ export function ChatView({
       if (claudePollTimerRef.current) {
         clearTimeout(claudePollTimerRef.current);
         claudePollTimerRef.current = null;
+      }
+      if (chatHighlightTimeoutRef.current) {
+        clearTimeout(chatHighlightTimeoutRef.current);
+        chatHighlightTimeoutRef.current = null;
       }
     };
   }, [api]);
@@ -1692,6 +2104,54 @@ export function ChatView({
     }
   };
 
+  const handleScrollToPlanChat = (draftId: string) => {
+    const planIndex = timeline.findIndex(
+      (entry) => entry.kind === "planDraft" && entry.draft.draftId === draftId
+    );
+    if (planIndex < 0) return;
+
+    let targetIndex = timeline.findIndex(
+      (entry, index) =>
+        index > planIndex &&
+        entry.kind === "message" &&
+        entry.role === "assistant"
+    );
+    if (targetIndex < 0) {
+      for (let index = planIndex - 1; index >= 0; index -= 1) {
+        const entry = timeline[index];
+        if (entry.kind === "message" && entry.role === "assistant") {
+          targetIndex = index;
+          break;
+        }
+      }
+    }
+    if (targetIndex < 0) return;
+
+    const transcript = scrollRef.current;
+    const target = transcript?.querySelector<HTMLElement>(
+      `[data-chat-entry-index="${targetIndex}"]`
+    );
+    if (!transcript || !target) return;
+
+    const transcriptRect = transcript.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    const targetTop =
+      transcript.scrollTop +
+      targetRect.top -
+      transcriptRect.top -
+      Math.max(24, (transcript.clientHeight - targetRect.height) / 2);
+
+    transcript.scrollTo({ top: Math.max(0, targetTop), behavior: "smooth" });
+    setHighlightedChatEntryIndex(targetIndex);
+    if (chatHighlightTimeoutRef.current) {
+      clearTimeout(chatHighlightTimeoutRef.current);
+    }
+    chatHighlightTimeoutRef.current = setTimeout(() => {
+      setHighlightedChatEntryIndex(null);
+      chatHighlightTimeoutRef.current = null;
+    }, 1800);
+  };
+
   const handleConfirmWorkoutDelete = async (requestId: string) => {
     if (!api || deletingRequestId) return;
     setDeletingRequestId(requestId);
@@ -1782,6 +2242,24 @@ export function ChatView({
   const showLoginGate = isChatGptProvider && !authStatus?.signedIn;
   const showClaudeGate =
     isClaudeProvider && claudeStatus?.state !== "connected";
+  const showPlanPanel = useMediaQuery("(min-width: 1400px)");
+  const planDrafts = timeline.flatMap((entry) =>
+    entry.kind === "planDraft" ? [entry.draft] : []
+  );
+  const latestPlanDraft = planDrafts.at(-1);
+  const selectedPlanDraft =
+    planDrafts.find((draft) => draft.draftId === selectedPlanDraftId) ??
+    latestPlanDraft;
+  const selectedPlanDraftIndex = selectedPlanDraft
+    ? planDrafts.findIndex((draft) => draft.draftId === selectedPlanDraft.draftId)
+    : -1;
+
+  useEffect(() => {
+    setSelectedPlanDraftId(latestPlanDraft?.draftId ?? null);
+    if (latestPlanDraft) {
+      setPlanPanelExpanded(false);
+    }
+  }, [activeSessionId, latestPlanDraft?.draftId]);
 
   const providerSwitch = (
     <ProviderSwitch
@@ -1791,13 +2269,15 @@ export function ChatView({
     />
   );
 
+  const conversationSidebarOpen = chatSettings.sidebarOpen !== false;
   const sidebarProps = {
-    open: true,
+    open: conversationSidebarOpen,
     overlay: false,
     sessions,
     activeSessionId,
     busy: isBusy,
-    onClose: () => {},
+    onClose: () => void handleUpdateChatSettings({ sidebarOpen: false }),
+    onOpen: () => void handleUpdateChatSettings({ sidebarOpen: true }),
     onNewChat: () => void handleNewChat(),
     onSelectSession: (sessionId: string) => void handleSelectSession(sessionId),
     onDeleteSession: (sessionId: string) => void handleDeleteSession(sessionId)
@@ -2182,6 +2662,9 @@ export function ChatView({
             }
 
             if (entry.kind === "planDraft") {
+              if (showPlanPanel) {
+                return null;
+              }
               return (
                 <div
                   key={entry.draft.draftId}
@@ -2279,7 +2762,12 @@ export function ChatView({
             return (
               <div
                 key={`message-${index}`}
-                className={`chat-row chat-row-${entry.role}`}
+                className={`chat-row chat-row-${entry.role}${
+                  highlightedChatEntryIndex === index
+                    ? " is-chat-jump-target"
+                    : ""
+                }`}
+                data-chat-entry-index={index}
               >
                 <div className={`chat-avatar chat-avatar-${entry.role}`}>
                   {entry.role === "assistant" ? (
@@ -2407,6 +2895,157 @@ export function ChatView({
             </p>
           </div>
         </div>
+        {showPlanPanel && selectedPlanDraft ? (
+          <aside
+            className={`chat-plan-panel${
+              planPanelExpanded ? " is-expanded" : " is-list-view"
+            }`}
+            aria-label={
+              planPanelExpanded ? "Training plan details" : "Generated plans"
+            }
+          >
+            {!planPanelExpanded ? (
+              <>
+                <header className="chat-plan-list-header">
+                  <div>
+                    <span className="chat-plan-panel-icon">
+                      <BookOpen size={15} aria-hidden="true" />
+                    </span>
+                    <div>
+                      <strong>Generated plans</strong>
+                      <span>Select a plan to review</span>
+                    </div>
+                  </div>
+                  <strong className="chat-plan-list-count">
+                    {planDrafts.length}
+                  </strong>
+                </header>
+                <ol className="chat-plan-list">
+                  {planDrafts.map((draft, index) => {
+                    const saved = Boolean(
+                      uploadedPlans[draft.draftId] ||
+                        draft.uploadResult ||
+                        draft.uploadedAt
+                    );
+                    const weeks = Math.max(
+                      1,
+                      groupPlanEntriesByWeek(draft.entries).filter(
+                        (week) => week.id !== "unscheduled"
+                      ).length
+                    );
+                    const primarySport = draft.entries[0]?.sport;
+                    const SportIcon = sportTheme(primarySport).icon;
+                    const selected = draft.draftId === selectedPlanDraft.draftId;
+
+                    return (
+                      <li key={draft.draftId}>
+                        <button
+                          type="button"
+                          className={`chat-plan-list-item${
+                            selected ? " is-selected" : ""
+                          }`}
+                          onClick={() => {
+                            setSelectedPlanDraftId(draft.draftId);
+                            setPlanPanelExpanded(true);
+                          }}
+                          aria-label={`Open ${draft.name || `plan ${index + 1}`}`}
+                        >
+                          <span
+                            className="chat-plan-list-sport"
+                            style={planSportStyle(primarySport)}
+                          >
+                            <SportIcon
+                              size={15}
+                              strokeWidth={2}
+                              aria-hidden="true"
+                            />
+                          </span>
+                          <span className="chat-plan-list-copy">
+                            <span className="chat-plan-list-kicker">
+                              Plan {index + 1}
+                            </span>
+                            <strong>{draft.name || "Untitled plan"}</strong>
+                            <span className="chat-plan-list-meta">
+                              <span>
+                                {draft.entries.length}{" "}
+                                {draft.entries.length === 1
+                                  ? "workout"
+                                  : "workouts"}
+                              </span>
+                              <span>
+                                {weeks} {weeks === 1 ? "week" : "weeks"}
+                              </span>
+                              <span data-status={saved ? "saved" : "draft"}>
+                                {saved ? "Saved" : "Draft"}
+                              </span>
+                            </span>
+                          </span>
+                          <ChevronRight size={15} aria-hidden="true" />
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ol>
+              </>
+            ) : (
+              <>
+                <header className="chat-plan-panel-header">
+                  <div className="chat-plan-panel-heading">
+                    <button
+                      type="button"
+                      className="chat-plan-panel-back"
+                      onClick={() => setPlanPanelExpanded(false)}
+                      aria-label="Back to generated plans"
+                      title="Back to generated plans"
+                    >
+                      <ChevronLeft size={15} aria-hidden="true" />
+                      Plans
+                    </button>
+                    <div className="chat-plan-panel-title is-detail-title">
+                      <div>
+                        <strong title={selectedPlanDraft.name}>
+                          {selectedPlanDraft.name || "Untitled plan"}
+                        </strong>
+                        <span>
+                          Plan {selectedPlanDraftIndex + 1} of {planDrafts.length}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="chat-plan-panel-actions">
+                      <button
+                        type="button"
+                        className="chat-plan-panel-chat-link"
+                        onClick={() =>
+                          handleScrollToPlanChat(selectedPlanDraft.draftId)
+                        }
+                        title="View the generated response in chat"
+                      >
+                        <MessageCircle size={14} aria-hidden="true" />
+                        View in chat
+                      </button>
+                    </div>
+                  </div>
+                </header>
+                <div className="chat-plan-panel-body">
+                  <PlanPreviewCard
+                    key={selectedPlanDraft.draftId}
+                    draft={selectedPlanDraft}
+                    uploading={uploadingDraftId === selectedPlanDraft.draftId}
+                    uploaded={uploadedPlans[selectedPlanDraft.draftId]}
+                    onUpload={(destination) =>
+                      void handleUploadPlanDraft(selectedPlanDraft.draftId, destination)
+                    }
+                    onReview={
+                      onReviewPlan
+                        ? () => handleReviewPlanDraft(selectedPlanDraft)
+                        : undefined
+                    }
+                  />
+                </div>
+              </>
+            )}
+          </aside>
+        ) : null}
       </div>
       <ChatSettingsModal {...settingsModalProps} />
     </div>

--- a/src/chat/ModelSwitch.tsx
+++ b/src/chat/ModelSwitch.tsx
@@ -1,0 +1,46 @@
+import type { ChatProvider } from "../../electron/types";
+import {
+  getChatModelOptions,
+  type ChatModelOption
+} from "../../electron/chatModels";
+import { SelectDropdown } from "../components/SelectDropdown";
+
+export function ModelSwitch({
+  provider,
+  model,
+  disabled,
+  onChange
+}: {
+  provider: ChatProvider;
+  model: string;
+  disabled?: boolean;
+  onChange: (model: string) => void;
+}) {
+  if (provider === "local") {
+    return null;
+  }
+
+  const baseOptions = getChatModelOptions(provider);
+  const options: ChatModelOption[] = baseOptions.some(
+    (option) => option.value === model
+  )
+    ? baseOptions
+    : [...baseOptions, { value: model, label: model }];
+  const providerLabel = provider === "claude-code" ? "Claude" : "ChatGPT";
+  const selectedLabel =
+    options.find((option) => option.value === model)?.label ?? model;
+
+  return (
+    <SelectDropdown
+      className="app-select--pill chat-model-select"
+      menuClassName="chat-select-menu"
+      value={model}
+      options={options}
+      onChange={onChange}
+      label={`${providerLabel} model`}
+      title={`${providerLabel} model: ${selectedLabel}`}
+      disabled={disabled}
+      portal
+    />
+  );
+}

--- a/src/chat/ModelSwitch.tsx
+++ b/src/chat/ModelSwitch.tsx
@@ -1,9 +1,18 @@
+import { Sparkles, Terminal } from "lucide-react";
 import type { ChatProvider } from "../../electron/types";
 import {
   getChatModelOptions,
   type ChatModelOption
 } from "../../electron/chatModels";
 import { SelectDropdown } from "../components/SelectDropdown";
+
+function renderChatGptIcon() {
+  return <Sparkles size={14} strokeWidth={2.1} aria-hidden="true" />;
+}
+
+function renderClaudeIcon() {
+  return <Terminal size={14} strokeWidth={2.1} aria-hidden="true" />;
+}
 
 export function ModelSwitch({
   provider,
@@ -27,16 +36,20 @@ export function ModelSwitch({
     ? baseOptions
     : [...baseOptions, { value: model, label: model }];
   const providerLabel = provider === "claude-code" ? "Claude" : "ChatGPT";
+  const tone = provider === "claude-code" ? "claude" : "gpt";
+  const renderIcon =
+    provider === "claude-code" ? renderClaudeIcon : renderChatGptIcon;
   const selectedLabel =
     options.find((option) => option.value === model)?.label ?? model;
 
   return (
     <SelectDropdown
-      className="app-select--pill chat-model-select"
-      menuClassName="chat-select-menu"
+      className={`app-select--pill chat-model-select chat-select--${tone}`}
+      menuClassName={`chat-select-menu chat-select-menu--${tone}`}
       value={model}
       options={options}
       onChange={onChange}
+      renderIcon={renderIcon}
       label={`${providerLabel} model`}
       title={`${providerLabel} model: ${selectedLabel}`}
       disabled={disabled}

--- a/src/chat/ProviderSwitch.tsx
+++ b/src/chat/ProviderSwitch.tsx
@@ -1,10 +1,10 @@
-import { Bot, Sparkles, Terminal } from "lucide-react";
 import type { ChatProvider } from "../../electron/types";
+import { SelectDropdown } from "../components/SelectDropdown";
 
-const OPTIONS = [
-  { value: "chatgpt" as const, label: "ChatGPT", icon: Sparkles },
-  { value: "claude-code" as const, label: "Claude", icon: Terminal },
-  { value: "local" as const, label: "Local model", icon: Bot }
+const OPTIONS: Array<{ value: ChatProvider; label: string }> = [
+  { value: "chatgpt", label: "ChatGPT" },
+  { value: "claude-code", label: "Claude" },
+  { value: "local", label: "Local model" }
 ];
 
 export function ProviderSwitch({
@@ -16,42 +16,20 @@ export function ProviderSwitch({
   disabled?: boolean;
   onChange: (provider: ChatProvider) => void;
 }) {
-  const activeIndex = OPTIONS.findIndex((option) => option.value === provider);
+  const selectedLabel =
+    OPTIONS.find((option) => option.value === provider)?.label ?? provider;
 
   return (
-    <div
-      className="chat-provider-switch"
-      data-provider={provider}
-      role="radiogroup"
-      aria-label="Coach provider"
-    >
-      <span
-        className="chat-provider-switch-indicator"
-        style={{ transform: `translateX(${Math.max(activeIndex, 0) * 100}%)` }}
-        aria-hidden="true"
-      />
-      {OPTIONS.map((option) => {
-        const Icon = option.icon;
-        const isActive = provider === option.value;
-
-        return (
-          <button
-            key={option.value}
-            type="button"
-            className={isActive ? "active" : ""}
-            role="radio"
-            aria-checked={isActive}
-            onClick={() => onChange(option.value)}
-            disabled={disabled || isActive}
-          >
-            <Icon size={13} aria-hidden="true" />
-            <span>{option.label}</span>
-            {isActive ? (
-              <span className="chat-provider-switch-dot" aria-hidden="true" />
-            ) : null}
-          </button>
-        );
-      })}
-    </div>
+    <SelectDropdown
+      className="app-select--pill chat-provider-select"
+      menuClassName="chat-select-menu"
+      value={provider}
+      options={OPTIONS}
+      onChange={onChange}
+      label="Coach provider"
+      title={`Coach provider: ${selectedLabel}`}
+      disabled={disabled}
+      portal
+    />
   );
 }

--- a/src/chat/ProviderSwitch.tsx
+++ b/src/chat/ProviderSwitch.tsx
@@ -1,3 +1,4 @@
+import { Bot, Sparkles, Terminal } from "lucide-react";
 import type { ChatProvider } from "../../electron/types";
 import { SelectDropdown } from "../components/SelectDropdown";
 
@@ -6,6 +7,22 @@ const OPTIONS: Array<{ value: ChatProvider; label: string }> = [
   { value: "claude-code", label: "Claude" },
   { value: "local", label: "Local model" }
 ];
+
+function getProviderTone(provider: ChatProvider) {
+  if (provider === "claude-code") return "claude";
+  if (provider === "local") return "local";
+  return "gpt";
+}
+
+function renderProviderIcon(provider: ChatProvider) {
+  if (provider === "claude-code") {
+    return <Terminal size={14} strokeWidth={2.1} aria-hidden="true" />;
+  }
+  if (provider === "local") {
+    return <Bot size={14} strokeWidth={2.1} aria-hidden="true" />;
+  }
+  return <Sparkles size={14} strokeWidth={2.1} aria-hidden="true" />;
+}
 
 export function ProviderSwitch({
   provider,
@@ -18,14 +35,16 @@ export function ProviderSwitch({
 }) {
   const selectedLabel =
     OPTIONS.find((option) => option.value === provider)?.label ?? provider;
+  const tone = getProviderTone(provider);
 
   return (
     <SelectDropdown
-      className="app-select--pill chat-provider-select"
-      menuClassName="chat-select-menu"
+      className={`app-select--pill chat-provider-select chat-select--${tone}`}
+      menuClassName={`chat-select-menu chat-provider-menu chat-select-menu--${tone}`}
       value={provider}
       options={OPTIONS}
       onChange={onChange}
+      renderIcon={renderProviderIcon}
       label="Coach provider"
       title={`Coach provider: ${selectedLabel}`}
       disabled={disabled}

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -153,12 +153,9 @@ export function AppSidebar({
       return;
     }
 
-    const navRect = nav.getBoundingClientRect();
-    const itemRect = activeItem.getBoundingClientRect();
-
     setIndicator({
-      top: itemRect.top - navRect.top,
-      height: itemRect.height,
+      top: activeItem.offsetTop,
+      height: activeItem.offsetHeight,
       ready: true,
     });
   }, [activeView, coachBusy, expanded, isOpen, overlayMode]);

--- a/src/components/DonateButton.tsx
+++ b/src/components/DonateButton.tsx
@@ -9,13 +9,13 @@ export function DonateButton() {
       href={DONATE_URL}
       target="_blank"
       rel="noreferrer"
-      aria-label="Donate to support CorosLink"
+      aria-label="Buy me a coffee"
       title="Buy me a coffee"
     >
       <span className="donate-button-art" aria-hidden="true">
         <Coffee className="donate-button-cup" size={17} strokeWidth={2.6} />
       </span>
-      <span className="donate-button-label">Donate</span>
+      <span className="donate-button-label">Buy me a coffee</span>
     </a>
   );
 }

--- a/src/components/SelectDropdown.tsx
+++ b/src/components/SelectDropdown.tsx
@@ -22,6 +22,7 @@ export interface SelectDropdownProps<T extends string> {
   onChange: (value: T) => void;
   label: string;
   className?: string;
+  menuClassName?: string;
   disabled?: boolean;
   portal?: boolean;
   title?: string;
@@ -54,6 +55,7 @@ export function SelectDropdown<T extends string>({
   onChange,
   label,
   className,
+  menuClassName,
   disabled = false,
   portal = false,
   title
@@ -222,7 +224,13 @@ export function SelectDropdown<T extends string>({
 
   const menu = isOpen ? (
     <div
-      className={`app-select-menu${portal ? " is-portaled" : ""}`}
+      className={[
+        "app-select-menu",
+        portal ? "is-portaled" : "",
+        menuClassName
+      ]
+        .filter(Boolean)
+        .join(" ")}
       id={menuId}
       ref={menuRef}
       role="listbox"

--- a/src/components/SelectDropdown.tsx
+++ b/src/components/SelectDropdown.tsx
@@ -2,6 +2,7 @@ import { Check, ChevronDown } from "lucide-react";
 import {
   type CSSProperties,
   type KeyboardEvent,
+  type ReactNode,
   useCallback,
   useEffect,
   useId,
@@ -23,6 +24,7 @@ export interface SelectDropdownProps<T extends string> {
   label: string;
   className?: string;
   menuClassName?: string;
+  renderIcon?: (value: T) => ReactNode;
   disabled?: boolean;
   portal?: boolean;
   title?: string;
@@ -49,6 +51,8 @@ const PORTAL_THEME_VARIABLES = [
   "--radius-sm"
 ] as const;
 
+const MENU_CLOSE_DURATION_MS = 180;
+
 export function SelectDropdown<T extends string>({
   value,
   options,
@@ -56,6 +60,7 @@ export function SelectDropdown<T extends string>({
   label,
   className,
   menuClassName,
+  renderIcon,
   disabled = false,
   portal = false,
   title
@@ -64,16 +69,41 @@ export function SelectDropdown<T extends string>({
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const closeTimerRef = useRef<number | null>(null);
   const typeaheadRef = useRef({ query: "", updatedAt: 0 });
   const [isOpen, setIsOpen] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
   const [highlightedValue, setHighlightedValue] = useState<T>(value);
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   const [portalTheme, setPortalTheme] = useState<PortalTheme>({});
   const selectedOption = options.find((option) => option.value === value);
   const selectedLabel = selectedOption?.label ?? "Select";
+  const selectedIcon = renderIcon?.(value);
+  const isMenuMounted = isOpen || isClosing;
   const labelId = `${dropdownId}-label`;
   const valueId = `${dropdownId}-value`;
   const menuId = `${dropdownId}-menu`;
+
+  const openMenu = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+    setIsClosing(false);
+    setIsOpen(true);
+  }, []);
+
+  const closeMenu = useCallback(() => {
+    setIsOpen(false);
+    setIsClosing(true);
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current);
+    }
+    closeTimerRef.current = window.setTimeout(() => {
+      setIsClosing(false);
+      closeTimerRef.current = null;
+    }, MENU_CLOSE_DURATION_MS);
+  }, []);
 
   const updateMenuPosition = useCallback(() => {
     if (!portal || !triggerRef.current) return;
@@ -114,13 +144,13 @@ export function SelectDropdown<T extends string>({
     function handlePointerDown(event: PointerEvent) {
       const target = event.target as Node;
       if (!rootRef.current?.contains(target) && !menuRef.current?.contains(target)) {
-        setIsOpen(false);
+        closeMenu();
       }
     }
 
     function handleDocumentKeyDown(event: globalThis.KeyboardEvent) {
       if (event.key === "Escape" || event.key === "Tab") {
-        setIsOpen(false);
+        closeMenu();
       }
     }
 
@@ -131,10 +161,18 @@ export function SelectDropdown<T extends string>({
       document.removeEventListener("pointerdown", handlePointerDown);
       document.removeEventListener("keydown", handleDocumentKeyDown);
     };
-  }, [isOpen, value]);
+  }, [closeMenu, isOpen, value]);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current !== null) {
+        window.clearTimeout(closeTimerRef.current);
+      }
+    };
+  }, []);
 
   useLayoutEffect(() => {
-    if (!isOpen || !portal) {
+    if (!isMenuMounted || !portal) {
       setMenuPosition(null);
       return;
     }
@@ -150,7 +188,7 @@ export function SelectDropdown<T extends string>({
       observer?.disconnect();
       window.removeEventListener("resize", updateMenuPosition);
     };
-  }, [isOpen, portal, updateMenuPosition]);
+  }, [isMenuMounted, portal, updateMenuPosition]);
 
   function moveHighlight(direction: 1 | -1) {
     if (options.length === 0) {
@@ -174,7 +212,7 @@ export function SelectDropdown<T extends string>({
   function selectOption(nextValue: T) {
     onChange(nextValue);
     setHighlightedValue(nextValue);
-    setIsOpen(false);
+    closeMenu();
   }
 
   function handleTriggerKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
@@ -186,7 +224,7 @@ export function SelectDropdown<T extends string>({
       event.preventDefault();
 
       if (!isOpen) {
-        setIsOpen(true);
+        openMenu();
         setHighlightedValue(value);
         return;
       }
@@ -216,17 +254,19 @@ export function SelectDropdown<T extends string>({
       typeaheadRef.current = { query, updatedAt: now };
       const match = options.find((option) => option.label.toLocaleLowerCase().startsWith(query));
       if (match) {
-        setIsOpen(true);
+        openMenu();
         setHighlightedValue(match.value);
       }
     }
   }
 
-  const menu = isOpen ? (
+  const menu = isMenuMounted ? (
     <div
       className={[
         "app-select-menu",
         portal ? "is-portaled" : "",
+        isOpen && (!portal || menuPosition) ? "is-opening" : "",
+        isClosing ? "is-closing" : "",
         menuClassName
       ]
         .filter(Boolean)
@@ -235,6 +275,8 @@ export function SelectDropdown<T extends string>({
       ref={menuRef}
       role="listbox"
       aria-label={label}
+      aria-hidden={isClosing || undefined}
+      data-side={menuPosition?.transform ? "top" : "bottom"}
       style={portal ? ({
         ...portalTheme,
         left: menuPosition?.left ?? 0,
@@ -245,41 +287,61 @@ export function SelectDropdown<T extends string>({
         visibility: menuPosition ? "visible" : "hidden"
       } satisfies CSSProperties) : undefined}
     >
-      {options.map((option) => {
-        const isSelected = option.value === value;
-        const isActive = option.value === highlightedValue;
+      <div className="app-select-menu-list">
+        {options.map((option, index) => {
+          const isSelected = option.value === value;
+          const isActive = option.value === highlightedValue;
+          const optionIcon = renderIcon?.(option.value);
 
-        return (
-          <button
-            type="button"
-            className={[
-              "app-select-option",
-              isSelected ? "is-selected" : "",
-              isActive ? "is-active" : ""
-            ]
-              .filter(Boolean)
-              .join(" ")}
-            id={`${dropdownId}-option-${String(option.value)}`}
-            key={option.value}
-            role="option"
-            aria-selected={isSelected}
-            onClick={() => selectOption(option.value)}
-            onMouseDown={(event) => event.preventDefault()}
-            onMouseEnter={() => setHighlightedValue(option.value)}
-          >
-            <span>{option.label}</span>
-            {isSelected ? (
-              <Check size={15} strokeWidth={2.6} aria-hidden="true" />
-            ) : null}
-          </button>
-        );
-      })}
+          return (
+            <button
+              type="button"
+              className={[
+                "app-select-option",
+                isSelected ? "is-selected" : "",
+                isActive ? "is-active" : ""
+              ]
+                .filter(Boolean)
+                .join(" ")}
+              data-value={option.value}
+              id={`${dropdownId}-option-${String(option.value)}`}
+              key={option.value}
+              role="option"
+              aria-selected={isSelected}
+              style={{
+                "--app-select-delay": `${40 + index * 18}ms`
+              } as CSSProperties}
+              onClick={() => selectOption(option.value)}
+              onMouseDown={(event) => event.preventDefault()}
+              onMouseEnter={() => setHighlightedValue(option.value)}
+            >
+              <span className="app-select-option-content">
+                {optionIcon ? (
+                  <span className="app-select-leading-icon" aria-hidden="true">
+                    {optionIcon}
+                  </span>
+                ) : null}
+                <span className="app-select-option-label">{option.label}</span>
+              </span>
+              {isSelected ? (
+                <Check
+                  className="app-select-option-check"
+                  size={15}
+                  strokeWidth={2.6}
+                  aria-hidden="true"
+                />
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
     </div>
   ) : null;
 
   return (
     <div
       className={["app-select", className].filter(Boolean).join(" ")}
+      data-value={value}
       ref={rootRef}
     >
       <span className="sr-only" id={labelId}>
@@ -299,13 +361,22 @@ export function SelectDropdown<T extends string>({
         title={title}
         onClick={() => {
           if (!disabled) {
-            setIsOpen((current) => !current);
+            if (isOpen) {
+              closeMenu();
+            } else {
+              openMenu();
+            }
           }
         }}
         onKeyDown={handleTriggerKeyDown}
       >
         <span className="app-select-value" id={valueId}>
-          {selectedLabel}
+          {selectedIcon ? (
+            <span className="app-select-leading-icon" aria-hidden="true">
+              {selectedIcon}
+            </span>
+          ) : null}
+          <span className="app-select-value-label">{selectedLabel}</span>
         </span>
         <ChevronDown
           className={isOpen ? "app-select-icon is-open" : "app-select-icon"}

--- a/src/coroslink-api.ts
+++ b/src/coroslink-api.ts
@@ -379,7 +379,11 @@ export interface CorosLinkApi {
   ) => Promise<TrainingPlanDocument>;
   deleteLocalTrainingPlan: (id: string, confirmed: boolean) => Promise<void>;
   previewTrainingPlanCalendar: (planId: string, startDate: string) => Promise<TrainingPlanCalendarPreview>;
-  addTrainingPlanToCalendar: (previewId: string, confirmed: boolean) => Promise<TrainingPlanCalendarMutationResult>;
+  addTrainingPlanToCalendar: (
+    previewId: string,
+    confirmed: boolean,
+    unitSystem: UnitSystem
+  ) => Promise<TrainingPlanCalendarMutationResult>;
   previewTrainingPlanCalendarRemoval: (planId: string) => Promise<TrainingPlanCalendarPreview>;
   removeTrainingPlanFromCalendar: (previewId: string, confirmed: boolean) => Promise<TrainingPlanCalendarMutationResult>;
   updateWorkoutMetadata: (

--- a/src/data/components/IntervalsImportPanel.tsx
+++ b/src/data/components/IntervalsImportPanel.tsx
@@ -25,6 +25,11 @@ import {
   formatDistanceMeters,
   formatTrainingTimestamp
 } from "../../training/formatters";
+import {
+  defineSelectionPreference,
+  selectionIsOneOf,
+  useSelectionPreference
+} from "../../preferences/selectionPreferences";
 
 const DEFAULT_DAYS_BACK = 30;
 
@@ -34,6 +39,12 @@ const RANGE_OPTIONS = [
   { days: 90, label: "90 days" },
   { days: 365, label: "1 year" }
 ] as const;
+
+const INTERVALS_RANGE_PREFERENCE = defineSelectionPreference<number>({
+  key: "data.intervalsDaysBack",
+  defaultValue: DEFAULT_DAYS_BACK,
+  validate: selectionIsOneOf([7, 30, 90, 365])
+});
 
 interface RowState {
   busy: boolean;
@@ -82,7 +93,9 @@ export function IntervalsImportPanel({ api }: { api: CorosLinkApi }) {
   const [connecting, setConnecting] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
 
-  const [daysBack, setDaysBack] = useState(DEFAULT_DAYS_BACK);
+  const [daysBack, setDaysBack] = useSelectionPreference(
+    INTERVALS_RANGE_PREFERENCE
+  );
   const [refreshNonce, setRefreshNonce] = useState(0);
   const [rows, setRows] = useState<IntervalsActivityWithStatus[]>([]);
   const [refreshing, setRefreshing] = useState(false);

--- a/src/maps/MapsView.tsx
+++ b/src/maps/MapsView.tsx
@@ -32,8 +32,41 @@ import type { CorosLinkApi } from "../coroslink-api";
 import { SelectDropdown } from "../components/SelectDropdown";
 import { formatBytes } from "../media/libraryUtils";
 import { RouteStudio } from "./routes/RouteStudio";
+import {
+  defineSelectionPreference,
+  selectionIsBoolean,
+  selectionIsOneOf,
+  useSelectionPreference
+} from "../preferences/selectionPreferences";
 
 type MapsTab = "coros" | "routes";
+
+interface CorosMapFilterPreference {
+  region: string;
+  landscape: boolean;
+  topo: boolean;
+}
+
+const MAPS_TAB_PREFERENCE = defineSelectionPreference<MapsTab>({
+  key: "maps.activeTab",
+  defaultValue: "coros",
+  validate: selectionIsOneOf(["coros", "routes"])
+});
+
+const COROS_MAP_FILTER_PREFERENCE =
+  defineSelectionPreference<CorosMapFilterPreference>({
+    key: "maps.corosFilters",
+    defaultValue: { region: "all", landscape: true, topo: true },
+    validate: (value): value is CorosMapFilterPreference => {
+      if (typeof value !== "object" || value === null) return false;
+      const candidate = value as Record<string, unknown>;
+      return (
+        typeof candidate.region === "string" &&
+        selectionIsBoolean(candidate.landscape) &&
+        selectionIsBoolean(candidate.topo)
+      );
+    }
+  });
 
 interface MapPackageGroup {
   key: string;
@@ -58,7 +91,9 @@ export function MapsView({
   onMessage,
   onError
 }: MapsViewProps) {
-  const [activeTab, setActiveTab] = useState<MapsTab>("coros");
+  const [activeTab, setActiveTab] = useSelectionPreference(
+    MAPS_TAB_PREFERENCE
+  );
 
   return (
     <div className="maps-view stack">
@@ -128,9 +163,14 @@ function CorosMapsTab({
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
   const [query, setQuery] = useState("");
-  const [regionFilter, setRegionFilter] = useState("all");
-  const [showLandscape, setShowLandscape] = useState(true);
-  const [showTopo, setShowTopo] = useState(true);
+  const [filters, setFilters] = useSelectionPreference(
+    COROS_MAP_FILTER_PREFERENCE
+  );
+  const {
+    region: regionFilter,
+    landscape: showLandscape,
+    topo: showTopo
+  } = filters;
   const [localSelection, setLocalSelection] =
     useState<CorosMapLocalSelection | null>(null);
   const [downloadJobs, setDownloadJobs] = useState<CorosMapDownloadJob[]>([]);
@@ -427,6 +467,15 @@ function CorosMapsTab({
     [regionOptions]
   );
 
+  useEffect(() => {
+    if (
+      manifest &&
+      !regionFilterOptions.some((option) => option.value === regionFilter)
+    ) {
+      setFilters((current) => ({ ...current, region: "all" }));
+    }
+  }, [manifest, regionFilter, regionFilterOptions, setFilters]);
+
   const packageGroups = useMemo(() => {
     const terms = normalizeSearch(query);
     const groups = new Map<string, MapPackageGroup>();
@@ -701,14 +750,21 @@ function CorosMapsTab({
             label="Region"
             value={regionFilter}
             options={regionFilterOptions}
-            onChange={setRegionFilter}
+            onChange={(region) =>
+              setFilters((current) => ({ ...current, region }))
+            }
           />
 
           <label className="check-row maps-check">
             <input
               type="checkbox"
               checked={showLandscape}
-              onChange={(event) => setShowLandscape(event.target.checked)}
+              onChange={(event) =>
+                setFilters((current) => ({
+                  ...current,
+                  landscape: event.target.checked
+                }))
+              }
             />
             Landscape
           </label>
@@ -716,7 +772,12 @@ function CorosMapsTab({
             <input
               type="checkbox"
               checked={showTopo}
-              onChange={(event) => setShowTopo(event.target.checked)}
+              onChange={(event) =>
+                setFilters((current) => ({
+                  ...current,
+                  topo: event.target.checked
+                }))
+              }
             />
             Topo
           </label>
@@ -1319,4 +1380,3 @@ function isInstallTransferCancelled(error: unknown): boolean {
 function toErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
-

--- a/src/maps/routes/RouteStudio.tsx
+++ b/src/maps/routes/RouteStudio.tsx
@@ -43,6 +43,43 @@ import { SKETCH_TEMPLATES } from "./sketchShapes";
 import { useRouteDraw } from "./useRouteDraw";
 import { useRouteSketch } from "./useRouteSketch";
 import { surfaceForActivity, toErrorMessage } from "./utils";
+import {
+  defineSelectionPreference,
+  selectionIsArrayOf,
+  selectionIsOneOf,
+  useSelectionPreference
+} from "../../preferences/selectionPreferences";
+
+const ROUTE_STUDIO_MODE_PREFERENCE =
+  defineSelectionPreference<RouteStudioMode>({
+    key: "maps.routeStudio.mode",
+    defaultValue: "generate",
+    validate: selectionIsOneOf(["generate", "draw", "sketch", "explore"])
+  });
+
+const ROUTE_STUDIO_BASE_LAYER_PREFERENCE =
+  defineSelectionPreference<RouteBaseLayer>({
+    key: "maps.routeStudio.baseLayer",
+    defaultValue: "outdoors",
+    validate: selectionIsOneOf([
+      "street",
+      "outdoors",
+      "light",
+      "dark",
+      "topo",
+      "satellite"
+    ])
+  });
+
+const ROUTE_STUDIO_OVERLAYS_PREFERENCE =
+  defineSelectionPreference<RouteOverlayId[]>({
+    key: "maps.routeStudio.overlays",
+    defaultValue: [],
+    validate: selectionIsArrayOf(
+      selectionIsOneOf(["hiking", "cycling", "mtb"]),
+      { unique: true }
+    )
+  });
 
 const MODE_TABS: Array<{
   id: RouteStudioMode;
@@ -65,7 +102,9 @@ export function RouteStudio({
   onError: (message: string | null) => void;
 }) {
   const { unitSystem } = useUnitSystem();
-  const [mode, setMode] = useState<RouteStudioMode>("generate");
+  const [mode, setMode] = useSelectionPreference(
+    ROUTE_STUDIO_MODE_PREFERENCE
+  );
   const [activityType, setActivityType] = useState<RouteActivityType>("running");
 
   // Generate state
@@ -98,8 +137,12 @@ export function RouteStudio({
   const [fitRequestId, setFitRequestId] = useState(0);
 
   // Map state
-  const [baseLayer, setBaseLayer] = useState<RouteBaseLayer>("outdoors");
-  const [overlays, setOverlays] = useState<RouteOverlayId[]>([]);
+  const [baseLayer, setBaseLayer] = useSelectionPreference(
+    ROUTE_STUDIO_BASE_LAYER_PREFERENCE
+  );
+  const [overlays, setOverlays] = useSelectionPreference(
+    ROUTE_STUDIO_OVERLAYS_PREFERENCE
+  );
 
   const draw = useRouteDraw(api, activityType);
   const sketch = useRouteSketch(api, activityType);

--- a/src/media/LibraryPanels.tsx
+++ b/src/media/LibraryPanels.tsx
@@ -30,6 +30,11 @@ import {
   sumBytes,
 } from "./libraryUtils";
 import { trackAvatarColor, trackInitial } from "./trackAvatar";
+import {
+  defineSelectionPreference,
+  selectionIsOneOf,
+  useSelectionPreference,
+} from "../preferences/selectionPreferences";
 
 type SortDirection = "asc" | "desc";
 type LocalLibrarySortKey = "title" | "size" | "created" | "status";
@@ -53,6 +58,41 @@ const watchSortDefaults: Record<WatchLibrarySortKey, SortDirection> = {
   size: "desc",
   modified: "desc",
 };
+
+function isSortState<Key extends string>(
+  value: unknown,
+  keys: readonly Key[],
+): value is SortState<Key> {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    keys.includes(candidate.key as Key) &&
+    (candidate.direction === "asc" || candidate.direction === "desc")
+  );
+}
+
+const LOCAL_TRACK_FILTER_PREFERENCE =
+  defineSelectionPreference<LocalTrackFilter>({
+    key: "media.library.localFilter",
+    defaultValue: "all",
+    validate: selectionIsOneOf(["all", "pending", "synced"]),
+  });
+
+const LOCAL_TRACK_SORT_PREFERENCE =
+  defineSelectionPreference<SortState<LocalLibrarySortKey>>({
+    key: "media.library.localSort",
+    defaultValue: { key: "created", direction: "desc" },
+    validate: (value): value is SortState<LocalLibrarySortKey> =>
+      isSortState(value, ["title", "size", "created", "status"]),
+  });
+
+const WATCH_TRACK_SORT_PREFERENCE =
+  defineSelectionPreference<SortState<WatchLibrarySortKey>>({
+    key: "media.library.watchSort",
+    defaultValue: { key: "name", direction: "asc" },
+    validate: (value): value is SortState<WatchLibrarySortKey> =>
+      isSortState(value, ["name", "size", "modified"]),
+  });
 
 function nextSortState<Key extends string>(
   current: SortState<Key>,
@@ -312,11 +352,12 @@ export function LocalLibraryPanel({
   onDeleteDownloads,
 }: LocalLibraryPanelProps) {
   const [searchQuery, setSearchQuery] = useState("");
-  const [trackFilter, setTrackFilter] = useState<LocalTrackFilter>("all");
-  const [sort, setSort] = useState<SortState<LocalLibrarySortKey>>({
-    key: "created",
-    direction: "desc",
-  });
+  const [trackFilter, setTrackFilter] = useSelectionPreference(
+    LOCAL_TRACK_FILTER_PREFERENCE,
+  );
+  const [sort, setSort] = useSelectionPreference(
+    LOCAL_TRACK_SORT_PREFERENCE,
+  );
   const deferredSearchQuery = useDeferredValue(searchQuery);
   const searchTerms = useMemo(
     () => getSearchTerms(deferredSearchQuery),
@@ -798,10 +839,9 @@ export function WatchLibraryPanel({
   onDeleteWatchTracks,
 }: WatchLibraryPanelProps) {
   const [searchQuery, setSearchQuery] = useState("");
-  const [sort, setSort] = useState<SortState<WatchLibrarySortKey>>({
-    key: "name",
-    direction: "asc",
-  });
+  const [sort, setSort] = useSelectionPreference(
+    WATCH_TRACK_SORT_PREFERENCE,
+  );
   const watchTracks = watchStatus?.tracks ?? [];
   const presentation = getWatchPresentation(watchStatus);
   const deferredSearchQuery = useDeferredValue(searchQuery);

--- a/src/overview/ActivityGlobeCard.tsx
+++ b/src/overview/ActivityGlobeCard.tsx
@@ -1267,7 +1267,7 @@ export function ActivityGlobeCard({
             ) : null}
           </header>
           <div className="training-map-recent-list">
-            {recentPlaces.map((summary) => {
+            {recentPlaces.map((summary, index) => {
               const label = placeLabels[summary.key] ?? coordinateLabel(summary.bucket);
               const selected = selectedLocationKey === summary.key;
               return (
@@ -1275,6 +1275,7 @@ export function ActivityGlobeCard({
                   key={summary.key}
                   type="button"
                   className={selected ? "is-selected" : undefined}
+                  style={{ "--recent-delay": `${index * 45}ms` } as CSSProperties}
                   aria-pressed={selected}
                   onClick={() => selectLocation(summary.bucket)}
                 >

--- a/src/overview/ActivityGlobeCard.tsx
+++ b/src/overview/ActivityGlobeCard.tsx
@@ -65,6 +65,10 @@ import {
   ActivityGlobeRenderer,
   type ActivityGlobeRendererHandle,
 } from "./ActivityGlobeRenderer";
+import {
+  defineSelectionPreference,
+  useSelectionPreference,
+} from "../preferences/selectionPreferences";
 import "./activityGlobe.css";
 
 interface ActivityGlobeCardProps {
@@ -77,6 +81,45 @@ interface ActivityGlobeCardProps {
 }
 
 type ActivityPeriod = "all" | "year" | "90-days" | "custom";
+
+interface ActivityPeriodPreference {
+  period: ActivityPeriod;
+  customStart: string;
+  customEnd: string;
+}
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function isIsoDateOrEmpty(value: unknown): value is string {
+  if (value === "") return true;
+  if (typeof value !== "string" || !ISO_DATE_PATTERN.test(value)) return false;
+  const date = new Date(`${value}T00:00:00`);
+  return !Number.isNaN(date.valueOf()) && date.toISOString().slice(0, 10) === value;
+}
+
+const ACTIVITY_PERIOD_PREFERENCE =
+  defineSelectionPreference<ActivityPeriodPreference>({
+    key: "overview.activityPeriod",
+    defaultValue: { period: "all", customStart: "", customEnd: "" },
+    validate: (value): value is ActivityPeriodPreference => {
+      if (typeof value !== "object" || value === null) return false;
+      const candidate = value as Record<string, unknown>;
+      if (
+        !["all", "year", "90-days", "custom"].includes(
+          String(candidate.period),
+        ) ||
+        !isIsoDateOrEmpty(candidate.customStart) ||
+        !isIsoDateOrEmpty(candidate.customEnd)
+      ) {
+        return false;
+      }
+      return !(
+        candidate.customStart &&
+        candidate.customEnd &&
+        candidate.customStart > candidate.customEnd
+      );
+    },
+  });
 
 interface PlaceLabel {
   city: string;
@@ -313,9 +356,10 @@ export function ActivityGlobeCard({
   const globeRendererRef = useRef<ActivityGlobeRendererHandle>(null);
   const streetEnterTimerRef = useRef<number | null>(null);
 
-  const [period, setPeriod] = useState<ActivityPeriod>("all");
-  const [customStart, setCustomStart] = useState("");
-  const [customEnd, setCustomEnd] = useState("");
+  const [periodPreference, setPeriodPreference] = useSelectionPreference(
+    ACTIVITY_PERIOD_PREFERENCE,
+  );
+  const { period, customStart, customEnd } = periodPreference;
   const [selectedLocationKey, setSelectedLocationKey] = useState<string | null>(
     null,
   );
@@ -830,7 +874,12 @@ export function ActivityGlobeCard({
                   type="button"
                   className={period === value ? "is-selected" : undefined}
                   aria-pressed={period === value}
-                  onClick={() => setPeriod(value)}
+                  onClick={() =>
+                    setPeriodPreference((current) => ({
+                      ...current,
+                      period: value,
+                    }))
+                  }
                 >
                   {label}
                   {value === "custom" ? (
@@ -847,7 +896,12 @@ export function ActivityGlobeCard({
                     type="date"
                     value={customStart}
                     max={customEnd || undefined}
-                    onChange={(event) => setCustomStart(event.target.value)}
+                    onChange={(event) =>
+                      setPeriodPreference((current) => ({
+                        ...current,
+                        customStart: event.target.value,
+                      }))
+                    }
                   />
                 </label>
                 <label>
@@ -856,7 +910,12 @@ export function ActivityGlobeCard({
                     type="date"
                     value={customEnd}
                     min={customStart || undefined}
-                    onChange={(event) => setCustomEnd(event.target.value)}
+                    onChange={(event) =>
+                      setPeriodPreference((current) => ({
+                        ...current,
+                        customEnd: event.target.value,
+                      }))
+                    }
                   />
                 </label>
               </div>

--- a/src/overview/ActivityGlobeCard.tsx
+++ b/src/overview/ActivityGlobeCard.tsx
@@ -1,6 +1,5 @@
 import {
   Activity,
-  ArrowRight,
   CalendarDays,
   ChevronLeft,
   ChevronRight,
@@ -16,6 +15,7 @@ import {
   Route,
   RotateCcw,
   Timer,
+  ZoomIn,
 } from "lucide-react";
 import {
   Area,
@@ -75,8 +75,6 @@ interface ActivityGlobeCardProps {
   activities: TrainingHubActivity[];
   connected: boolean;
   detail: TrainingHubActivityDetail | null;
-  loading: boolean;
-  onOpenTraining: () => void;
   onSelectActivity: (activity: TrainingHubActivity) => void;
 }
 
@@ -89,6 +87,7 @@ interface ActivityPeriodPreference {
 }
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const LOCATION_ZOOM_DURATION_MS = 1_100;
 
 function isIsoDateOrEmpty(value: unknown): value is string {
   if (value === "") return true;
@@ -348,8 +347,6 @@ export function ActivityGlobeCard({
   activities,
   connected,
   detail,
-  loading,
-  onOpenTraining,
   onSelectActivity,
 }: ActivityGlobeCardProps) {
   const { unitSystem } = useUnitSystem();
@@ -419,6 +416,7 @@ export function ActivityGlobeCard({
   const [canResetView, setCanResetView] = useState(false);
   const [hoveringCluster, setHoveringCluster] = useState(false);
   const [streetFocus, setStreetFocus] = useState<StreetMapFocus | null>(null);
+  const [zoomingToStreet, setZoomingToStreet] = useState(false);
   const streetMode = streetFocus !== null;
 
   const routePoints = useMemo(() => {
@@ -580,6 +578,7 @@ export function ActivityGlobeCard({
     }
     setSelectedLocationKey(null);
     setStreetFocus(null);
+    setZoomingToStreet(false);
     setCanResetView(false);
   }, [period, customStart, customEnd]);
 
@@ -588,6 +587,7 @@ export function ActivityGlobeCard({
       window.clearTimeout(streetEnterTimerRef.current);
       streetEnterTimerRef.current = null;
     }
+    setZoomingToStreet(false);
     setStreetFocus(focus);
     setCanResetView(true);
     setHoveringCluster(false);
@@ -607,6 +607,11 @@ export function ActivityGlobeCard({
     bucket: GeoHeatBucket,
     options?: { openStreet?: boolean },
   ) => {
+    if (streetEnterTimerRef.current !== null) {
+      window.clearTimeout(streetEnterTimerRef.current);
+      streetEnterTimerRef.current = null;
+    }
+    setZoomingToStreet(false);
     const summary = locationSummaries.find(
       (candidate) => candidate.key === bucket.key,
     );
@@ -621,11 +626,33 @@ export function ActivityGlobeCard({
     setCanResetView(true);
   };
 
+  const zoomIntoSelectedLocation = () => {
+    if (!selectedLocation || zoomingToStreet) {
+      return;
+    }
+    const focus = {
+      lat: selectedLocation.bucket.lat,
+      lon: selectedLocation.bucket.lon,
+    };
+    const duration =
+      globeRendererRef.current?.zoomToLocation(
+        focus,
+        LOCATION_ZOOM_DURATION_MS,
+      ) ?? 0;
+    if (duration === 0) {
+      enterStreetFocus(focus);
+      return;
+    }
+    setZoomingToStreet(true);
+    scheduleStreetFocus(focus, duration);
+  };
+
   const restoreBaselineCamera = (duration = 900) => {
     if (streetEnterTimerRef.current !== null) {
       window.clearTimeout(streetEnterTimerRef.current);
       streetEnterTimerRef.current = null;
     }
+    setZoomingToStreet(false);
     globeRendererRef.current?.resetView(duration);
     setCanResetView(false);
   };
@@ -1075,11 +1102,12 @@ export function ActivityGlobeCard({
                   )}
                   <button
                     type="button"
-                    className="training-map-view-action"
-                    onClick={onOpenTraining}
+                    className={`training-map-view-action${zoomingToStreet ? " is-zooming" : ""}`}
+                    onClick={zoomIntoSelectedLocation}
+                    disabled={zoomingToStreet}
                   >
-                    {loading ? "Loading route" : "View activities"}
-                    <ArrowRight size={15} aria-hidden="true" />
+                    {zoomingToStreet ? "Zooming in" : "Zoom in"}
+                    <ZoomIn size={15} aria-hidden="true" />
                   </button>
                 </div>
               </div>

--- a/src/overview/ActivityGlobeRenderer.tsx
+++ b/src/overview/ActivityGlobeRenderer.tsx
@@ -39,6 +39,10 @@ interface ActivityGlobeRendererProps {
 
 export interface ActivityGlobeRendererHandle {
   resetView: (duration?: number) => void;
+  zoomToLocation: (
+    focus: { lat: number; lon: number },
+    duration?: number,
+  ) => number;
 }
 
 interface GlobeView {
@@ -77,6 +81,7 @@ const FRAMING_VERSION = "full-panel-v3";
 const SELECTED_LATITUDE_OFFSET = 6.5;
 const CAMERA_FOCUS_MS = 600;
 const STREET_VIEW_ALTITUDE = 0.42;
+const STREET_TRANSITION_ALTITUDE = 0.36;
 const IDLE_DELAY_MS = 4_200;
 const IDLE_ROTATION_SPEED = 0.08;
 
@@ -330,7 +335,34 @@ const ActivityGlobeRendererComponent = forwardRef<
     [onViewChange, reducedMotion, scheduleIdleRotation, stopIdleRotation],
   );
 
-  useImperativeHandle(forwardedRef, () => ({ resetView }), [resetView]);
+  const zoomToLocation = useCallback(
+    (focus: { lat: number; lon: number }, duration = 1_100) => {
+      const globe = globeRef.current;
+      const animationDuration = reducedMotion ? 0 : duration;
+      if (!globe) {
+        return 0;
+      }
+      streetRequestedRef.current = true;
+      stopIdleRotation();
+      globe.pointOfView(
+        {
+          lat: clampLatitude(focus.lat),
+          lng: focus.lon,
+          altitude: STREET_TRANSITION_ALTITUDE,
+        },
+        animationDuration,
+      );
+      onViewChange(true);
+      return animationDuration;
+    },
+    [onViewChange, reducedMotion, stopIdleRotation],
+  );
+
+  useImperativeHandle(
+    forwardedRef,
+    () => ({ resetView, zoomToLocation }),
+    [resetView, zoomToLocation],
+  );
 
   useEffect(() => {
     const element = containerRef.current;

--- a/src/overview/activityGlobe.css
+++ b/src/overview/activityGlobe.css
@@ -3,6 +3,8 @@
   --map-panel-background: #0d1115;
   --map-secondary-surface: #11161b;
   --map-elevated-surface: #151b20;
+  --map-card-surface: #131920;
+  --map-card-surface-hover: #192129;
   --map-border: rgba(235, 242, 246, 0.09);
   --map-border-strong: rgba(235, 242, 246, 0.16);
   --map-text-primary: #edf1f3;
@@ -11,6 +13,8 @@
   --map-accent: #35bd91;
   --map-accent-hover: #46c99e;
   --map-accent-muted: rgba(53, 189, 145, 0.12);
+  --map-accent-gradient: linear-gradient(135deg, #2fbe91 0%, #1fb6a6 100%);
+  --map-on-accent: #f2fbf7;
   --map-globe-background: transparent;
   --map-globe-radial: rgba(83, 153, 207, 0.12);
   --map-globe-rim-light: rgba(121, 184, 226, 0.08);
@@ -25,22 +29,32 @@
   --map-heat-low: rgba(53, 189, 145, 0.2);
   --map-heat-medium: rgba(72, 204, 160, 0.6);
   --map-heat-high: rgba(194, 247, 226, 0.94);
-  --map-panel-shadow: 0 24px 54px rgba(0, 0, 0, 0.28);
+  --map-panel-shadow:
+    inset 0 1px 0 rgba(235, 242, 246, 0.04),
+    0 24px 54px rgba(0, 0, 0, 0.28);
+  --map-card-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.18),
+    0 12px 30px rgba(0, 0, 0, 0.16);
+  --map-ease: cubic-bezier(0.22, 0.61, 0.21, 1);
 }
 
 :root[data-theme="paper"] {
   --map-app-background: #eef1f3;
   --map-panel-background: #f7f8f9;
-  --map-secondary-surface: #f0f3f4;
-  --map-elevated-surface: #e9edef;
-  --map-border: rgba(26, 35, 42, 0.1);
-  --map-border-strong: rgba(26, 35, 42, 0.18);
+  --map-secondary-surface: #eef1f2;
+  --map-elevated-surface: #e7ebed;
+  --map-card-surface: #ffffff;
+  --map-card-surface-hover: #ffffff;
+  --map-border: rgba(26, 35, 42, 0.09);
+  --map-border-strong: rgba(26, 35, 42, 0.17);
   --map-text-primary: #171c20;
   --map-text-secondary: #4d575e;
   --map-text-muted: #737e85;
   --map-accent: #0f8967;
   --map-accent-hover: #0b7658;
-  --map-accent-muted: rgba(15, 137, 103, 0.11);
+  --map-accent-muted: rgba(15, 137, 103, 0.1);
+  --map-accent-gradient: linear-gradient(135deg, #17a67d 0%, #128a7f 100%);
+  --map-on-accent: #f4fbf8;
   --map-globe-background: transparent;
   --map-globe-radial: rgba(57, 116, 156, 0.07);
   --map-globe-rim-light: rgba(82, 132, 166, 0.045);
@@ -56,21 +70,32 @@
   --map-heat-medium: rgba(20, 157, 116, 0.58);
   --map-heat-high: rgba(4, 111, 80, 0.92);
   --map-panel-shadow:
-    0 1px 2px rgba(42, 52, 60, 0.04),
-    0 18px 44px rgba(42, 52, 60, 0.09);
+    inset 0 1px 0 rgba(255, 255, 255, 0.65),
+    0 1px 2px rgba(60, 50, 35, 0.04),
+    0 18px 44px rgba(60, 50, 35, 0.08);
+  --map-card-shadow:
+    0 1px 2px rgba(60, 50, 35, 0.05),
+    0 10px 26px rgba(60, 50, 35, 0.06);
 }
 
 .training-map {
   container-type: inline-size;
+  position: relative;
   width: 100%;
   max-width: 1800px;
   min-width: 0;
   margin-inline: auto;
-  padding: clamp(16px, 1.45vw, 24px);
+  padding: clamp(18px, 1.6vw, 26px);
   overflow: hidden;
   border: 1px solid var(--map-border);
-  border-radius: 20px;
-  background: var(--map-panel-background);
+  border-radius: 22px;
+  background:
+    radial-gradient(
+      ellipse 52% 38% at 100% 0%,
+      color-mix(in srgb, var(--map-accent) 7%, transparent) 0%,
+      transparent 72%
+    ),
+    var(--map-panel-background);
   color: var(--map-text-primary);
   box-shadow: var(--map-panel-shadow);
 }
@@ -97,43 +122,57 @@
 }
 
 .training-map-header .training-map-eyebrow {
-  margin: 0 0 5px;
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  margin: 0 0 8px;
   color: var(--map-accent);
-  font-size: 11px;
-  font-weight: 750;
-  letter-spacing: 0.1em;
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.17em;
   text-transform: uppercase;
+}
+
+.training-map-header .training-map-eyebrow::before {
+  content: "";
+  flex: 0 0 auto;
+  width: 16px;
+  height: 2.5px;
+  border-radius: 2px;
+  background: var(--map-accent-gradient);
 }
 
 .training-map-header h2 {
   margin: 0;
   color: var(--map-text-primary);
   font-family: var(--font-display);
-  font-size: clamp(28px, 2.15vw, 36px);
-  font-weight: 680;
-  line-height: 1.04;
-  letter-spacing: -0.04em;
+  font-size: clamp(30px, 2.3vw, 38px);
+  font-weight: 700;
+  line-height: 1.02;
+  letter-spacing: -0.045em;
 }
 
 .training-map-header > p:last-child {
-  margin: 4px 0 0;
+  margin: 7px 0 0;
   color: var(--map-text-secondary);
   font-size: 13.5px;
-  line-height: 1.45;
+  line-height: 1.5;
 }
 
 .training-map-period-wrap {
   display: grid;
-  gap: 8px;
+  gap: 10px;
 }
 
 .training-map-periods {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 3px;
+  gap: 4px;
   border: 1px solid var(--map-border);
-  border-radius: 12px;
+  border-radius: 14px;
   background: var(--map-secondary-surface);
+  box-shadow:
+    inset 0 1px 2px color-mix(in srgb, var(--map-text-primary) 4%, transparent);
   padding: 4px;
 }
 
@@ -143,21 +182,22 @@
   justify-content: center;
   gap: 6px;
   min-width: 0;
-  min-height: 34px;
+  min-height: 36px;
   border: 0;
-  border-radius: 9px;
+  border-radius: 10px;
   background: transparent;
   color: var(--map-text-secondary);
   padding: 0 7px;
-  font-size: 11.5px;
+  font-size: 12px;
   font-weight: 650;
+  letter-spacing: -0.01em;
   white-space: nowrap;
   cursor: pointer;
   transition:
-    color 180ms ease,
-    background 180ms ease,
-    transform 180ms ease,
-    box-shadow 180ms ease;
+    color 200ms var(--map-ease),
+    background 200ms var(--map-ease),
+    box-shadow 200ms var(--map-ease),
+    transform 120ms var(--map-ease);
 }
 
 .training-map-periods button:hover {
@@ -166,9 +206,11 @@
 }
 
 .training-map-periods button.is-selected {
-  background: var(--map-accent);
-  color: #f7fbf9;
-  box-shadow: 0 4px 12px color-mix(in srgb, var(--map-accent) 22%, transparent);
+  background: var(--map-accent-gradient);
+  color: var(--map-on-accent);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.2),
+    0 3px 10px color-mix(in srgb, var(--map-accent) 30%, transparent);
 }
 
 .training-map-periods button:active,
@@ -200,18 +242,28 @@
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
-  gap: 8px;
-  min-height: 38px;
+  gap: 9px;
+  min-height: 40px;
   border: 1px solid var(--map-border);
-  border-radius: 10px;
-  background: var(--map-secondary-surface);
-  padding: 4px 8px 4px 10px;
+  border-radius: 12px;
+  background: var(--map-card-surface);
+  padding: 4px 10px 4px 12px;
+  transition:
+    border-color 180ms var(--map-ease),
+    box-shadow 180ms var(--map-ease);
+}
+
+.training-map-date-range label:focus-within {
+  border-color: color-mix(in srgb, var(--map-accent) 45%, var(--map-border));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--map-accent) 12%, transparent);
 }
 
 .training-map-date-range label > span {
   color: var(--map-text-muted);
-  font-size: 10.5px;
-  font-weight: 650;
+  font-size: 9.5px;
+  font-weight: 750;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
 }
 
 .training-map-date-range input {
@@ -220,7 +272,7 @@
   border: 0;
   background: transparent;
   color: var(--map-text-primary);
-  font-size: 11px;
+  font-size: 11.5px;
   font-variant-numeric: tabular-nums;
   outline: none;
 }
@@ -228,8 +280,15 @@
 .training-map-stats {
   overflow: hidden;
   border: 1px solid var(--map-border);
-  border-radius: 16px;
-  background: var(--map-secondary-surface);
+  border-radius: 18px;
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--map-text-primary) 2%, transparent) 0%,
+      transparent 58%
+    ),
+    var(--map-card-surface);
+  box-shadow: var(--map-card-shadow);
 }
 
 .training-map-primary-stats,
@@ -243,15 +302,16 @@
 .training-map-primary-stats {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  padding: 15px 12px 14px;
+  padding: 18px 10px 16px;
 }
 
 .training-map-primary-stat {
   display: grid;
-  gap: 8px;
+  align-content: start;
+  gap: 10px;
   min-width: 0;
-  padding: 0 10px;
-  animation: training-map-stat-in 360ms ease both;
+  padding: 0 14px;
+  animation: training-map-stat-in 420ms var(--map-ease) both;
   animation-delay: var(--stat-delay);
 }
 
@@ -261,7 +321,8 @@
 
 .training-map-primary-stat dt {
   display: grid;
-  gap: 6px;
+  justify-items: start;
+  gap: 9px;
   min-width: 0;
   color: var(--map-text-muted);
   font-size: 10px;
@@ -269,7 +330,20 @@
   line-height: 1.15;
 }
 
+.training-map-primary-stat dt span {
+  font-size: 9.5px;
+  font-weight: 750;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
 .training-map-primary-stat dt svg {
+  width: 16px;
+  height: 16px;
+  box-sizing: content-box;
+  padding: 6px;
+  border-radius: 9px;
+  background: var(--map-accent-muted);
   color: var(--map-accent);
 }
 
@@ -277,7 +351,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
-  gap: 4px;
+  gap: 5px;
   min-width: 0;
   margin: 0;
   font-variant-numeric: tabular-nums;
@@ -286,15 +360,15 @@
 .training-map-primary-stat dd strong {
   color: var(--map-text-primary);
   font-family: var(--font-display);
-  font-size: clamp(21px, 1.65vw, 28px);
-  font-weight: 680;
-  line-height: 1;
-  letter-spacing: -0.04em;
+  font-size: clamp(26px, 2vw, 34px);
+  font-weight: 700;
+  line-height: 0.95;
+  letter-spacing: -0.045em;
 }
 
 .training-map-primary-stat dd span {
   color: var(--map-text-muted);
-  font-size: 9.5px;
+  font-size: 11px;
   font-weight: 600;
 }
 
@@ -302,15 +376,16 @@
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   border-top: 1px solid var(--map-border);
-  padding: 10px 12px;
+  background: color-mix(in srgb, var(--map-text-primary) 2.5%, transparent);
+  padding: 12px 10px;
 }
 
 .training-map-secondary-stats > div {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 9px;
   min-width: 0;
-  padding: 0 10px;
+  padding: 0 12px;
 }
 
 .training-map-secondary-stats > div + div {
@@ -319,6 +394,12 @@
 
 .training-map-secondary-stats svg {
   flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  box-sizing: content-box;
+  padding: 4px;
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--map-text-primary) 5%, transparent);
   color: var(--map-text-secondary);
 }
 
@@ -343,17 +424,18 @@
   gap: 3px;
   margin: 0;
   color: var(--map-text-primary);
-  font-size: 12px;
+  font-size: 13px;
   font-variant-numeric: tabular-nums;
 }
 
 .training-map-secondary-stats dd strong {
   font-weight: 700;
+  letter-spacing: -0.01em;
 }
 
 .training-map-secondary-stats dd small {
   color: var(--map-text-muted);
-  font-size: 9px;
+  font-size: 9.5px;
   font-weight: 600;
 }
 
@@ -362,32 +444,39 @@
   min-height: 214px;
   overflow: hidden;
   border: 1px solid var(--map-border);
-  border-radius: 16px;
-  background: var(--map-secondary-surface);
+  border-radius: 18px;
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--map-text-primary) 1.5%, transparent) 0%,
+      transparent 52%
+    ),
+    var(--map-card-surface);
+  box-shadow: var(--map-card-shadow);
 }
 
 .training-map-location-content {
   height: 100%;
   min-height: 212px;
-  padding: 15px 17px;
-  animation: training-map-content-in 210ms ease both;
+  padding: 18px 20px;
+  animation: training-map-content-in 240ms var(--map-ease) both;
 }
 
 .training-map-location-header {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: 10px;
-  padding-bottom: 12px;
+  gap: 11px;
+  padding-bottom: 13px;
   border-bottom: 1px solid var(--map-border);
 }
 
 .training-map-location-icon {
   display: grid;
   place-items: center;
-  width: 34px;
-  height: 34px;
-  border-radius: 10px;
+  width: 36px;
+  height: 36px;
+  border-radius: 11px;
   background: var(--map-accent-muted);
   color: var(--map-accent);
 }
@@ -398,10 +487,10 @@
   margin: 0;
   color: var(--map-text-primary);
   font-family: var(--font-display);
-  font-size: 16px;
-  font-weight: 680;
+  font-size: 17px;
+  font-weight: 700;
   line-height: 1.15;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.025em;
 }
 
 .training-map-location-header p {
@@ -411,38 +500,54 @@
 }
 
 .training-map-selected-label {
-  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
   background: var(--map-accent-muted);
   color: var(--map-accent);
-  padding: 5px 8px;
-  font-size: 10px;
-  font-weight: 700;
+  padding: 5px 10px;
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.training-map-selected-label::before {
+  content: "";
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentcolor;
 }
 
 .training-map-location-metrics {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 10px;
-  padding: 12px 0 10px;
+  padding: 14px 0 12px;
 }
 
 .training-map-location-metrics div {
   display: grid;
-  gap: 3px;
+  gap: 4px;
   min-width: 0;
 }
 
 .training-map-location-metrics dt {
   color: var(--map-text-muted);
-  font-size: 9.5px;
+  font-size: 9px;
+  font-weight: 750;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
 }
 
 .training-map-location-metrics dd {
   overflow: hidden;
   margin: 0;
   color: var(--map-text-primary);
-  font-size: 12px;
-  font-weight: 680;
+  font-size: 13px;
+  font-weight: 700;
   line-height: 1.3;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -451,7 +556,7 @@
 
 .training-map-location-metrics dd small {
   color: var(--map-text-muted);
-  font-size: 9px;
+  font-size: 9.5px;
   font-weight: 600;
 }
 
@@ -469,13 +574,18 @@
 
 .training-map-location-trend > div:first-child span {
   color: var(--map-text-muted);
-  font-size: 9.5px;
+  font-size: 9px;
+  font-weight: 750;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
 }
 
 .training-map-location-trend > div:first-child strong {
   color: var(--map-text-primary);
-  font-size: 12px;
-  font-weight: 680;
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
   font-variant-numeric: tabular-nums;
 }
 
@@ -497,77 +607,124 @@
   align-items: center;
   justify-content: center;
   gap: 7px;
-  min-height: 36px;
-  border: 1px solid color-mix(in srgb, var(--map-accent) 35%, var(--map-border));
-  border-radius: 10px;
-  background: transparent;
-  color: var(--map-accent);
-  padding: 0 12px;
-  font-size: 10.5px;
-  font-weight: 700;
+  min-height: 38px;
+  border: 0;
+  border-radius: 11px;
+  background: var(--map-accent-gradient);
+  color: var(--map-on-accent);
+  padding: 0 14px;
+  font-size: 11px;
+  font-weight: 750;
+  letter-spacing: 0.01em;
   white-space: nowrap;
   cursor: pointer;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    0 4px 14px color-mix(in srgb, var(--map-accent) 26%, transparent);
   transition:
-    color 180ms ease,
-    border-color 180ms ease,
-    background 180ms ease,
-    transform 180ms ease;
+    filter 200ms var(--map-ease),
+    box-shadow 200ms var(--map-ease),
+    transform 160ms var(--map-ease);
+}
+
+.training-map-view-action svg {
+  transition: transform 180ms var(--map-ease);
 }
 
 .training-map-view-action:hover {
-  border-color: var(--map-accent);
-  background: var(--map-accent-muted);
-  color: var(--map-accent-hover);
+  filter: brightness(1.06);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    0 7px 20px color-mix(in srgb, var(--map-accent) 34%, transparent);
+  transform: translateY(-1px);
+}
+
+.training-map-view-action:hover svg {
+  transform: translateX(2px);
 }
 
 .training-map-overview {
+  position: relative;
   display: grid;
   align-content: center;
-  gap: 16px;
+  gap: 20px;
+}
+
+.training-map-overview::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: -58px;
+  width: 250px;
+  height: 250px;
+  transform: translateY(-50%);
+  border-radius: 50%;
+  background:
+    radial-gradient(
+      circle at center,
+      var(--map-accent) 0 2.5px,
+      transparent 3.5px
+    ),
+    repeating-radial-gradient(
+      circle at center,
+      transparent 0 37px,
+      color-mix(in srgb, var(--map-accent) 16%, transparent) 37px 38px
+    );
+  opacity: 0.55;
+  -webkit-mask-image: radial-gradient(circle, #000 26%, transparent 68%);
+  mask-image: radial-gradient(circle, #000 26%, transparent 68%);
+  pointer-events: none;
 }
 
 .training-map-overview > header {
+  position: relative;
   display: grid;
-  gap: 5px;
+  gap: 6px;
 }
 
 .training-map-overview > header p,
 .training-map-location-empty p {
-  max-width: 48ch;
+  max-width: 46ch;
   margin: 0;
   color: var(--map-text-secondary);
-  font-size: 11px;
-  line-height: 1.45;
+  font-size: 11.5px;
+  line-height: 1.5;
 }
 
 .training-map-overview-values {
+  position: relative;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .training-map-overview-values div {
   display: grid;
-  gap: 4px;
+  gap: 5px;
   min-width: 0;
-  padding-right: 12px;
+  padding-right: 14px;
 }
 
 .training-map-overview-values div + div {
   border-left: 1px solid var(--map-border);
-  padding-left: 12px;
+  padding-left: 14px;
 }
 
 .training-map-overview-values dt {
   color: var(--map-text-muted);
-  font-size: 9.5px;
+  font-size: 9px;
+  font-weight: 750;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
 }
 
 .training-map-overview-values dd {
   overflow: hidden;
   margin: 0;
   color: var(--map-text-primary);
-  font-size: 12px;
-  font-weight: 680;
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -575,10 +732,28 @@
 .training-map-location-empty {
   display: grid;
   align-content: center;
-  justify-items: start;
-  gap: 8px;
+  justify-items: center;
+  gap: 10px;
   height: 100%;
   color: var(--map-accent);
+  text-align: center;
+}
+
+.training-map-location-empty svg {
+  width: 20px;
+  height: 20px;
+  box-sizing: content-box;
+  padding: 10px;
+  border-radius: 13px;
+  background: var(--map-accent-muted);
+}
+
+.training-map-location-empty h3 {
+  margin-top: 2px;
+}
+
+.training-map-location-empty p {
+  max-width: 40ch;
 }
 
 .training-map-location-loading {
@@ -592,7 +767,7 @@
   display: block;
   height: 14px;
   border-radius: 6px;
-  background: var(--map-elevated-surface);
+  background: color-mix(in srgb, var(--map-text-primary) 7%, transparent);
   animation: training-map-skeleton 1.4s ease-in-out infinite;
 }
 
@@ -615,7 +790,7 @@
   overflow: hidden;
   isolation: isolate;
   border: 1px solid var(--map-border);
-  border-radius: 16px;
+  border-radius: 18px;
   background:
     radial-gradient(ellipse 62% 58% at 50% 42%, var(--map-globe-radial) 0%, transparent 72%),
     radial-gradient(ellipse 78% 78% at 50% 52%, var(--map-globe-rim-light) 0%, transparent 76%),
@@ -727,10 +902,11 @@
   background: var(--map-globe-label-bg);
   box-shadow: 0 7px 20px rgba(0, 0, 0, 0.2);
   color: var(--map-globe-label-text);
-  padding: 0 9px;
-  font-family: var(--font-body);
+  padding: 0 10px;
+  font-family: var(--font-display);
   font-size: 10.5px;
   font-weight: 650;
+  letter-spacing: -0.01em;
   line-height: 1;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -750,46 +926,58 @@
 }
 
 .training-map-globe-helper {
-  top: 18px;
-  left: 20px;
+  top: 16px;
+  left: 16px;
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  min-height: 32px;
+  border: 1px solid var(--map-border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--map-secondary-surface) 64%, transparent);
+  backdrop-filter: blur(14px) saturate(1.15);
+  -webkit-backdrop-filter: blur(14px) saturate(1.15);
+  box-shadow: 0 8px 22px var(--map-globe-control-shadow);
   color: var(--map-text-secondary);
-  font-size: 11px;
-  font-weight: 600;
+  padding: 0 13px;
+  font-size: 10.5px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
   pointer-events: none;
 }
 
 .training-map-globe-helper svg {
-  color: var(--map-text-muted);
+  width: 14px;
+  height: 14px;
+  color: var(--map-accent);
 }
 
 .training-map-reset {
   top: 16px;
-  right: 18px;
+  right: 16px;
   display: inline-flex;
   align-items: center;
   gap: 7px;
-  min-height: 34px;
-  border: 1px solid var(--map-border-strong);
-  border-radius: 10px;
-  background: color-mix(in srgb, var(--map-secondary-surface) 76%, transparent);
-  backdrop-filter: blur(14px) saturate(1.14);
-  -webkit-backdrop-filter: blur(14px) saturate(1.14);
+  min-height: 32px;
+  border: 1px solid var(--map-border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--map-secondary-surface) 72%, transparent);
+  backdrop-filter: blur(14px) saturate(1.15);
+  -webkit-backdrop-filter: blur(14px) saturate(1.15);
   box-shadow:
     inset 0 1px 0 color-mix(in srgb, var(--map-text-primary) 8%, transparent),
-    0 10px 28px var(--map-globe-control-shadow);
+    0 8px 22px var(--map-globe-control-shadow);
   color: var(--map-text-secondary);
-  padding: 0 11px;
+  padding: 0 13px;
   font-size: 10.5px;
   font-weight: 650;
+  letter-spacing: -0.01em;
   cursor: pointer;
   transition:
-    color 180ms ease,
-    background 180ms ease,
-    border-color 180ms ease,
-    transform 180ms ease;
+    color 180ms var(--map-ease),
+    background 180ms var(--map-ease),
+    border-color 180ms var(--map-ease),
+    transform 160ms var(--map-ease);
 }
 
 .training-map-reset:hover:not(:disabled) {
@@ -805,10 +993,10 @@
 
 .training-map-globe-meta {
   left: 18px;
-  bottom: 16px;
+  bottom: 15px;
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
 }
 
 .training-map-globe-meta > div {
@@ -818,6 +1006,7 @@
   color: var(--map-text-muted);
   font-size: 9.5px;
   font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
 .training-map-globe-meta svg {
@@ -826,13 +1015,14 @@
 
 .training-map-legend {
   right: 18px;
-  bottom: 16px;
+  bottom: 15px;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 7px;
   color: var(--map-text-muted);
   font-size: 9.5px;
   font-weight: 600;
+  letter-spacing: 0.02em;
   pointer-events: none;
 }
 
@@ -879,8 +1069,8 @@
 }
 
 .training-map-recent {
-  margin-top: 18px;
-  padding-top: 16px;
+  margin-top: 20px;
+  padding-top: 18px;
   border-top: 1px solid var(--map-border);
 }
 
@@ -889,7 +1079,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  margin-bottom: 11px;
+  margin-bottom: 12px;
   padding: 0 4px;
 }
 
@@ -897,9 +1087,9 @@
   margin: 0;
   color: var(--map-text-primary);
   font-family: var(--font-display);
-  font-size: 13px;
-  font-weight: 680;
-  letter-spacing: -0.01em;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.015em;
 }
 
 .training-map-recent-controls {
@@ -913,15 +1103,15 @@
   width: 30px;
   height: 30px;
   border: 1px solid var(--map-border);
-  border-radius: 10px;
-  background: var(--map-secondary-surface);
+  border-radius: 9px;
+  background: var(--map-card-surface);
   color: var(--map-text-secondary);
   cursor: pointer;
   transition:
-    color 180ms ease,
-    border-color 180ms ease,
-    background 180ms ease,
-    transform 180ms ease;
+    color 180ms var(--map-ease),
+    border-color 180ms var(--map-ease),
+    background 180ms var(--map-ease),
+    transform 160ms var(--map-ease);
 }
 
 .training-map-recent-controls button:hover:not(:disabled) {
@@ -938,51 +1128,67 @@
 .training-map-recent-list {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
-  gap: 9px;
+  gap: 10px;
 }
 
 .training-map-recent-list > button {
   display: grid;
   grid-template-columns: auto minmax(0, 1.35fr) auto auto auto;
   align-items: center;
-  gap: 8px;
+  gap: 9px;
   min-width: 0;
-  min-height: 72px;
+  min-height: 76px;
   border: 1px solid var(--map-border);
-  border-radius: 14px;
-  background: var(--map-secondary-surface);
+  border-radius: 16px;
+  background: var(--map-card-surface);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--map-text-primary) 4%, transparent);
   color: var(--map-text-primary);
-  padding: 10px;
+  padding: 12px 14px;
   text-align: left;
   cursor: pointer;
+  animation: training-map-content-in 300ms var(--map-ease) both;
+  animation-delay: var(--recent-delay, 0ms);
   transition:
-    color 180ms ease,
-    border-color 180ms ease,
-    background 180ms ease,
-    transform 180ms ease,
-    box-shadow 180ms ease;
+    color 200ms var(--map-ease),
+    border-color 200ms var(--map-ease),
+    background 200ms var(--map-ease),
+    transform 200ms var(--map-ease),
+    box-shadow 200ms var(--map-ease);
 }
 
 .training-map-recent-list > button:hover {
   border-color: var(--map-border-strong);
-  background: var(--map-elevated-surface);
-  transform: translateY(-1px);
+  background: var(--map-card-surface-hover);
+  box-shadow: 0 10px 26px color-mix(in srgb, var(--map-text-primary) 8%, transparent);
+  transform: translateY(-2px);
 }
 
 .training-map-recent-list > button.is-selected {
-  border-color: color-mix(in srgb, var(--map-accent) 48%, var(--map-border));
-  background: var(--map-accent-muted);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--map-accent) 12%, transparent);
+  border-color: color-mix(in srgb, var(--map-accent) 55%, var(--map-border));
+  background: color-mix(in srgb, var(--map-accent-muted) 55%, var(--map-card-surface));
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--map-accent) 22%, transparent),
+    0 8px 22px color-mix(in srgb, var(--map-accent) 10%, transparent);
 }
 
 .training-map-recent-pin {
   display: grid;
   place-items: center;
-  width: 32px;
-  height: 32px;
-  border-radius: 10px;
-  background: var(--map-elevated-surface);
+  width: 34px;
+  height: 34px;
+  border-radius: 11px;
+  background: var(--map-accent-muted);
   color: var(--map-accent);
+  transition:
+    background 200ms var(--map-ease),
+    color 200ms var(--map-ease),
+    box-shadow 200ms var(--map-ease);
+}
+
+.training-map-recent-list > button.is-selected .training-map-recent-pin {
+  background: var(--map-accent-gradient);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  color: var(--map-on-accent);
 }
 
 .training-map-recent-place,
@@ -996,8 +1202,9 @@
 .training-map-recent-value > strong {
   overflow: hidden;
   color: var(--map-text-primary);
-  font-size: 10.5px;
+  font-size: 11.5px;
   font-weight: 700;
+  letter-spacing: -0.01em;
   line-height: 1.2;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1009,7 +1216,7 @@
 .training-map-recent-value strong small {
   overflow: hidden;
   color: var(--map-text-muted);
-  font-size: 8.5px;
+  font-size: 9px;
   font-weight: 550;
   line-height: 1.2;
   text-overflow: ellipsis;
@@ -1017,12 +1224,21 @@
 }
 
 .training-map-recent-value {
-  padding-left: 7px;
+  gap: 3px;
+  padding-left: 10px;
   border-left: 1px solid var(--map-border);
 }
 
 .training-map-recent-chevron {
   color: var(--map-text-muted);
+  transition:
+    color 180ms var(--map-ease),
+    transform 180ms var(--map-ease);
+}
+
+.training-map-recent-list > button:hover .training-map-recent-chevron {
+  color: var(--map-accent);
+  transform: translateX(2px);
 }
 
 @keyframes training-map-stat-in {
@@ -1069,16 +1285,16 @@
   }
 
   .training-map-primary-stat {
-    padding-inline: 7px;
+    padding-inline: 9px;
   }
 
-  .training-map-primary-stat dt {
-    font-size: 9px;
+  .training-map-primary-stat dd strong {
+    font-size: clamp(22px, 1.9vw, 28px);
   }
 
   .training-map-secondary-stats > div {
-    gap: 6px;
-    padding-inline: 7px;
+    gap: 7px;
+    padding-inline: 8px;
   }
 
   .training-map-secondary-stats dt {
@@ -1086,17 +1302,17 @@
   }
 
   .training-map-location-content {
-    padding-inline: 14px;
+    padding-inline: 16px;
   }
 
   .training-map-recent-list > button {
-    gap: 6px;
-    padding-inline: 8px;
+    gap: 7px;
+    padding-inline: 10px;
   }
 
   .training-map-recent-pin {
-    width: 28px;
-    height: 28px;
+    width: 30px;
+    height: 30px;
   }
 
   .training-map-recent-value:nth-of-type(4) {
@@ -1106,7 +1322,7 @@
 
 @container (max-width: 1120px) {
   .training-map {
-    padding: 14px;
+    padding: 16px;
   }
 
   .training-map-main {
@@ -1120,24 +1336,28 @@
   }
 
   .training-map-information {
-    gap: 11px;
+    gap: 12px;
   }
 
   .training-map-header h2 {
-    font-size: 26px;
+    font-size: 28px;
   }
 
   .training-map-header > p:last-child {
-    font-size: 12px;
+    font-size: 12.5px;
   }
 
   .training-map-periods button {
-    min-height: 31px;
-    font-size: 10px;
+    min-height: 33px;
+    font-size: 10.5px;
   }
 
   .training-map-primary-stats {
-    padding-inline: 8px;
+    padding-inline: 6px;
+  }
+
+  .training-map-primary-stat {
+    padding-inline: 10px;
   }
 
   .training-map-primary-stat dt svg {
@@ -1146,7 +1366,7 @@
   }
 
   .training-map-primary-stat dd strong {
-    font-size: 20px;
+    font-size: 22px;
   }
 
   .training-map-location-metrics {
@@ -1156,10 +1376,6 @@
   .training-map-location-trend {
     grid-template-columns: minmax(86px, 0.78fr) minmax(76px, 1fr) auto;
     gap: 8px;
-  }
-
-  .training-map-globe-helper {
-    left: 14px;
   }
 
   .training-map-globe-stage .activity-globe-webgl {
@@ -1175,17 +1391,152 @@
   }
 }
 
+/* Stack the globe beneath the summary once the columns would feel cramped,
+   so narrow layouts stay intentional instead of clipping the globe. */
+@container (max-width: 900px) {
+  .training-map-main {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .training-map-information {
+    min-height: 0;
+  }
+
+  .training-map-globe-panel {
+    min-height: clamp(340px, 52vh, 470px);
+  }
+
+  .training-map-location {
+    min-height: 0;
+  }
+
+  .training-map-location-content {
+    min-height: 190px;
+  }
+}
+
+@container (max-width: 640px) {
+  .training-map {
+    padding: 14px;
+    border-radius: 18px;
+  }
+
+  .training-map-information {
+    gap: 12px;
+  }
+
+  .training-map-header h2 {
+    font-size: 27px;
+  }
+
+  .training-map-periods {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .training-map-primary-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    padding: 6px 0;
+  }
+
+  .training-map-primary-stat {
+    padding: 12px 16px;
+  }
+
+  .training-map-primary-stat + .training-map-primary-stat {
+    border-left: 0;
+  }
+
+  .training-map-primary-stat:nth-child(even) {
+    border-left: 1px solid var(--map-border);
+  }
+
+  .training-map-primary-stat:nth-child(n + 3) {
+    border-top: 1px solid var(--map-border);
+  }
+
+  .training-map-secondary-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    row-gap: 12px;
+    padding: 12px 16px;
+  }
+
+  .training-map-secondary-stats > div {
+    padding: 0;
+  }
+
+  .training-map-secondary-stats > div + div {
+    border-left: 0;
+  }
+
+  .training-map-secondary-stats dt {
+    display: block;
+  }
+
+  .training-map-location-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    row-gap: 12px;
+  }
+
+  .training-map-location-trend {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+    gap: 10px;
+  }
+
+  .training-map-location-chart {
+    width: 100%;
+    height: 52px;
+  }
+
+  .training-map-view-action {
+    justify-self: start;
+  }
+
+  .training-map-overview::before {
+    right: -84px;
+    opacity: 0.4;
+  }
+
+  .training-map-overview-values {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 12px;
+  }
+
+  .training-map-overview-values div {
+    padding-right: 0;
+  }
+
+  .training-map-overview-values div + div {
+    border-left: 0;
+    border-top: 1px solid var(--map-border);
+    padding-left: 0;
+    padding-top: 12px;
+  }
+
+  .training-map-recent-list {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .training-map-recent-list > button:nth-child(5) {
+    display: grid;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .training-map-primary-stat,
   .training-map-location-content,
   .training-map-date-range,
+  .training-map-recent-list > button,
   .training-map-location-loading span {
     animation: none;
   }
 
   .training-map-periods button,
   .training-map-view-action,
+  .training-map-view-action svg,
   .training-map-recent-list > button,
+  .training-map-recent-chevron,
+  .training-map-recent-pin,
   .training-map-reset,
   .training-map-recent-controls button {
     transition: none;

--- a/src/overview/activityGlobe.css
+++ b/src/overview/activityGlobe.css
@@ -640,7 +640,22 @@
 }
 
 .training-map-view-action:hover svg {
-  transform: translateX(2px);
+  transform: scale(1.12);
+}
+
+.training-map-view-action:disabled {
+  cursor: wait;
+  filter: brightness(1.04);
+}
+
+.training-map-view-action.is-zooming svg {
+  animation: training-map-zoom-pulse 520ms ease-in-out infinite alternate;
+}
+
+@keyframes training-map-zoom-pulse {
+  to {
+    transform: scale(1.28);
+  }
 }
 
 .training-map-overview {

--- a/src/preferences/selectionPreferences.ts
+++ b/src/preferences/selectionPreferences.ts
@@ -1,0 +1,153 @@
+import {
+  useCallback,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction
+} from "react";
+
+const SELECTION_STORAGE_PREFIX = "coroslink.selection.v1";
+
+export interface SelectionPreferenceStorage {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+}
+
+export interface SelectionPreference<T> {
+  key: string;
+  defaultValue: T;
+  validate: (value: unknown) => value is T;
+}
+
+export interface RestoredSelectionPreference<T> {
+  value: T;
+  restored: boolean;
+}
+
+export interface SelectionPreferenceMeta {
+  /** True only when the initial value came from a valid persisted entry. */
+  restored: boolean;
+}
+
+export type SelectionPreferenceState<T> = readonly [
+  T,
+  Dispatch<SetStateAction<T>>,
+  SelectionPreferenceMeta
+];
+
+export function defineSelectionPreference<T>(
+  preference: SelectionPreference<T>
+): SelectionPreference<T> {
+  return preference;
+}
+
+export function selectionPreferenceStorageKey(key: string): string {
+  return `${SELECTION_STORAGE_PREFIX}.${key}`;
+}
+
+function browserStorage(): SelectionPreferenceStorage | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+  try {
+    return window.localStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+export function readSelectionPreference<T>(
+  preference: SelectionPreference<T>,
+  storage: SelectionPreferenceStorage | undefined = browserStorage(),
+  fallback: T = preference.defaultValue
+): RestoredSelectionPreference<T> {
+  if (!storage) {
+    return { value: fallback, restored: false };
+  }
+
+  try {
+    const raw = storage.getItem(selectionPreferenceStorageKey(preference.key));
+    if (raw === null) {
+      return { value: fallback, restored: false };
+    }
+    const parsed: unknown = JSON.parse(raw);
+    return preference.validate(parsed)
+      ? { value: parsed, restored: true }
+      : { value: fallback, restored: false };
+  } catch {
+    return { value: fallback, restored: false };
+  }
+}
+
+export function writeSelectionPreference<T>(
+  preference: SelectionPreference<T>,
+  value: T,
+  storage: SelectionPreferenceStorage | undefined = browserStorage()
+): void {
+  if (!storage || !preference.validate(value)) {
+    return;
+  }
+
+  try {
+    storage.setItem(
+      selectionPreferenceStorageKey(preference.key),
+      JSON.stringify(value)
+    );
+  } catch {
+    // The renderer remains fully usable when storage is unavailable or full.
+  }
+}
+
+export function useSelectionPreference<T>(
+  preference: SelectionPreference<T>,
+  fallback: T = preference.defaultValue
+): SelectionPreferenceState<T> {
+  const initialRef = useRef<RestoredSelectionPreference<T> | null>(null);
+  if (initialRef.current === null) {
+    initialRef.current = readSelectionPreference(preference, undefined, fallback);
+  }
+
+  const [value, setValueState] = useState<T>(() => initialRef.current!.value);
+  const valueRef = useRef(value);
+  const preferenceRef = useRef(preference);
+  preferenceRef.current = preference;
+
+  const setValue = useCallback<Dispatch<SetStateAction<T>>>((action) => {
+    const current = valueRef.current;
+    const next =
+      typeof action === "function"
+        ? (action as (previous: T) => T)(current)
+        : action;
+    valueRef.current = next;
+    setValueState(next);
+    writeSelectionPreference(preferenceRef.current, next);
+  }, []);
+
+  return [value, setValue, { restored: initialRef.current.restored }] as const;
+}
+
+export function selectionIsOneOf<const T extends readonly unknown[]>(
+  values: T
+): (value: unknown) => value is T[number] {
+  const allowed = new Set<unknown>(values);
+  return (value: unknown): value is T[number] => allowed.has(value);
+}
+
+export function selectionIsBoolean(value: unknown): value is boolean {
+  return typeof value === "boolean";
+}
+
+export function selectionIsArrayOf<T>(
+  validateItem: (value: unknown) => value is T,
+  options: { minLength?: number; unique?: boolean } = {}
+): (value: unknown) => value is T[] {
+  return (value: unknown): value is T[] => {
+    if (!Array.isArray(value) || value.length < (options.minLength ?? 0)) {
+      return false;
+    }
+    if (!value.every(validateItem)) {
+      return false;
+    }
+    return !options.unique || new Set(value).size === value.length;
+  };
+}

--- a/src/strength/StrengthView.tsx
+++ b/src/strength/StrengthView.tsx
@@ -65,6 +65,11 @@ import "./strength.css";
 import "./exerciseExplorer.css";
 import { useUnitSystem } from "../units/UnitSystemProvider";
 import { kilogramsToDisplayWeight, weightUnit } from "../units/units";
+import {
+  defineSelectionPreference,
+  selectionIsOneOf,
+  useSelectionPreference
+} from "../preferences/selectionPreferences";
 
 interface StrengthViewProps {
   api: CorosLinkApi;
@@ -86,6 +91,31 @@ const METRIC_OPTIONS: { id: HeatMetric; label: string }[] = [
   { id: "volume", label: "Volume" },
   { id: "time", label: "Time" }
 ];
+
+const STRENGTH_DAYS_PREFERENCE = defineSelectionPreference<number>({
+  key: "strength.days",
+  defaultValue: 90,
+  validate: selectionIsOneOf([30, 90, 180, 365])
+});
+
+const STRENGTH_SOURCE_PREFERENCE =
+  defineSelectionPreference<StrengthDataSource>({
+    key: "strength.source",
+    defaultValue: "combined",
+    validate: selectionIsOneOf(["combined", "hevy", "coros"])
+  });
+
+const STRENGTH_BODY_VIEW_PREFERENCE = defineSelectionPreference<BodyView>({
+  key: "strength.bodyView",
+  defaultValue: "front",
+  validate: selectionIsOneOf(["front", "back"])
+});
+
+const STRENGTH_METRIC_PREFERENCE = defineSelectionPreference<HeatMetric>({
+  key: "strength.metric",
+  defaultValue: "sets",
+  validate: selectionIsOneOf(["sets", "volume", "time"])
+});
 
 /** Chunks are drained in a loop; this caps a runaway backfill. */
 const MAX_SYNC_ROUNDS = 60;
@@ -407,8 +437,10 @@ export function StrengthView({
   const { theme } = useTheme();
   const ember = theme === "paper" ? EMBER.paper : EMBER.dark;
 
-  const [days, setDays] = useState(90);
-  const [source, setSource] = useState<StrengthDataSource>("combined");
+  const [days, setDays] = useSelectionPreference(STRENGTH_DAYS_PREFERENCE);
+  const [source, setSource, sourcePreference] = useSelectionPreference(
+    STRENGTH_SOURCE_PREFERENCE
+  );
   const [hevyStatus, setHevyStatus] = useState<HevyStatus | null>(null);
   const [hevyStatusLoading, setHevyStatusLoading] = useState(true);
   const [hevyDialogOpen, setHevyDialogOpen] = useState(false);
@@ -421,9 +453,13 @@ export function StrengthView({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [warnings, setWarnings] = useState<string[]>([]);
-  const [view, setView] = useState<BodyView>("front");
+  const [view, setView] = useSelectionPreference(
+    STRENGTH_BODY_VIEW_PREFERENCE
+  );
   const [viewRequest, setViewRequest] = useState(0);
-  const [metric, setMetric] = useState<HeatMetric>("sets");
+  const [metric, setMetric] = useSelectionPreference(
+    STRENGTH_METRIC_PREFERENCE
+  );
   const [selectedMuscle, setSelectedMuscle] = useState<MuscleId | null>(null);
   const [selectedExerciseName, setSelectedExerciseName] = useState<string | null>(null);
   // Hover remains a transient highlight on the mannequin. The right-hand
@@ -432,7 +468,7 @@ export function StrengthView({
   const [figureHover, setFigureHover] = useState<MuscleId | null>(null);
   const [listHover, setListHover] = useState<MuscleId | null>(null);
   const syncSequenceRef = useRef(0);
-  const sourceInitializedRef = useRef(false);
+  const sourceInitializedRef = useRef(sourcePreference.restored);
   const hevyConnected = Boolean(hevyStatus?.connected);
   const anyConnected = corosConnected || hevyConnected;
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -713,6 +713,21 @@ input::placeholder {
   flex: 1;
   align-content: start;
   isolation: isolate;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: color-mix(in srgb, var(--text-secondary) 42%, transparent)
+    transparent;
+  scrollbar-width: thin;
+}
+
+.app-sidebar-nav::-webkit-scrollbar {
+  width: 6px;
+}
+
+.app-sidebar-nav::-webkit-scrollbar-thumb {
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--text-secondary) 42%, transparent);
 }
 
 .app-sidebar-indicator {
@@ -801,6 +816,10 @@ input::placeholder {
   justify-content: center;
   padding-inline: 0;
   gap: 0;
+}
+
+.app-sidebar.is-collapsed .app-sidebar-nav-item:hover {
+  transform: none;
 }
 
 .app-sidebar.is-collapsed .app-sidebar-nav-copy,
@@ -17275,30 +17294,6 @@ tr.data-intervals-row-missing {
   filter: drop-shadow(0 2px 8px var(--accent-glow));
 }
 
-.chat-sidebar-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
-  margin-right: 2px;
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius-sm);
-  background: var(--surface);
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease,
-    background 0.15s ease;
-}
-
-.chat-sidebar-toggle:hover {
-  color: var(--text-primary);
-  border-color: var(--accent-glow);
-  background: var(--glass-bg-hover);
-}
-
 .chat-layout {
   position: relative;
   display: flex;
@@ -17306,6 +17301,40 @@ tr.data-intervals-row-missing {
   min-height: 0;
   min-width: 0;
   gap: 0;
+}
+
+.chat-sidebar-expand-button {
+  position: absolute;
+  top: var(--sidebar-float-gap);
+  left: -1px;
+  z-index: 6;
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--sidebar-glass-border);
+  border-left: 0;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  background: color-mix(in srgb, var(--surface) 88%, transparent);
+  -webkit-backdrop-filter: blur(16px) saturate(140%);
+  backdrop-filter: blur(16px) saturate(140%);
+  color: var(--text-secondary);
+  box-shadow: var(--glass-inset), 0 8px 20px rgba(0, 0, 0, 0.22);
+  cursor: pointer;
+  animation: chat-sidebar-expand-enter 0.2s ease both;
+  transition: color 0.15s ease, border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.chat-sidebar-expand-button:hover {
+  border-color: var(--accent-glow);
+  background: var(--glass-bg-hover);
+  color: var(--text-primary);
+}
+
+@keyframes chat-sidebar-expand-enter {
+  from { opacity: 0; transform: translateX(-4px); }
+  to { opacity: 1; transform: translateX(0); }
 }
 
 .chat-sidebar-shell {
@@ -17317,14 +17346,15 @@ tr.data-intervals-row-missing {
   min-height: 0;
   min-width: 0;
   overflow: hidden;
-  padding: var(--sidebar-float-gap) 0 var(--sidebar-float-gap)
-    var(--sidebar-float-gap);
+  padding: var(--sidebar-float-gap) 0;
   box-sizing: content-box;
-  transition: width 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+  transition: width 0.28s cubic-bezier(0.22, 1, 0.36, 1),
+    padding-left 0.28s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .chat-sidebar-shell.is-open {
   width: 280px;
+  padding-left: var(--sidebar-float-gap);
 }
 
 .chat-sidebar-shell.is-overlay-mode {
@@ -17342,6 +17372,444 @@ tr.data-intervals-row-missing {
   flex: 1;
   min-width: 0;
   min-height: 0;
+}
+
+.chat-plan-panel {
+  display: flex;
+  flex: 0 0 clamp(248px, 20vw, 296px);
+  flex-direction: column;
+  align-self: stretch;
+  min-width: 0;
+  min-height: 0;
+  margin: var(--sidebar-float-gap) var(--sidebar-float-gap)
+    var(--sidebar-float-gap) 0;
+  overflow: hidden;
+  border: 1px solid var(--sidebar-glass-border);
+  border-radius: var(--sidebar-radius);
+  background: var(--sidebar-glass-bg);
+  -webkit-backdrop-filter: blur(var(--glass-blur-shell)) saturate(180%);
+  backdrop-filter: blur(var(--glass-blur-shell)) saturate(180%);
+  box-shadow: var(--sidebar-glass-shadow);
+  transition: flex-basis 0.32s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.chat-plan-panel.is-expanded {
+  flex-basis: clamp(440px, 38vw, 620px);
+}
+
+.chat-plan-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex: none;
+  min-height: 58px;
+  padding: 11px 12px;
+  border-bottom: 1px solid var(--glass-border);
+  background: color-mix(in srgb, var(--glass-bg-elevated) 72%, transparent);
+  animation: chat-plan-panel-enter 0.24s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.chat-plan-list-header > div {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+
+.chat-plan-list-header > div > div {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+}
+
+.chat-plan-list-header strong {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 12.5px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-plan-list-header span {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.chat-plan-list-count {
+  display: grid;
+  place-items: center;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 6px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary) !important;
+  background: var(--glass-bg);
+  font-size: 10.5px !important;
+  font-variant-numeric: tabular-nums;
+}
+
+.chat-plan-list {
+  display: grid;
+  align-content: start;
+  flex: 1;
+  gap: 3px;
+  min-height: 0;
+  margin: 0;
+  padding: 8px;
+  overflow-y: auto;
+  list-style: none;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--text-secondary) 18%, transparent)
+    transparent;
+  animation: chat-plan-panel-enter 0.24s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.chat-plan-list-item {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) 16px;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  min-width: 0;
+  padding: 10px 8px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  text-align: left;
+  cursor: pointer;
+  transition: color 0.16s ease, border-color 0.16s ease,
+    background 0.16s ease, transform 0.16s ease;
+}
+
+.chat-plan-list-item:hover {
+  border-color: var(--glass-border);
+  background: var(--glass-bg-hover);
+  color: var(--text-primary);
+}
+
+.chat-plan-list-item:active {
+  transform: translateY(1px);
+}
+
+.chat-plan-list-item:focus-visible {
+  outline: 2px solid var(--chat-signal);
+  outline-offset: -1px;
+}
+
+.chat-plan-list-item.is-selected {
+  border-color: color-mix(in srgb, var(--chat-signal-border) 64%, transparent);
+  background: color-mix(in srgb, var(--chat-signal-soft) 62%, transparent);
+}
+
+.chat-plan-list-sport {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid color-mix(in srgb, var(--chat-plan-sport) 34%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--chat-plan-sport) 10%, transparent);
+  color: var(--chat-plan-sport);
+}
+
+.chat-plan-list-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.chat-plan-list-kicker {
+  color: var(--text-muted);
+  font-size: 9.5px;
+  font-weight: 650;
+}
+
+.chat-plan-list-copy > strong {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 11.5px;
+  font-weight: 650;
+  line-height: 1.25;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.chat-plan-list-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px 6px;
+  color: var(--text-muted);
+  font-size: 9.5px;
+  line-height: 1.2;
+}
+
+.chat-plan-list-meta > span + span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.chat-plan-list-meta > span + span::before {
+  width: 1px;
+  height: 9px;
+  background: var(--glass-border);
+  content: "";
+}
+
+.chat-plan-list-meta [data-status="saved"] {
+  color: var(--chat-signal-strong);
+}
+
+.chat-plan-list-item > svg {
+  color: var(--text-muted);
+  transition: color 0.16s ease, transform 0.16s ease;
+}
+
+.chat-plan-list-item:hover > svg {
+  color: var(--chat-signal-strong);
+  transform: translateX(2px);
+}
+
+.chat-plan-panel-header {
+  display: block;
+  flex: none;
+  padding: 11px 12px;
+  border-bottom: 1px solid var(--glass-border);
+  background: color-mix(in srgb, var(--glass-bg-elevated) 72%, transparent);
+  animation: chat-plan-panel-enter 0.24s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.chat-plan-panel-heading {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+}
+
+.chat-plan-panel-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.chat-plan-panel-title > div {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+}
+
+.chat-plan-panel-title strong {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.chat-plan-panel-title span {
+  color: var(--text-muted);
+  font-size: 10.5px;
+}
+
+.chat-plan-panel-title.is-detail-title {
+  overflow: hidden;
+}
+
+.chat-plan-panel-title.is-detail-title strong,
+.chat-plan-panel-title.is-detail-title span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-plan-panel-icon {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  flex: none;
+  border: 1px solid var(--chat-signal-border);
+  border-radius: 9px;
+  background: var(--chat-signal-soft);
+  color: var(--chat-signal-strong) !important;
+}
+
+.chat-plan-panel-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: none;
+}
+
+.chat-plan-panel-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 30px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--glass-bg);
+  color: var(--text-secondary);
+  padding: 0 8px 0 6px;
+  font-size: 10.5px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease,
+    background 0.15s ease, transform 0.15s ease;
+}
+
+.chat-plan-panel-back:hover {
+  border-color: var(--chat-signal-border);
+  background: var(--glass-bg-hover);
+  color: var(--chat-signal-strong);
+}
+
+.chat-plan-panel-back:active {
+  transform: translateY(1px);
+}
+
+.chat-plan-panel-back:focus-visible {
+  outline: 2px solid var(--chat-signal);
+  outline-offset: 2px;
+}
+
+.chat-plan-panel-chat-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 30px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  padding: 0 8px;
+  font-size: 10.5px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.chat-plan-panel-chat-link:hover {
+  border-color: var(--glass-border);
+  background: var(--glass-bg-hover);
+  color: var(--text-primary);
+}
+
+@keyframes chat-plan-panel-enter {
+  from {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.chat-plan-panel-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 12px;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--text-secondary) 14%, transparent)
+    transparent;
+  animation: chat-plan-panel-enter 0.24s 0.03s cubic-bezier(0.22, 1, 0.36, 1)
+    both;
+}
+
+.chat-plan-panel-body:hover {
+  scrollbar-color: color-mix(in srgb, var(--text-secondary) 30%, transparent)
+    transparent;
+}
+
+.chat-plan-panel-body::-webkit-scrollbar {
+  width: 6px;
+  background: transparent;
+}
+
+.chat-plan-panel-body::-webkit-scrollbar-track,
+.chat-plan-panel-body::-webkit-scrollbar-track-piece,
+.chat-plan-panel-body::-webkit-scrollbar-corner {
+  background: transparent;
+  box-shadow: none;
+}
+
+.chat-plan-panel-body::-webkit-scrollbar-thumb {
+  min-height: 44px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-secondary) 12%, transparent);
+  background-clip: padding-box;
+}
+
+.chat-plan-panel-body:hover::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--text-secondary) 28%, transparent);
+  background-clip: padding-box;
+}
+
+.chat-plan-panel-body::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--text-secondary) 42%, transparent);
+  background-clip: padding-box;
+}
+
+.chat-plan-panel-body > .chat-plan-card {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+}
+
+.chat-plan-panel .chat-plan-entry {
+  grid-template-columns: auto minmax(0, 1fr);
+}
+
+.chat-plan-panel .chat-plan-entry-meta {
+  grid-column: 2;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.chat-plan-panel .chat-plan-actions > button {
+  justify-content: center;
+  white-space: nowrap;
+}
+
+.chat-plan-panel .chat-plan-actions .chat-plan-review {
+  flex: 0 1 auto;
+}
+
+.chat-plan-panel .chat-plan-actions .chat-plan-upload {
+  flex: 1 1 220px;
+}
+
+.chat-plan-panel .chat-plan-actions {
+  position: sticky;
+  bottom: -1px;
+  padding: 10px 0 1px;
+  background: linear-gradient(
+    180deg,
+    transparent 0,
+    color-mix(in srgb, var(--bg-base) 92%, transparent) 18px
+  );
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+}
+
+@media (max-width: 1399px) {
+  .chat-plan-panel {
+    display: none;
+  }
 }
 
 .chat-main-login {
@@ -17618,7 +18086,49 @@ tr.data-intervals-row-missing {
 
 .chat-history-panel {
   position: relative;
+  overflow: hidden;
+}
+
+.chat-session-list {
   overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--text-secondary) 14%, transparent)
+    transparent;
+}
+
+.chat-session-list:hover {
+  scrollbar-color: color-mix(in srgb, var(--text-secondary) 30%, transparent)
+    transparent;
+}
+
+.chat-session-list::-webkit-scrollbar {
+  width: 6px;
+  background: transparent;
+}
+
+.chat-session-list::-webkit-scrollbar-track,
+.chat-session-list::-webkit-scrollbar-track-piece,
+.chat-session-list::-webkit-scrollbar-corner {
+  background: transparent;
+  box-shadow: none;
+}
+
+.chat-session-list::-webkit-scrollbar-thumb {
+  min-height: 44px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-secondary) 12%, transparent);
+  background-clip: padding-box;
+}
+
+.chat-session-list:hover::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--text-secondary) 28%, transparent);
+  background-clip: padding-box;
+}
+
+.chat-session-list::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--text-secondary) 42%, transparent);
+  background-clip: padding-box;
 }
 
 .chat-settings-panel {
@@ -17628,10 +18138,10 @@ tr.data-intervals-row-missing {
 .chat-history-toolbar {
   display: grid;
   gap: 10px;
+  flex: none;
   padding: 14px 12px 12px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-  position: sticky;
-  top: 0;
+  position: relative;
   z-index: 1;
   background: rgba(10, 14, 20, 0.42);
   -webkit-backdrop-filter: blur(20px) saturate(140%);
@@ -17640,11 +18150,36 @@ tr.data-intervals-row-missing {
 }
 
 .chat-history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   padding: 0 2px;
 }
 
 .chat-history-header .eyebrow {
   margin: 0;
+}
+
+.chat-history-collapse-button {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  flex: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.chat-history-collapse-button:hover {
+  border-color: var(--glass-border);
+  background: var(--glass-bg-hover);
+  color: var(--text-primary);
 }
 
 .chat-new-chat-sidebar {
@@ -18454,6 +18989,44 @@ tr.data-intervals-row-missing {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--text-secondary) 14%, transparent)
+    transparent;
+}
+
+.chat-transcript:hover {
+  scrollbar-color: color-mix(in srgb, var(--text-secondary) 30%, transparent)
+    transparent;
+}
+
+.chat-transcript::-webkit-scrollbar {
+  width: 6px;
+  background: transparent;
+}
+
+.chat-transcript::-webkit-scrollbar-track,
+.chat-transcript::-webkit-scrollbar-track-piece,
+.chat-transcript::-webkit-scrollbar-corner {
+  background: transparent;
+  box-shadow: none;
+}
+
+.chat-transcript::-webkit-scrollbar-thumb {
+  min-height: 44px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-secondary) 12%, transparent);
+  background-clip: padding-box;
+}
+
+.chat-transcript:hover::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--text-secondary) 28%, transparent);
+  background-clip: padding-box;
+}
+
+.chat-transcript::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--text-secondary) 42%, transparent);
+  background-clip: padding-box;
 }
 
 .chat-thread {
@@ -18476,6 +19049,29 @@ tr.data-intervals-row-missing {
 
 .chat-row-user {
   flex-direction: row-reverse;
+}
+
+.chat-row.is-chat-jump-target {
+  border-radius: var(--radius-md);
+  outline: 1px solid color-mix(in srgb, var(--chat-signal) 50%, transparent);
+  outline-offset: 8px;
+  background: color-mix(in srgb, var(--chat-signal-soft) 45%, transparent);
+  box-shadow: 0 0 24px color-mix(in srgb, var(--chat-signal-glow) 42%, transparent);
+  animation: chat-jump-highlight 1.8s ease both;
+}
+
+@keyframes chat-jump-highlight {
+  0%, 100% {
+    outline-color: transparent;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  18%, 72% {
+    outline-color: color-mix(in srgb, var(--chat-signal) 50%, transparent);
+    background: color-mix(in srgb, var(--chat-signal-soft) 45%, transparent);
+    box-shadow: 0 0 24px color-mix(in srgb, var(--chat-signal-glow) 42%, transparent);
+  }
 }
 
 .chat-avatar {
@@ -18774,11 +19370,17 @@ tr.data-intervals-row-missing {
   .chat-empty-icon::before,
   .chat-suggestion,
   .chat-row,
+  .chat-row.is-chat-jump-target,
   .chat-avatar,
   .chat-typing span,
   .chat-thinking summary i,
   .chat-mcp-pill.connected::before,
-  .chat-mcp-panel {
+  .chat-mcp-panel,
+  .chat-sidebar-expand-button,
+  .chat-plan-list-header,
+  .chat-plan-list,
+  .chat-plan-panel-header,
+  .chat-plan-panel-body {
     animation: none;
   }
 
@@ -18805,7 +19407,8 @@ tr.data-intervals-row-missing {
   .chat-layout,
   .chat-sidebar-shell,
   .chat-sidebar.is-overlay,
-  .chat-sidebar-overlay {
+  .chat-sidebar-overlay,
+  .chat-plan-panel {
     transition: none;
   }
 }
@@ -19396,11 +19999,23 @@ tr.data-intervals-row-missing {
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-md);
   background: var(--glass-bg);
-  padding: 12px 14px;
+  padding: 14px 16px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
   min-width: min(100%, 420px);
+  box-shadow: var(--glass-inset);
+}
+
+.chat-plan-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.chat-plan-card-title {
+  min-width: 0;
 }
 
 .chat-plan-card-header h4 {
@@ -19410,106 +20025,631 @@ tr.data-intervals-row-missing {
 }
 
 .chat-plan-card-summary {
+  display: block;
+  max-width: 62ch;
   font-size: 12px;
+  line-height: 1.45;
   color: var(--text-secondary);
 }
 
-.chat-plan-table-wrap {
-  overflow-x: auto;
+.chat-plan-sports {
+  display: inline-flex;
+  flex: none;
+  gap: 4px;
+  padding-top: 1px;
 }
 
-.chat-plan-table {
-  width: 100%;
-  border-collapse: collapse;
+.chat-plan-sport-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  color: var(--chat-plan-sport, var(--text-secondary));
+  background: color-mix(in srgb, var(--chat-plan-sport, var(--text-secondary)) 14%, transparent);
+  border: 1px solid color-mix(in srgb, var(--chat-plan-sport, var(--text-secondary)) 30%, transparent);
+}
+
+.chat-plan-overview {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--glass-bg-elevated) 48%, transparent);
+}
+
+.chat-plan-overview-item {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  padding: 8px 10px;
+}
+
+.chat-plan-overview-item + .chat-plan-overview-item {
+  border-left: 1px solid var(--glass-border);
+}
+
+.chat-plan-overview-item span {
+  color: var(--text-muted);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+}
+
+.chat-plan-overview-item strong {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-plan-week {
+  display: grid;
+  gap: 9px;
+  min-width: 0;
+}
+
+.chat-plan-week-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 1px 2px 0;
+}
+
+.chat-plan-week-header > div:first-child {
+  display: grid;
+  grid-template-columns: auto auto;
+  align-items: baseline;
+  justify-content: start;
+  gap: 1px 8px;
+  min-width: 0;
+}
+
+.chat-plan-week-header > div:first-child > span {
+  grid-column: 1;
+  color: var(--chat-signal-strong);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+}
+
+.chat-plan-week-header h5 {
+  grid-column: 1;
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+}
+
+.chat-plan-week-header small {
+  grid-column: 2;
+  grid-row: 2;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  white-space: nowrap;
+}
+
+.chat-plan-week-stepper {
+  display: grid;
+  grid-template-columns: 28px auto 28px;
+  align-items: center;
+  gap: 5px;
+  flex: none;
+}
+
+.chat-plan-week-stepper button {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--glass-bg);
+  color: var(--text-secondary);
+  transition: border-color 0.15s ease, background 0.15s ease,
+    color 0.15s ease, transform 0.15s ease;
+}
+
+.chat-plan-week-stepper button:hover:not(:disabled) {
+  border-color: var(--chat-signal-border);
+  background: var(--glass-bg-hover);
+  color: var(--chat-signal-strong);
+}
+
+.chat-plan-week-stepper button:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.chat-plan-week-stepper > span {
+  min-width: 42px;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 650;
+  text-align: center;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.chat-plan-week-tabs {
+  display: flex;
+  gap: 6px;
+  min-width: 0;
+  overflow-x: auto;
+  padding: 0 0 2px;
+  scrollbar-width: none;
+  scroll-snap-type: x proximity;
+}
+
+.chat-plan-week-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.chat-plan-week-tabs button {
+  display: grid;
+  flex: 0 0 auto;
+  gap: 1px;
+  min-width: 104px;
+  padding: 7px 9px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  text-align: left;
+  scroll-snap-align: start;
+  transition: border-color 0.15s ease, background 0.15s ease,
+    color 0.15s ease, transform 0.15s ease;
+}
+
+.chat-plan-week-tabs button:hover:not(.is-active) {
+  border-color: color-mix(in srgb, var(--text-muted) 60%, transparent);
+  background: var(--glass-bg);
+  color: var(--text-primary);
+}
+
+.chat-plan-week-tabs button:active {
+  transform: translateY(1px);
+}
+
+.chat-plan-week-tabs button.is-active {
+  border-color: var(--chat-signal-border);
+  background: var(--chat-signal-soft);
+  color: var(--chat-signal-strong);
+}
+
+.chat-plan-week-tabs strong {
+  font-size: 10.5px;
+  font-weight: 700;
+}
+
+.chat-plan-week-tabs span {
+  color: var(--text-muted);
+  font-size: 9.5px;
+  white-space: nowrap;
+}
+
+.chat-plan-empty-week {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 58px;
+  padding: 10px 12px;
+  border: 1px dashed var(--glass-border);
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
   font-size: 12px;
 }
 
-.chat-plan-table th,
-.chat-plan-table td {
-  text-align: left;
-  padding: 6px 8px;
-  border-bottom: 1px solid var(--glass-border);
+.chat-plan-issues {
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--glass-bg) 58%, transparent);
 }
 
-.chat-plan-table th {
+.chat-plan-issues[data-tone="alert"] {
+  border-color: color-mix(in srgb, var(--error-text) 30%, var(--glass-border));
+}
+
+.chat-plan-issues summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto 18px;
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  padding: 7px 10px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  list-style: none;
+}
+
+.chat-plan-issues summary::-webkit-details-marker {
+  display: none;
+}
+
+.chat-plan-issues summary > span {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  gap: 7px;
+}
+
+.chat-plan-issues summary strong {
+  overflow: hidden;
+  font-size: 11.5px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-plan-issues summary small {
   color: var(--text-muted);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.chat-plan-issues summary > svg {
+  color: var(--text-muted);
+  transition: transform 0.15s ease;
+}
+
+.chat-plan-issues[open] summary > svg {
+  transform: rotate(180deg);
+}
+
+.chat-plan-issues[data-tone="alert"] summary > span > svg,
+.chat-plan-issues[data-tone="alert"] summary strong {
+  color: var(--error-text);
+}
+
+.chat-plan-issues[data-tone="note"] summary > span > svg {
+  color: var(--chat-signal-strong);
+}
+
+.chat-plan-issues summary:hover {
+  background: var(--glass-bg-hover);
+}
+
+.chat-plan-issues summary:focus-visible {
+  outline: 2px solid var(--chat-signal);
+  outline-offset: -2px;
+}
+
+.chat-plan-issues > ul {
+  max-height: 180px;
+  overflow-y: auto;
+  padding: 0 10px 9px;
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, var(--text-secondary) 22%, transparent)
+    transparent;
+}
+
+.chat-plan-entries {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--glass-bg) 52%, transparent);
+}
+
+.chat-plan-entry {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 10px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: inset 3px 0 0 color-mix(in srgb, var(--chat-plan-sport, var(--text-muted)) 70%, transparent);
+}
+
+.chat-plan-entry + .chat-plan-entry {
+  border-top: 1px solid var(--glass-border);
+}
+
+.chat-plan-entry-date {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  min-width: 46px;
+  min-height: 48px;
+  padding: 4px 6px;
+  border: 1px solid var(--glass-border);
+  border-radius: 7px;
+  background: var(--glass-bg-elevated);
+  color: var(--text-muted);
+}
+
+.chat-plan-entry-weekday,
+.chat-plan-entry-month {
+  font-size: 9px;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  line-height: 1.2;
+}
+
+.chat-plan-entry-day {
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.chat-plan-entry-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.chat-plan-entry-name {
+  font-size: 12.5px;
+  font-weight: 650;
+  color: var(--text-primary);
+}
+
+.chat-plan-entry-steps {
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
+.chat-plan-entry-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
+}
+
+.chat-plan-entry-volume {
+  font-size: 13px;
+  font-weight: 650;
+  color: var(--text-primary);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.chat-plan-entry-tags {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 5px;
+  max-width: 230px;
+}
+
+.chat-plan-entry-type {
+  font-size: 10px;
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
+  padding: 2px 7px;
+  white-space: nowrap;
+}
+
+.chat-plan-entry-sport {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
   font-weight: 600;
+  white-space: nowrap;
+  color: var(--chat-plan-sport, var(--text-secondary));
+  background: color-mix(in srgb, var(--chat-plan-sport, var(--text-secondary)) 13%, transparent);
+  border: 1px solid color-mix(in srgb, var(--chat-plan-sport, var(--text-secondary)) 26%, transparent);
+  border-radius: var(--radius-pill);
+  padding: 2px 8px;
+}
+
+.chat-plan-warnings,
+.chat-plan-notes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
 }
 
 .chat-plan-warnings {
-  margin: 0;
-  padding-left: 18px;
-  font-size: 12px;
   color: var(--error-text);
 }
 
 .chat-plan-notes {
-  margin: 0;
-  padding-left: 18px;
-  font-size: 12px;
   color: var(--text-secondary);
+}
+
+.chat-plan-warnings li,
+.chat-plan-notes li {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+}
+
+.chat-plan-warnings svg,
+.chat-plan-notes svg {
+  flex: none;
+  margin-top: 2px;
 }
 
 .chat-plan-confirmation {
   display: grid;
   gap: 10px;
-  padding: 10px;
+  min-inline-size: 0;
+  margin: 0;
+  padding: 12px;
   border: 1px solid var(--glass-border);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
   background: color-mix(in srgb, var(--glass-bg) 76%, transparent);
 }
 
-.chat-plan-confirmation label {
-  display: grid;
-  gap: 5px;
-  color: var(--text-secondary);
-  font-size: 12px;
+.chat-plan-confirmation legend {
+  margin-left: -4px;
+  padding: 0 4px;
+  color: var(--text-primary);
+  font-size: 12.5px;
+  font-weight: 650;
 }
 
-.chat-plan-confirmation select {
-  min-height: 36px;
-  padding: 0 10px;
+.chat-plan-destination-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.chat-plan-destination-option {
+  position: relative;
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) 18px;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  min-height: 64px;
+  padding: 9px 10px;
   border: 1px solid var(--glass-border);
   border-radius: var(--radius-sm);
   color: var(--text-primary);
-  background: var(--bg-base);
+  background: color-mix(in srgb, var(--glass-bg-elevated) 42%, transparent);
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease,
+    transform 0.15s ease;
 }
 
-.chat-plan-facts {
+.chat-plan-destination-option:hover:not(.is-disabled) {
+  border-color: color-mix(in srgb, var(--text-muted) 62%, transparent);
+  background: var(--glass-bg-hover);
+}
+
+.chat-plan-destination-option:active:not(.is-disabled) {
+  transform: translateY(1px);
+}
+
+.chat-plan-destination-option.is-selected {
+  border-color: var(--chat-signal-border);
+  background: var(--chat-signal-soft);
+}
+
+.chat-plan-destination-option.is-disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
+}
+
+.chat-plan-destination-option:has(input:focus-visible) {
+  outline: 2px solid var(--chat-signal);
+  outline-offset: 2px;
+}
+
+.chat-plan-destination-icon {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 6px 12px;
-  margin: 0;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--glass-bg);
+  color: var(--text-muted);
 }
 
-.chat-plan-facts div {
+.chat-plan-destination-option.is-selected .chat-plan-destination-icon {
+  border-color: var(--chat-signal-border);
+  color: var(--chat-signal-strong);
+}
+
+.chat-plan-destination-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.chat-plan-destination-copy strong {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 11.5px;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-plan-destination-copy small {
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.chat-plan-destination-check {
+  color: var(--chat-signal-strong);
+  opacity: 0;
+}
+
+.chat-plan-destination-option.is-selected .chat-plan-destination-check {
+  opacity: 1;
+}
+
+.chat-plan-destination-summary {
   display: flex;
-  justify-content: space-between;
-  gap: 10px;
-  font-size: 11px;
+  align-items: flex-start;
+  gap: 7px;
+  margin: 0;
+  padding: 0 2px;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  line-height: 1.45;
 }
 
-.chat-plan-facts dt { color: var(--text-muted); }
-.chat-plan-facts dd { margin: 0; color: var(--text-primary); text-align: right; }
-
-.chat-plan-write-preview {
-  font-size: 11px;
-  color: var(--text-secondary);
+.chat-plan-destination-summary svg {
+  flex: none;
+  margin-top: 1px;
 }
 
-.chat-plan-write-preview strong { color: var(--text-primary); }
-.chat-plan-write-preview p { margin: 5px 0 0; }
-.chat-plan-write-preview ul {
-  max-height: 116px;
-  overflow-y: auto;
-  margin: 5px 0 0;
-  padding-left: 18px;
+.chat-plan-destination-summary[data-tone="ok"] svg {
+  color: var(--chat-signal-strong);
+}
+
+.chat-plan-destination-summary[data-tone="alert"],
+.chat-plan-destination-summary[data-tone="alert"] svg {
+  color: var(--error-text);
 }
 
 .chat-plan-success {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
   margin: 0;
+  padding: 9px 12px;
   font-size: 12px;
+  line-height: 1.5;
   color: var(--chat-signal-strong);
+  background: var(--chat-signal-soft);
+  border: 1px solid var(--chat-signal-border);
+  border-radius: var(--radius-sm);
+}
+
+.chat-plan-success svg {
+  flex: none;
+  margin-top: 1px;
 }
 
 .chat-plan-actions {
@@ -19530,6 +20670,7 @@ tr.data-intervals-row-missing {
   font-size: 12px;
   font-weight: 650;
   cursor: pointer;
+  transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
 }
 
 .chat-plan-review:hover:not(:disabled) {
@@ -19555,15 +20696,91 @@ tr.data-intervals-row-missing {
   font-size: 12px;
   font-weight: 650;
   cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .chat-plan-upload:hover:not(:disabled) {
   border-color: var(--chat-signal);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--chat-signal-glow) 45%, transparent);
 }
 
 .chat-plan-upload:disabled {
   opacity: 0.65;
   cursor: default;
+}
+
+.chat-plan-review:active:not(:disabled),
+.chat-plan-upload:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.chat-plan-week-tabs button:focus-visible,
+.chat-plan-week-stepper button:focus-visible,
+.chat-plan-review:focus-visible,
+.chat-plan-upload:focus-visible {
+  outline: 2px solid var(--chat-signal);
+  outline-offset: 2px;
+}
+
+@media (max-width: 600px) {
+  .chat-plan-card {
+    padding: 12px;
+  }
+
+  .chat-plan-overview {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .chat-plan-overview-item:nth-child(3) {
+    border-left: 0;
+  }
+
+  .chat-plan-overview-item:nth-child(n + 3) {
+    border-top: 1px solid var(--glass-border);
+  }
+
+  .chat-plan-week-header {
+    align-items: flex-start;
+  }
+
+  .chat-plan-week-header > div:first-child {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-plan-week-header small {
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  .chat-plan-issues summary {
+    grid-template-columns: minmax(0, 1fr) 18px;
+  }
+
+  .chat-plan-issues summary small {
+    display: none;
+  }
+
+  .chat-plan-entry {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .chat-plan-entry-meta {
+    grid-column: 2;
+    align-items: flex-start;
+  }
+
+  .chat-plan-entry-tags {
+    justify-content: flex-start;
+  }
+
+  .chat-plan-destination-options {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-plan-actions > button {
+    flex: 1 1 100%;
+    justify-content: center;
+  }
 }
 
 .chat-hr-trend-card,

--- a/src/styles.css
+++ b/src/styles.css
@@ -577,7 +577,7 @@ input::placeholder {
   min-height: 0;
   min-width: 0;
   overflow: hidden;
-  padding: 0 0 var(--sidebar-float-gap) var(--sidebar-float-gap);
+  padding: 0;
   box-sizing: content-box;
 }
 
@@ -620,7 +620,7 @@ input::placeholder {
   width: 100%;
   overflow: hidden;
   border: 1px solid var(--sidebar-glass-border);
-  border-radius: var(--sidebar-radius);
+  border-radius: 0 var(--sidebar-radius) 0 0;
   background: var(--sidebar-glass-bg);
   -webkit-backdrop-filter: blur(var(--glass-blur-shell)) saturate(180%);
   backdrop-filter: blur(var(--glass-blur-shell)) saturate(180%);
@@ -648,7 +648,7 @@ input::placeholder {
   position: absolute;
   inset: 1px;
   z-index: 0;
-  border-radius: calc(var(--sidebar-radius) - 1px);
+  border-radius: 0 calc(var(--sidebar-radius) - 1px) 0 0;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   pointer-events: none;
 }
@@ -656,10 +656,10 @@ input::placeholder {
 .app-sidebar.is-overlay {
   position: absolute;
   top: 0;
-  left: var(--sidebar-float-gap);
-  bottom: var(--sidebar-float-gap);
+  left: 0;
+  bottom: 0;
   z-index: 40;
-  width: min(280px, calc(100vw - (var(--sidebar-float-gap) * 2)));
+  width: min(280px, 100vw);
   min-width: 0;
   height: auto;
   background: var(--sidebar-overlay-bg);
@@ -6780,12 +6780,27 @@ td span {
 }
 
 .app-select-value {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   flex: 1;
+  min-width: 0;
+}
+
+.app-select-value-label,
+.app-select-option-label {
   min-width: 0;
   overflow: hidden;
   text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.app-select-leading-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
 }
 
 .app-select-icon {
@@ -6824,6 +6839,11 @@ td span {
   bottom: auto;
 }
 
+.app-select-menu-list {
+  display: grid;
+  gap: 2px;
+}
+
 .app-select-option {
   display: flex;
   align-items: center;
@@ -6839,6 +6859,13 @@ td span {
   font: inherit;
   font-weight: 600;
   cursor: pointer;
+}
+
+.app-select-option-content {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
 }
 
 .app-select-option:hover,
@@ -12845,10 +12872,12 @@ td span {
 }
 
 .training-chart-tooltip {
+  position: relative;
   display: grid;
   gap: 8px;
   min-width: 152px;
-  padding: 10px 12px 11px;
+  padding: 12px 12px 11px;
+  overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: var(--radius-md);
   background:
@@ -12861,6 +12890,15 @@ td span {
   backdrop-filter: blur(16px) saturate(1.3);
   animation: training-tooltip-pop 0.18s ease-out;
   pointer-events: none;
+}
+
+.training-chart-tooltip-accent {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 2px;
+  opacity: 0.85;
 }
 
 .training-chart-tooltip-label {
@@ -12913,18 +12951,39 @@ td span {
   display: grid;
   align-content: center;
   justify-items: center;
-  gap: 10px;
+  gap: 12px;
   min-height: clamp(200px, 23vh, 320px);
-  padding: 20px;
-  border: 1px dashed rgba(255, 255, 255, 0.12);
+  padding: 24px;
+  border: 1px dashed rgba(255, 255, 255, 0.1);
   border-radius: var(--radius-md);
   background: rgba(255, 255, 255, 0.02);
   text-align: center;
 }
 
-.training-chart-empty svg {
+.training-chart-empty-icon {
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+}
+
+.training-chart-empty-text {
+  display: grid;
+  gap: 3px;
+}
+
+.training-chart-empty-text strong {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.training-chart-empty-text span {
+  max-width: 32ch;
   color: var(--text-muted);
-  opacity: 0.7;
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 .training-empty-chart,
@@ -19630,12 +19689,58 @@ tr.data-intervals-row-missing {
 
 .chat-provider-select,
 .chat-model-select {
+  --chat-select-tone: var(--accent);
+  --chat-select-tone-strong: var(--accent-strong);
+  --chat-select-tone-soft: var(--accent-soft);
+  --chat-select-tone-shadow: var(--accent-glow);
   --chat-select-border: color-mix(
     in srgb,
-    var(--accent) 18%,
+    var(--chat-select-tone) 18%,
     var(--glass-border)
   );
   flex: none;
+}
+
+.chat-select--gpt,
+.chat-select-menu--gpt {
+  --chat-select-tone: #d9e1e8;
+  --chat-select-tone-strong: #f2f5f7;
+  --chat-select-tone-soft: rgba(211, 222, 231, 0.13);
+  --chat-select-tone-shadow: rgba(211, 222, 231, 0.18);
+}
+
+.chat-select--claude,
+.chat-select-menu--claude {
+  --chat-select-tone: #d97757;
+  --chat-select-tone-strong: #f2a17f;
+  --chat-select-tone-soft: rgba(217, 119, 87, 0.15);
+  --chat-select-tone-shadow: rgba(217, 119, 87, 0.22);
+}
+
+.chat-select--local,
+.chat-select-menu--local {
+  --chat-select-tone: #35c4b0;
+  --chat-select-tone-strong: #70e3d3;
+  --chat-select-tone-soft: rgba(53, 196, 176, 0.14);
+  --chat-select-tone-shadow: rgba(53, 196, 176, 0.2);
+}
+
+.chat-provider-menu .app-select-option[data-value="chatgpt"] {
+  --chat-select-tone: #d9e1e8;
+  --chat-select-tone-strong: #f2f5f7;
+  --chat-select-tone-soft: rgba(211, 222, 231, 0.13);
+}
+
+.chat-provider-menu .app-select-option[data-value="claude-code"] {
+  --chat-select-tone: #d97757;
+  --chat-select-tone-strong: #f2a17f;
+  --chat-select-tone-soft: rgba(217, 119, 87, 0.15);
+}
+
+.chat-provider-menu .app-select-option[data-value="local"] {
+  --chat-select-tone: #35c4b0;
+  --chat-select-tone-strong: #70e3d3;
+  --chat-select-tone-soft: rgba(53, 196, 176, 0.14);
 }
 
 .chat-provider-select {
@@ -19653,9 +19758,14 @@ tr.data-intervals-row-missing {
   padding: 0 10px;
   border-color: var(--chat-select-border);
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.07), transparent 62%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.09), transparent 58%),
+    linear-gradient(115deg, var(--chat-select-tone-soft), transparent 68%),
     var(--glass-bg);
-  color: var(--text-secondary);
+  color: color-mix(
+    in srgb,
+    var(--chat-select-tone) 44%,
+    var(--text-secondary)
+  );
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.08),
     0 6px 16px rgba(2, 10, 8, 0.16);
@@ -19671,22 +19781,37 @@ tr.data-intervals-row-missing {
 
 .chat-provider-select .app-select-trigger:hover,
 .chat-model-select .app-select-trigger:hover {
-  border-color: var(--accent-glow);
-  background: var(--glass-bg-hover);
+  border-color: color-mix(
+    in srgb,
+    var(--chat-select-tone) 48%,
+    var(--glass-border)
+  );
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.11), transparent 60%),
+    linear-gradient(115deg, var(--chat-select-tone-soft), transparent 72%),
+    var(--glass-bg-hover);
   color: var(--text-primary);
   transform: translateY(-1px);
 }
 
 .chat-provider-select .app-select-trigger[aria-expanded="true"],
 .chat-model-select .app-select-trigger[aria-expanded="true"] {
-  border-color: color-mix(in srgb, var(--accent) 58%, var(--glass-border));
+  border-color: color-mix(
+    in srgb,
+    var(--chat-select-tone) 58%,
+    var(--glass-border)
+  );
   background:
-    linear-gradient(180deg, var(--accent-soft), transparent 72%),
+    linear-gradient(180deg, var(--chat-select-tone-soft), transparent 72%),
     var(--glass-bg-hover);
   color: var(--text-primary);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.1),
-    0 0 0 3px color-mix(in srgb, var(--accent-soft) 72%, transparent),
+    0 0 0 3px color-mix(
+      in srgb,
+      var(--chat-select-tone-shadow) 66%,
+      transparent
+    ),
     0 10px 24px rgba(2, 10, 8, 0.22);
   transform: none;
 }
@@ -19700,19 +19825,43 @@ tr.data-intervals-row-missing {
 .chat-model-select .app-select-icon {
   width: 14px;
   height: 14px;
-  color: color-mix(in srgb, var(--accent) 62%, var(--text-secondary));
+  color: var(--chat-select-tone);
+}
+
+.chat-provider-select .app-select-leading-icon,
+.chat-model-select .app-select-leading-icon {
+  width: 20px;
+  height: 20px;
+  border: 1px solid color-mix(
+    in srgb,
+    var(--chat-select-tone) 25%,
+    transparent
+  );
+  border-radius: 7px;
+  background: var(--chat-select-tone-soft);
+  color: var(--chat-select-tone-strong);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .chat-select-menu {
+  --chat-select-tone: var(--accent);
+  --chat-select-tone-strong: var(--accent-strong);
+  --chat-select-tone-soft: var(--accent-soft);
+  --chat-select-tone-shadow: var(--accent-glow);
+  --chat-menu-offset: -10px;
+  --chat-option-offset: -5px;
   min-width: 220px;
-  gap: 3px;
   padding: 7px;
-  border-color: color-mix(in srgb, var(--accent) 24%, var(--glass-border));
+  border-color: color-mix(
+    in srgb,
+    var(--chat-select-tone) 24%,
+    var(--glass-border)
+  );
   border-radius: var(--radius-md);
   background:
     linear-gradient(
       155deg,
-      color-mix(in srgb, var(--accent) 9%, transparent),
+      color-mix(in srgb, var(--chat-select-tone) 9%, transparent),
       transparent 42%
     ),
     color-mix(in srgb, var(--surface) 94%, #151b1a 6%);
@@ -19725,8 +19874,31 @@ tr.data-intervals-row-missing {
   backdrop-filter: blur(22px) saturate(1.35);
   font-size: 12.5px;
   scrollbar-color:
-    color-mix(in srgb, var(--accent) 54%, var(--text-muted)) transparent;
+    color-mix(
+      in srgb,
+      var(--chat-select-tone) 54%,
+      var(--text-muted)
+    )
+    transparent;
   scrollbar-width: thin;
+}
+
+.chat-select-menu[data-side="top"] {
+  --chat-menu-offset: 10px;
+  --chat-option-offset: 5px;
+}
+
+.chat-select-menu.is-closing {
+  pointer-events: none;
+}
+
+.chat-select-menu .app-select-menu-list {
+  gap: 3px;
+  transform-origin: top center;
+}
+
+.chat-select-menu[data-side="top"] .app-select-menu-list {
+  transform-origin: bottom center;
 }
 
 .chat-select-menu .app-select-option {
@@ -19747,8 +19919,16 @@ tr.data-intervals-row-missing {
 .chat-select-menu .app-select-option:hover,
 .chat-select-menu .app-select-option.is-active,
 .chat-select-menu .app-select-option:focus-visible {
-  border-color: color-mix(in srgb, var(--accent) 18%, transparent);
-  background: color-mix(in srgb, var(--accent-soft) 48%, var(--glass-bg-hover));
+  border-color: color-mix(
+    in srgb,
+    var(--chat-select-tone) 22%,
+    transparent
+  );
+  background: color-mix(
+    in srgb,
+    var(--chat-select-tone-soft) 62%,
+    var(--glass-bg-hover)
+  );
   color: var(--text-primary);
 }
 
@@ -19757,24 +19937,50 @@ tr.data-intervals-row-missing {
 }
 
 .chat-select-menu .app-select-option.is-selected {
-  border-color: color-mix(in srgb, var(--accent) 34%, transparent);
+  border-color: color-mix(
+    in srgb,
+    var(--chat-select-tone) 34%,
+    transparent
+  );
   background:
     linear-gradient(
       90deg,
-      color-mix(in srgb, var(--accent-soft) 92%, transparent),
-      color-mix(in srgb, var(--accent-soft) 44%, transparent)
+      color-mix(in srgb, var(--chat-select-tone-soft) 94%, transparent),
+      color-mix(in srgb, var(--chat-select-tone-soft) 46%, transparent)
     );
-  color: var(--accent-strong);
+  color: var(--chat-select-tone-strong);
 }
 
-.chat-select-menu .app-select-option.is-selected svg {
+.chat-select-menu .app-select-leading-icon {
+  width: 24px;
+  height: 24px;
+  border: 1px solid color-mix(
+    in srgb,
+    var(--chat-select-tone) 24%,
+    transparent
+  );
+  border-radius: 8px;
+  background: var(--chat-select-tone-soft);
+  color: var(--chat-select-tone-strong);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.07);
+}
+
+.chat-select-menu .app-select-option-check {
   width: 22px;
   height: 22px;
   padding: 4px;
-  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border: 1px solid color-mix(
+    in srgb,
+    var(--chat-select-tone) 30%,
+    transparent
+  );
   border-radius: 50%;
-  background: color-mix(in srgb, var(--accent-soft) 86%, transparent);
-  color: var(--accent-strong);
+  background: color-mix(
+    in srgb,
+    var(--chat-select-tone-soft) 88%,
+    transparent
+  );
+  color: var(--chat-select-tone-strong);
 }
 
 .chat-select-menu::-webkit-scrollbar {
@@ -19790,17 +19996,47 @@ tr.data-intervals-row-missing {
   border: 1px solid transparent;
   border-radius: var(--radius-pill);
   background:
-    color-mix(in srgb, var(--accent) 54%, var(--text-muted)) padding-box;
+    color-mix(
+      in srgb,
+      var(--chat-select-tone) 54%,
+      var(--text-muted)
+    )
+    padding-box;
 }
 
 .chat-select-menu::-webkit-scrollbar-thumb:hover {
   background:
-    color-mix(in srgb, var(--accent) 74%, var(--text-secondary)) padding-box;
+    color-mix(
+      in srgb,
+      var(--chat-select-tone) 74%,
+      var(--text-secondary)
+    )
+    padding-box;
 }
 
 @media (prefers-reduced-motion: no-preference) {
-  .chat-select-menu {
-    animation: chat-select-menu-reveal 140ms ease-out both;
+  .chat-select-menu.is-opening {
+    animation: chat-select-menu-surface-in 220ms ease-out;
+  }
+
+  .chat-select-menu.is-opening .app-select-menu-list {
+    animation: chat-select-menu-content-in 300ms
+      cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .chat-select-menu.is-opening .app-select-option {
+    animation: chat-select-option-in 220ms cubic-bezier(0.16, 1, 0.3, 1)
+      backwards;
+    animation-delay: var(--app-select-delay);
+  }
+
+  .chat-select-menu.is-closing {
+    animation: chat-select-menu-surface-out 160ms ease-in forwards;
+  }
+
+  .chat-select-menu.is-closing .app-select-menu-list {
+    animation: chat-select-menu-content-out 160ms cubic-bezier(0.4, 0, 1, 1)
+      forwards;
   }
 }
 
@@ -19808,6 +20044,7 @@ tr.data-intervals-row-missing {
   .chat-provider-select .app-select-trigger,
   .chat-model-select .app-select-trigger,
   .chat-select-menu,
+  .chat-select-menu .app-select-menu-list,
   .chat-select-menu .app-select-option {
     animation: none;
     transition: none;
@@ -19817,6 +20054,10 @@ tr.data-intervals-row-missing {
   .chat-model-select .app-select-trigger:hover,
   .chat-select-menu .app-select-option.is-active:not(.is-selected) {
     transform: none;
+  }
+
+  .chat-select-menu.is-closing {
+    opacity: 0;
   }
 }
 
@@ -19828,13 +20069,59 @@ tr.data-intervals-row-missing {
   }
 }
 
-@keyframes chat-select-menu-reveal {
+@keyframes chat-select-menu-surface-in {
   from {
     opacity: 0;
   }
 
   to {
     opacity: 1;
+  }
+}
+
+@keyframes chat-select-menu-content-in {
+  from {
+    opacity: 0.35;
+    transform: translateY(var(--chat-menu-offset)) scale(0.965);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes chat-select-option-in {
+  from {
+    opacity: 0;
+    transform: translateY(var(--chat-option-offset)) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes chat-select-menu-surface-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes chat-select-menu-content-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(var(--chat-menu-offset)) scale(0.975);
   }
 }
 
@@ -22995,6 +23282,54 @@ tr.data-intervals-row-missing {
     0 10px 32px rgba(60, 50, 35, 0.14);
 }
 
+:root[data-theme="paper"] .chat-select--gpt,
+:root[data-theme="paper"] .chat-select-menu--gpt {
+  --chat-select-tone: #6f7c86;
+  --chat-select-tone-strong: #3f4a53;
+  --chat-select-tone-soft: rgba(96, 111, 123, 0.12);
+  --chat-select-tone-shadow: rgba(96, 111, 123, 0.18);
+}
+
+:root[data-theme="paper"] .chat-select--claude,
+:root[data-theme="paper"] .chat-select-menu--claude {
+  --chat-select-tone: #bd5b3c;
+  --chat-select-tone-strong: #934329;
+  --chat-select-tone-soft: rgba(189, 91, 60, 0.12);
+  --chat-select-tone-shadow: rgba(189, 91, 60, 0.18);
+}
+
+:root[data-theme="paper"] .chat-select--local,
+:root[data-theme="paper"] .chat-select-menu--local {
+  --chat-select-tone: #0c7f74;
+  --chat-select-tone-strong: #08665d;
+  --chat-select-tone-soft: rgba(12, 127, 116, 0.11);
+  --chat-select-tone-shadow: rgba(12, 127, 116, 0.16);
+}
+
+:root[data-theme="paper"]
+  .chat-provider-menu
+  .app-select-option[data-value="chatgpt"] {
+  --chat-select-tone: #6f7c86;
+  --chat-select-tone-strong: #3f4a53;
+  --chat-select-tone-soft: rgba(96, 111, 123, 0.12);
+}
+
+:root[data-theme="paper"]
+  .chat-provider-menu
+  .app-select-option[data-value="claude-code"] {
+  --chat-select-tone: #bd5b3c;
+  --chat-select-tone-strong: #934329;
+  --chat-select-tone-soft: rgba(189, 91, 60, 0.12);
+}
+
+:root[data-theme="paper"]
+  .chat-provider-menu
+  .app-select-option[data-value="local"] {
+  --chat-select-tone: #0c7f74;
+  --chat-select-tone-strong: #08665d;
+  --chat-select-tone-soft: rgba(12, 127, 116, 0.11);
+}
+
 :root[data-theme="paper"] .chat-provider-select .app-select-trigger,
 :root[data-theme="paper"] .chat-model-select .app-select-trigger {
   box-shadow:
@@ -23393,7 +23728,7 @@ tr.data-intervals-row-missing {
  * Panels use a 72%-white glass fill plus a white-on-white sheen that reads as
  * near-invisible over the cream page. Make them opaque white cards with a
  * crisper border + warm lift so they separate from the background. */
-:root[data-theme="paper"] .panel:not(.is-disconnected) {
+:root[data-theme="paper"] .panel:not(.is-disconnected):not(.strength-body-panel) {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0.4)),
     var(--glass-bg-elevated);

--- a/src/styles.css
+++ b/src/styles.css
@@ -11247,6 +11247,7 @@ td span {
 /* ── Sleep summary panel ───────────────────────────────────────────── */
 .sleep-panel {
   --sleep-tone: rgba(120, 146, 255, 0.72);
+  container: sleep-summary / inline-size;
   display: grid;
   grid-template-rows: auto auto minmax(0, 1fr) auto;
   align-content: start;
@@ -11590,34 +11591,87 @@ td span {
   line-height: 1.35;
 }
 
-.sleep-panel-metrics,
-.sleep-panel-footer {
+.sleep-panel-metrics {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px 16px;
-  border-top: 1px solid rgba(255, 255, 255, 0.07);
-  padding-top: 14px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px 16px;
+  margin: 0;
+  border-top: 1px solid var(--glass-border);
+  padding-top: 12px;
 }
 
-.sleep-panel-metrics span,
-.sleep-panel-footer span {
-  display: block;
+.sleep-metric {
+  display: grid;
+  align-content: start;
+  gap: 4px;
+  min-width: 0;
+}
+
+.sleep-metric.is-window {
+  grid-column: 1 / -1;
+}
+
+.sleep-metric dt {
+  min-width: 0;
+  overflow: hidden;
   color: var(--text-muted);
-  font-size: 10px;
+  font-size: 9.5px;
   font-weight: 800;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.065em;
+  line-height: 1.15;
+  text-overflow: ellipsis;
   text-transform: uppercase;
+  white-space: nowrap;
 }
 
-.sleep-panel-metrics strong,
-.sleep-panel-footer strong {
-  display: block;
-  margin-top: 3px;
+.sleep-metric dd {
+  min-width: 0;
+  overflow: hidden;
+  margin: 0;
   color: var(--text-primary);
-  font-size: 12px;
+  font-size: 15px;
   font-weight: 700;
-  line-height: 1.25;
-  overflow-wrap: anywhere;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sleep-window-value {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  letter-spacing: -0.02em;
+}
+
+.sleep-window-time {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+
+.sleep-window-time svg {
+  flex-shrink: 0;
+  color: color-mix(in srgb, var(--sleep-tone) 76%, var(--text-secondary));
+}
+
+.sleep-window-arrow {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+@container sleep-summary (min-width: 680px) {
+  .sleep-panel-metrics {
+    grid-template-columns: minmax(230px, 1.5fr) repeat(3, minmax(90px, 1fr));
+    gap: 18px;
+  }
+
+  .sleep-metric.is-window {
+    grid-column: auto;
+  }
 }
 
 @keyframes vo2-band-reveal {
@@ -12651,6 +12705,8 @@ td span {
 }
 
 .training-chart-panel {
+  --chart-panel-tint: rgba(79, 214, 166, 0.08);
+  --chart-curve-glow: rgba(79, 214, 166, 0.3);
   display: grid;
   gap: 20px;
   min-height: clamp(300px, 34vh, 430px);
@@ -12659,15 +12715,72 @@ td span {
   border-radius: var(--radius-lg);
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02) 52%),
-    radial-gradient(120% 80% at 0% 0%, rgba(45, 154, 116, 0.07), transparent 58%),
+    radial-gradient(120% 80% at 0% 0%, var(--chart-panel-tint), transparent 58%),
     rgba(255, 255, 255, 0.034);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.09);
   -webkit-backdrop-filter: none;
   backdrop-filter: none;
 }
 
+.training-chart-panel[data-metric="rpe"] {
+  --chart-panel-tint: rgba(167, 139, 250, 0.09);
+  --chart-curve-glow: rgba(183, 155, 255, 0.32);
+}
+
+.training-chart-panel[data-metric="hrv"] {
+  --chart-panel-tint: rgba(116, 192, 143, 0.08);
+  --chart-curve-glow: rgba(116, 192, 143, 0.3);
+}
+
+.training-chart-panel[data-metric="sleep"] {
+  --chart-panel-tint: rgba(122, 184, 255, 0.09);
+  --chart-curve-glow: rgba(122, 184, 255, 0.32);
+}
+
+.training-chart-panel .recharts-area-curve {
+  filter: drop-shadow(0 5px 12px var(--chart-curve-glow));
+}
+
 .training-chart-heading {
   align-items: flex-end;
+}
+
+.training-chart-heading-side {
+  display: grid;
+  justify-items: end;
+  gap: 8px;
+}
+
+.training-chart-stat {
+  display: grid;
+  justify-items: end;
+  gap: 5px;
+}
+
+.training-chart-stat-value {
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  font-size: clamp(20px, 1.9vw, 24px);
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1;
+}
+
+.training-chart-stat-delta {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px 8px;
+  border-radius: var(--radius-pill);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.training-chart-stat-delta svg {
+  flex-shrink: 0;
 }
 
 .training-chart-shell {
@@ -12731,9 +12844,87 @@ td span {
   border-top: 2px dashed var(--accent-gold);
 }
 
-.training-chart-tooltip strong {
-  font-size: 15px;
+.training-chart-tooltip {
+  display: grid;
+  gap: 8px;
+  min-width: 152px;
+  padding: 10px 12px 11px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(180deg, rgba(28, 33, 31, 0.92), rgba(13, 16, 15, 0.94));
+  box-shadow:
+    0 18px 40px rgba(0, 0, 0, 0.5),
+    0 2px 8px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  -webkit-backdrop-filter: blur(16px) saturate(1.3);
+  backdrop-filter: blur(16px) saturate(1.3);
+  animation: training-tooltip-pop 0.18s ease-out;
+  pointer-events: none;
+}
+
+.training-chart-tooltip-label {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.training-chart-tooltip-rows {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.training-chart-tooltip-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.training-chart-tooltip-key {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  font-weight: 600;
+}
+
+.training-chart-tooltip-key i {
+  width: 8px;
+  height: 8px;
+  flex-shrink: 0;
+  border-radius: 50%;
+}
+
+.training-chart-tooltip-row strong {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
   font-weight: 700;
+}
+
+.training-chart-empty {
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  gap: 10px;
+  min-height: clamp(200px, 23vh, 320px);
+  padding: 20px;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.02);
+  text-align: center;
+}
+
+.training-chart-empty svg {
+  color: var(--text-muted);
+  opacity: 0.7;
 }
 
 .training-empty-chart,
@@ -15660,6 +15851,18 @@ tr.data-intervals-row-missing {
   }
 }
 
+@keyframes training-tooltip-pop {
+  from {
+    opacity: 0;
+    transform: translateY(4px) scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
 @keyframes training-fill {
   from {
     transform: scaleX(0);
@@ -16181,6 +16384,7 @@ tr.data-intervals-row-missing {
   .training-table-row,
   .race-card,
   .training-chart-shell .recharts-wrapper,
+  .training-chart-tooltip,
   .training-zone-donut .recharts-wrapper,
   .training-status-dot.is-connected,
   .training-zone-fill,
@@ -18636,113 +18840,6 @@ tr.data-intervals-row-missing {
   color: var(--text-muted);
 }
 
-.chat-provider-switch {
-  position: relative;
-  display: inline-grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  align-items: stretch;
-  padding: 3px;
-  border: 1px solid var(--glass-border);
-  border-radius: var(--radius-pill);
-  background: rgba(255, 255, 255, 0.03);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-}
-
-.chat-provider-switch-indicator {
-  position: absolute;
-  top: 3px;
-  bottom: 3px;
-  left: 3px;
-  width: calc(33.333% - 2px);
-  border-radius: var(--radius-pill);
-  background: var(--accent-soft);
-  border: 1px solid var(--accent-glow);
-  box-shadow: 0 0 18px var(--accent-glow);
-  transition:
-    transform 0.22s cubic-bezier(0.22, 1, 0.36, 1),
-    background 0.15s ease,
-    border-color 0.15s ease,
-    box-shadow 0.15s ease;
-  pointer-events: none;
-}
-
-.chat-provider-switch[data-provider="local"] .chat-provider-switch-indicator {
-  background: rgba(31, 182, 166, 0.16);
-  border-color: rgba(31, 182, 166, 0.42);
-  box-shadow: 0 0 18px rgba(31, 182, 166, 0.28);
-}
-
-.chat-provider-switch[data-provider="claude-code"] .chat-provider-switch-indicator {
-  background: rgba(139, 92, 246, 0.16);
-  border-color: rgba(167, 139, 250, 0.44);
-  box-shadow: 0 0 18px rgba(139, 92, 246, 0.28);
-}
-
-.chat-provider-switch button {
-  position: relative;
-  z-index: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  border: 0;
-  border-radius: var(--radius-pill);
-  background: transparent;
-  color: var(--text-muted);
-  padding: 6px 12px;
-  font-size: 12px;
-  font-weight: 700;
-  cursor: pointer;
-  white-space: nowrap;
-  transition:
-    color 0.15s ease,
-    opacity 0.15s ease;
-}
-
-.chat-provider-switch button svg {
-  flex-shrink: 0;
-  opacity: 0.72;
-  transition: opacity 0.15s ease, color 0.15s ease;
-}
-
-.chat-provider-switch button:hover:not(:disabled) {
-  color: var(--text-secondary);
-}
-
-.chat-provider-switch button:hover:not(:disabled) svg {
-  opacity: 0.95;
-}
-
-.chat-provider-switch button.active {
-  color: var(--accent-strong);
-}
-
-.chat-provider-switch[data-provider="local"] button.active {
-  color: #5eead4;
-}
-
-.chat-provider-switch[data-provider="claude-code"] button.active {
-  color: #c4b5fd;
-}
-
-.chat-provider-switch button.active svg {
-  opacity: 1;
-}
-
-.chat-provider-switch-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: currentColor;
-  box-shadow: 0 0 8px currentColor;
-  flex-shrink: 0;
-}
-
-.chat-provider-switch button:disabled:not(.active) {
-  opacity: 0.5;
-  cursor: default;
-}
-
 .chat-local-status {
   display: inline-flex;
   align-items: center;
@@ -18799,7 +18896,8 @@ tr.data-intervals-row-missing {
   padding: 6px 12px;
   font-size: 12px;
   cursor: pointer;
-  transition: color 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+  transition: color 0.18s ease, border-color 0.18s ease,
+    background 0.18s ease, transform 0.18s ease;
 }
 
 .chat-new-chat:hover:not(:disabled) {
@@ -19510,7 +19608,8 @@ tr.data-intervals-row-missing {
 .chat-composer-toolbar {
   display: flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: space-between;
+  gap: 12px;
   width: 100%;
   max-width: 760px;
   margin-bottom: 8px;
@@ -19520,6 +19619,254 @@ tr.data-intervals-row-missing {
   justify-content: center;
   margin-top: 16px;
   margin-bottom: 0;
+}
+
+.chat-provider-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.chat-provider-select,
+.chat-model-select {
+  --chat-select-border: color-mix(
+    in srgb,
+    var(--accent) 18%,
+    var(--glass-border)
+  );
+  flex: none;
+}
+
+.chat-provider-select {
+  width: 138px;
+}
+
+.chat-model-select {
+  width: 146px;
+}
+
+.chat-provider-select .app-select-trigger,
+.chat-model-select .app-select-trigger {
+  position: relative;
+  min-height: 34px;
+  padding: 0 10px;
+  border-color: var(--chat-select-border);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.07), transparent 62%),
+    var(--glass-bg);
+  color: var(--text-secondary);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 6px 16px rgba(2, 10, 8, 0.16);
+  font-size: 12px;
+  font-weight: 700;
+  transition:
+    border-color 160ms ease,
+    background 160ms ease,
+    box-shadow 160ms ease,
+    color 160ms ease,
+    transform 160ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.chat-provider-select .app-select-trigger:hover,
+.chat-model-select .app-select-trigger:hover {
+  border-color: var(--accent-glow);
+  background: var(--glass-bg-hover);
+  color: var(--text-primary);
+  transform: translateY(-1px);
+}
+
+.chat-provider-select .app-select-trigger[aria-expanded="true"],
+.chat-model-select .app-select-trigger[aria-expanded="true"] {
+  border-color: color-mix(in srgb, var(--accent) 58%, var(--glass-border));
+  background:
+    linear-gradient(180deg, var(--accent-soft), transparent 72%),
+    var(--glass-bg-hover);
+  color: var(--text-primary);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    0 0 0 3px color-mix(in srgb, var(--accent-soft) 72%, transparent),
+    0 10px 24px rgba(2, 10, 8, 0.22);
+  transform: none;
+}
+
+.chat-provider-select .app-select-trigger:active:not(:disabled),
+.chat-model-select .app-select-trigger:active:not(:disabled) {
+  transform: scale(0.985);
+}
+
+.chat-provider-select .app-select-icon,
+.chat-model-select .app-select-icon {
+  width: 14px;
+  height: 14px;
+  color: color-mix(in srgb, var(--accent) 62%, var(--text-secondary));
+}
+
+.chat-select-menu {
+  min-width: 220px;
+  gap: 3px;
+  padding: 7px;
+  border-color: color-mix(in srgb, var(--accent) 24%, var(--glass-border));
+  border-radius: var(--radius-md);
+  background:
+    linear-gradient(
+      155deg,
+      color-mix(in srgb, var(--accent) 9%, transparent),
+      transparent 42%
+    ),
+    color-mix(in srgb, var(--surface) 94%, #151b1a 6%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.09),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.02),
+    0 22px 54px rgba(2, 8, 7, 0.52),
+    0 6px 18px rgba(2, 8, 7, 0.3);
+  -webkit-backdrop-filter: blur(22px) saturate(1.35);
+  backdrop-filter: blur(22px) saturate(1.35);
+  font-size: 12.5px;
+  scrollbar-color:
+    color-mix(in srgb, var(--accent) 54%, var(--text-muted)) transparent;
+  scrollbar-width: thin;
+}
+
+.chat-select-menu .app-select-option {
+  position: relative;
+  min-height: 38px;
+  padding: 0 10px 0 12px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  color: var(--text-secondary);
+  font-weight: 650;
+  transition:
+    background 140ms ease,
+    border-color 140ms ease,
+    color 140ms ease,
+    transform 140ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.chat-select-menu .app-select-option:hover,
+.chat-select-menu .app-select-option.is-active,
+.chat-select-menu .app-select-option:focus-visible {
+  border-color: color-mix(in srgb, var(--accent) 18%, transparent);
+  background: color-mix(in srgb, var(--accent-soft) 48%, var(--glass-bg-hover));
+  color: var(--text-primary);
+}
+
+.chat-select-menu .app-select-option.is-active:not(.is-selected) {
+  transform: translateX(2px);
+}
+
+.chat-select-menu .app-select-option.is-selected {
+  border-color: color-mix(in srgb, var(--accent) 34%, transparent);
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--accent-soft) 92%, transparent),
+      color-mix(in srgb, var(--accent-soft) 44%, transparent)
+    );
+  color: var(--accent-strong);
+}
+
+.chat-select-menu .app-select-option.is-selected svg {
+  width: 22px;
+  height: 22px;
+  padding: 4px;
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--accent-soft) 86%, transparent);
+  color: var(--accent-strong);
+}
+
+.chat-select-menu::-webkit-scrollbar {
+  width: 6px;
+}
+
+.chat-select-menu::-webkit-scrollbar-track {
+  margin-block: 9px;
+  background: transparent;
+}
+
+.chat-select-menu::-webkit-scrollbar-thumb {
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background:
+    color-mix(in srgb, var(--accent) 54%, var(--text-muted)) padding-box;
+}
+
+.chat-select-menu::-webkit-scrollbar-thumb:hover {
+  background:
+    color-mix(in srgb, var(--accent) 74%, var(--text-secondary)) padding-box;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .chat-select-menu {
+    animation: chat-select-menu-reveal 140ms ease-out both;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chat-provider-select .app-select-trigger,
+  .chat-model-select .app-select-trigger,
+  .chat-select-menu,
+  .chat-select-menu .app-select-option {
+    animation: none;
+    transition: none;
+  }
+
+  .chat-provider-select .app-select-trigger:hover,
+  .chat-model-select .app-select-trigger:hover,
+  .chat-select-menu .app-select-option.is-active:not(.is-selected) {
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .chat-select-menu {
+    background: var(--surface);
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+  }
+}
+
+@keyframes chat-select-menu-reveal {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.chat-composer-new-chat {
+  min-height: 34px;
+  flex: none;
+  font-weight: 700;
+}
+
+.chat-composer-new-chat:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.chat-composer-new-chat:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 520px) {
+  .chat-composer-toolbar:not(.chat-composer-toolbar-login) {
+    gap: 8px;
+  }
+
+  .chat-composer-new-chat {
+    width: 34px;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .chat-composer-new-chat span {
+    display: none;
+  }
 }
 
 .chat-composer-inner {
@@ -22648,28 +22995,38 @@ tr.data-intervals-row-missing {
     0 10px 32px rgba(60, 50, 35, 0.14);
 }
 
-:root[data-theme="paper"] .chat-provider-switch {
-  background: rgba(38, 34, 28, 0.05);
-  box-shadow: inset 0 1px 0 rgba(38, 34, 28, 0.03);
+:root[data-theme="paper"] .chat-provider-select .app-select-trigger,
+:root[data-theme="paper"] .chat-model-select .app-select-trigger {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.82),
+    0 5px 14px rgba(60, 50, 35, 0.08);
 }
 
-:root[data-theme="paper"] .chat-provider-switch-indicator {
-  border-color: rgba(38, 34, 28, 0.12);
-  box-shadow: none;
+:root[data-theme="paper"]
+  .chat-provider-select
+  .app-select-trigger[aria-expanded="true"],
+:root[data-theme="paper"]
+  .chat-model-select
+  .app-select-trigger[aria-expanded="true"] {
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.9),
+    0 0 0 3px var(--accent-soft),
+    0 10px 24px rgba(60, 50, 35, 0.12);
 }
 
-:root[data-theme="paper"] .chat-provider-switch button.active {
-  color: #3d3a36;
-}
-
-:root[data-theme="paper"] .chat-provider-switch[data-provider="local"] .chat-provider-switch-indicator {
-  background: rgba(18, 138, 127, 0.16);
-  border-color: rgba(18, 138, 127, 0.4);
-  box-shadow: none;
-}
-
-:root[data-theme="paper"] .chat-provider-switch[data-provider="local"] button.active {
-  color: #0c7f74;
+:root[data-theme="paper"] .chat-select-menu {
+  background:
+    linear-gradient(
+      155deg,
+      color-mix(in srgb, var(--accent) 7%, transparent),
+      transparent 42%
+    ),
+    rgba(255, 255, 255, 0.97);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.92),
+    inset 0 0 0 1px rgba(38, 34, 28, 0.025),
+    0 22px 50px rgba(60, 50, 35, 0.16),
+    0 5px 16px rgba(60, 50, 35, 0.08);
 }
 
 /* --- Route Studio panels + Leaflet controls ------------------------------- */
@@ -23437,10 +23794,27 @@ tr.data-intervals-row-missing {
 
 /* --- Training Hub: charts -------------------------------------------------- */
 :root[data-theme="paper"] .training-chart-panel {
+  --chart-curve-glow: rgba(15, 138, 102, 0.2);
   box-shadow: var(--shadow-card);
 }
 
-:root[data-theme="paper"] .training-empty-state {
+:root[data-theme="paper"] .training-chart-panel[data-metric="rpe"] {
+  --chart-panel-tint: rgba(124, 92, 214, 0.08);
+  --chart-curve-glow: rgba(124, 92, 214, 0.2);
+}
+
+:root[data-theme="paper"] .training-chart-panel[data-metric="hrv"] {
+  --chart-panel-tint: rgba(18, 148, 110, 0.07);
+  --chart-curve-glow: rgba(15, 127, 95, 0.2);
+}
+
+:root[data-theme="paper"] .training-chart-panel[data-metric="sleep"] {
+  --chart-panel-tint: rgba(61, 111, 214, 0.08);
+  --chart-curve-glow: rgba(61, 111, 214, 0.2);
+}
+
+:root[data-theme="paper"] .training-empty-state,
+:root[data-theme="paper"] .training-chart-empty {
   border-color: rgba(38, 34, 28, 0.14);
   background: rgba(38, 34, 28, 0.025);
 }
@@ -23456,6 +23830,15 @@ tr.data-intervals-row-missing {
   background: var(--glass-bg-elevated);
   box-shadow: var(--shadow-soft);
   color: var(--text-secondary);
+}
+
+:root[data-theme="paper"] .training-chart-tooltip {
+  border-color: var(--glass-border);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.97), rgba(250, 247, 240, 0.97));
+  box-shadow:
+    var(--shadow-soft),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
 /* --- Training Hub: zone distribution --------------------------------------- */

--- a/src/training-library/PlanCompare.tsx
+++ b/src/training-library/PlanCompare.tsx
@@ -12,6 +12,8 @@ import {
 } from "recharts";
 import type { TrainingPlanDocument } from "../../electron/types";
 import { compareTrainingPlans } from "../../electron/trainingPlanDomain";
+import { useUnitSystem } from "../units/UnitSystemProvider";
+import { formatDistanceValue } from "../units/units";
 
 interface PlanCompareProps {
   plans: TrainingPlanDocument[];
@@ -27,6 +29,7 @@ function durationLabel(seconds: number): string {
 }
 
 export function PlanCompare({ plans, selectedIds, onSelectionChange, onClose }: PlanCompareProps) {
+  const { unitSystem } = useUnitSystem();
   const selected = plans.filter((plan) => selectedIds.includes(plan.id)).slice(0, 3);
   const comparison = useMemo(() => compareTrainingPlans(selected), [selected]);
   const chartData = useMemo(() => {
@@ -67,7 +70,7 @@ export function PlanCompare({ plans, selectedIds, onSelectionChange, onClose }: 
           <h3>{summary.name}</h3>
           <dl>
             <div><dt>Total duration</dt><dd>{durationLabel(summary.durationSeconds)}</dd></div>
-            <div><dt>Total distance</dt><dd>{(summary.distanceMeters / 1000).toFixed(1)} km</dd></div>
+            <div><dt>Total distance</dt><dd>{formatDistanceValue(summary.distanceMeters, unitSystem, { digits: 1 })}</dd></div>
             <div><dt>Estimated load</dt><dd>{Math.round(summary.trainingLoad)}</dd></div>
             <div><dt>Workouts</dt><dd>{summary.workouts}</dd></div>
             <div><dt>Peak week</dt><dd>{summary.peakWeek ?? "-"}</dd></div>

--- a/src/training-library/PlanEditor.tsx
+++ b/src/training-library/PlanEditor.tsx
@@ -44,6 +44,8 @@ import type { CorosLinkApi } from "../coroslink-api";
 import { WorkoutEditorModal } from "../calendar/WorkoutEditorModal";
 import { SelectDropdown } from "../components/SelectDropdown";
 import { replaceTrainingPlanEntryWorkout } from "../../electron/planWorkoutEditor";
+import { useUnitSystem } from "../units/UnitSystemProvider";
+import { formatDistanceValue } from "../units/units";
 import { Ridge } from "./Ridge";
 import { SportDot } from "./sportTheme";
 
@@ -99,6 +101,7 @@ function mondayOf(value: string): string {
 }
 
 export function PlanEditor({ api, initialPlan, workouts, calendarEnabled, offline, onCalendar, onSave, onClose }: PlanEditorProps) {
+  const { unitSystem } = useUnitSystem();
   const [history, setHistory] = useState<TrainingPlanDocument[]>([structuredClone(initialPlan)]);
   const [historyIndex, setHistoryIndex] = useState(0);
   const [saving, setSaving] = useState(false);
@@ -415,7 +418,7 @@ export function PlanEditor({ api, initialPlan, workouts, calendarEnabled, offlin
           <dl>
             <div><dt>Workouts</dt><dd>{summary.workouts}</dd></div>
             <div><dt>Duration</dt><dd>{Math.round(summary.durationSeconds / 360) / 10} hr</dd></div>
-            <div><dt>Distance</dt><dd>{Math.round(summary.distanceMeters / 100) / 10} km</dd></div>
+            <div><dt>Distance</dt><dd>{formatDistanceValue(summary.distanceMeters, unitSystem, { digits: 1 })}</dd></div>
             <div><dt>Training load</dt><dd>{Math.round(summary.trainingLoad)}</dd></div>
             <div><dt>Rest days</dt><dd>{summary.restDays}</dd></div>
             <div><dt>Peak week</dt><dd>{summary.peakWeek ?? "-"}</dd></div>

--- a/src/training-library/TrainingLibraryView.tsx
+++ b/src/training-library/TrainingLibraryView.tsx
@@ -60,6 +60,11 @@ import { TrainingPlanCalendarDialog } from "./TrainingPlanCalendarDialog";
 import { TrainingPlanGenerator } from "./TrainingPlanGenerator";
 import { useUnitSystem } from "../units/UnitSystemProvider";
 import { formatDistanceValue } from "../units/units";
+import {
+  defineSelectionPreference,
+  selectionIsOneOf,
+  useSelectionPreference
+} from "../preferences/selectionPreferences";
 import "./trainingLibrary.css";
 
 interface TrainingLibraryViewProps {
@@ -81,6 +86,18 @@ const SECTIONS: Array<{ id: LibrarySection; label: string; icon: typeof Zap }> =
   { id: "templates", label: "Templates", icon: Bookmark },
   { id: "adherence", label: "Adherence", icon: Target }
 ];
+
+const LIBRARY_SECTION_PREFERENCE =
+  defineSelectionPreference<LibrarySection>({
+    key: "trainingLibrary.section",
+    defaultValue: "workouts",
+    validate: selectionIsOneOf([
+      "workouts",
+      "plans",
+      "templates",
+      "adherence"
+    ])
+  });
 
 /** Sync states worth interrupting the reader for. Everything else stays quiet. */
 const UNSETTLED_SYNC = new Set(["pending", "conflicted", "failed", "stale"]);
@@ -153,7 +170,9 @@ export function TrainingLibraryView({
   onMessage,
   onError
 }: TrainingLibraryViewProps) {
-  const [section, setSection] = useState<LibrarySection>("workouts");
+  const [section, setSection] = useSelectionPreference(
+    LIBRARY_SECTION_PREFERENCE
+  );
   const [snapshot, setSnapshot] = useState<TrainingLibrarySnapshot | null>(null);
   const [loading, setLoading] = useState(true);
   const [fatalError, setFatalError] = useState<string | null>(null);
@@ -519,6 +538,61 @@ const PLAN_SORT_OPTIONS: Array<{ value: PlanColumn; label: string }> = [
   { value: "load", label: "Training load" }
 ];
 
+type PlanIndexNoun = "plan" | "template";
+
+const PLAN_SCOPE_PREFERENCES = {
+  plan: defineSelectionPreference<string>({
+    key: "trainingLibrary.plans.scope",
+    defaultValue: "all",
+    validate: (value): value is string =>
+      typeof value === "string" &&
+      ["all", "favorite", "coros", "local", "coach", "unsettled", "archived"].includes(value)
+  }),
+  template: defineSelectionPreference<string>({
+    key: "trainingLibrary.templates.scope",
+    defaultValue: "all",
+    validate: (value): value is string =>
+      typeof value === "string" &&
+      ["all", "favorite", "coros", "local", "coach", "unsettled", "archived"].includes(value)
+  })
+} satisfies Record<PlanIndexNoun, unknown>;
+
+function isPlanSort(value: unknown): value is PlanSort {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    ["name", "weeks", "sessions", "load", "updated"].includes(
+      String(candidate.column)
+    ) && typeof candidate.descending === "boolean"
+  );
+}
+
+const PLAN_SORT_PREFERENCES = {
+  plan: defineSelectionPreference<PlanSort>({
+    key: "trainingLibrary.plans.sort",
+    defaultValue: { column: "updated", descending: true },
+    validate: isPlanSort
+  }),
+  template: defineSelectionPreference<PlanSort>({
+    key: "trainingLibrary.templates.sort",
+    defaultValue: { column: "updated", descending: true },
+    validate: isPlanSort
+  })
+} satisfies Record<PlanIndexNoun, unknown>;
+
+const PLAN_LAYOUT_PREFERENCES = {
+  plan: defineSelectionPreference<"grid" | "list">({
+    key: "trainingLibrary.plans.layout",
+    defaultValue: "grid",
+    validate: selectionIsOneOf(["grid", "list"])
+  }),
+  template: defineSelectionPreference<"grid" | "list">({
+    key: "trainingLibrary.templates.layout",
+    defaultValue: "grid",
+    validate: selectionIsOneOf(["grid", "list"])
+  })
+} satisfies Record<PlanIndexNoun, unknown>;
+
 /**
  * Everything a tile and a row both need, derived once so the two layouts can
  * never drift apart on what a plan says.
@@ -553,7 +627,7 @@ function planView(
 
 interface PlanIndexProps {
   api: CorosLinkApi;
-  noun: "plan" | "template";
+  noun: PlanIndexNoun;
   plans: TrainingPlanDocument[];
   collections: TrainingCollection[];
   onCreate: () => void;
@@ -585,9 +659,13 @@ function PlanIndex({
   onCompare
 }: PlanIndexProps) {
   const [query, setQuery] = useState("");
-  const [scope, setScope] = useState("all");
-  const [sort, setSort] = useState<PlanSort>({ column: "updated", descending: true });
-  const [layout, setLayout] = useState<"grid" | "list">("grid");
+  const [scope, setScope] = useSelectionPreference(
+    PLAN_SCOPE_PREFERENCES[noun]
+  );
+  const [sort, setSort] = useSelectionPreference(PLAN_SORT_PREFERENCES[noun]);
+  const [layout, setLayout] = useSelectionPreference(
+    PLAN_LAYOUT_PREFERENCES[noun]
+  );
   const [selected, setSelected] = useState<string[]>([]);
 
   const summaries = useMemo(
@@ -609,6 +687,11 @@ function PlanIndex({
     if (plans.some((plan) => plan.archived)) options.push({ id: "archived", label: "Archived" });
     return options;
   }, [plans]);
+
+  const scopeAvailable = scopes.some((option) => option.id === scope);
+  useEffect(() => {
+    if (!scopeAvailable) setScope("all");
+  }, [scopeAvailable, setScope]);
 
   const visible = useMemo(() => {
     const needle = query.trim().toLowerCase();
@@ -1109,6 +1192,14 @@ const ADHERENCE_STATES: Array<{ id: string; label: string }> = [
   { id: "upcoming", label: "Upcoming" }
 ];
 
+const ADHERENCE_STATE_PREFERENCE = defineSelectionPreference<string>({
+  key: "trainingLibrary.adherenceState",
+  defaultValue: "all",
+  validate: (value): value is string =>
+    typeof value === "string" &&
+    ADHERENCE_STATES.some((option) => option.id === value)
+});
+
 interface AdherenceSectionProps {
   api: CorosLinkApi;
   matches: TrainingActivityMatch[];
@@ -1121,7 +1212,9 @@ function AdherenceSection({ api, matches, onRefresh, onMessage, onError }: Adher
   const { unitSystem } = useUnitSystem();
   const [activities, setActivities] = useState<TrainingHubActivity[]>([]);
   const [loading, setLoading] = useState(true);
-  const [state, setState] = useState("all");
+  const [state, setState] = useSelectionPreference(
+    ADHERENCE_STATE_PREFERENCE
+  );
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -1178,6 +1271,11 @@ function AdherenceSection({ api, matches, onRefresh, onMessage, onError }: Adher
   const statesPresent = ADHERENCE_STATES.filter(
     (option) => option.id === "all" || matches.some((match) => match.status === option.id)
   );
+  const stateAvailable = statesPresent.some((option) => option.id === state);
+
+  useEffect(() => {
+    if (!stateAvailable) setState("all");
+  }, [setState, stateAvailable]);
 
   const activityOptions = useMemo(
     () => [

--- a/src/training-library/TrainingLibraryView.tsx
+++ b/src/training-library/TrainingLibraryView.tsx
@@ -58,6 +58,8 @@ import { PlanEditor } from "./PlanEditor";
 import { WorkoutWorkspace } from "./WorkoutWorkspace";
 import { TrainingPlanCalendarDialog } from "./TrainingPlanCalendarDialog";
 import { TrainingPlanGenerator } from "./TrainingPlanGenerator";
+import { useUnitSystem } from "../units/UnitSystemProvider";
+import { formatDistanceValue } from "../units/units";
 import "./trainingLibrary.css";
 
 interface TrainingLibraryViewProps {
@@ -1116,6 +1118,7 @@ interface AdherenceSectionProps {
 }
 
 function AdherenceSection({ api, matches, onRefresh, onMessage, onError }: AdherenceSectionProps) {
+  const { unitSystem } = useUnitSystem();
   const [activities, setActivities] = useState<TrainingHubActivity[]>([]);
   const [loading, setLoading] = useState(true);
   const [state, setState] = useState("all");
@@ -1331,7 +1334,7 @@ function AdherenceSection({ api, matches, onRefresh, onMessage, onError }: Adher
                 const completedParts = [
                   formatDuration(match.completedDurationSeconds),
                   match.completedDistanceMeters
-                    ? `${(match.completedDistanceMeters / 1000).toFixed(1)} km`
+                    ? formatDistanceValue(match.completedDistanceMeters, unitSystem, { digits: 1 })
                     : null,
                   match.completedTrainingLoad ? `${Math.round(match.completedTrainingLoad)} load` : null
                 ].filter(Boolean);
@@ -1464,7 +1467,9 @@ function AdherenceSection({ api, matches, onRefresh, onMessage, onError }: Adher
                 </span>
                 <span className="tl-fig">{formatDuration(activity.duration)}</span>
                 <span className={`tl-fig${activity.distance ? "" : " is-nil"}`}>
-                  {activity.distance ? `${(activity.distance / 1000).toFixed(1)}` : "—"}
+                  {activity.distance
+                    ? formatDistanceValue(activity.distance, unitSystem, { digits: 1 })
+                    : "—"}
                 </span>
                 <span className={`tl-fig${activity.trainingLoad ? "" : " is-nil"}`}>
                   {activity.trainingLoad ? Math.round(activity.trainingLoad) : "—"}

--- a/src/training-library/TrainingPlanCalendarDialog.tsx
+++ b/src/training-library/TrainingPlanCalendarDialog.tsx
@@ -15,6 +15,7 @@ import type {
 } from "../../electron/types";
 import { activeTrainingPlanCalendarInstall } from "../../electron/trainingPlanDomain";
 import type { CorosLinkApi } from "../coroslink-api";
+import { useUnitSystem } from "../units/UnitSystemProvider";
 
 interface TrainingPlanCalendarDialogProps {
   api: CorosLinkApi;
@@ -51,6 +52,7 @@ function initialInstallDate(plan: TrainingPlanDocument): string {
 }
 
 export function TrainingPlanCalendarDialog({ api, plan, offline, requestedOperation, onClose, onComplete }: TrainingPlanCalendarDialogProps) {
+  const { unitSystem } = useUnitSystem();
   const install = activeTrainingPlanCalendarInstall(plan);
   const operation = requestedOperation ?? (install && !(install.state === "partial" && install.lastOperation === "install") ? "remove" : "install");
   const [startDate, setStartDate] = useState(() => initialInstallDate(plan));
@@ -102,7 +104,7 @@ export function TrainingPlanCalendarDialog({ api, plan, offline, requestedOperat
     setError(null);
     try {
       const result = operation === "install"
-        ? await api.addTrainingPlanToCalendar(preview.previewId, true)
+        ? await api.addTrainingPlanToCalendar(preview.previewId, true, unitSystem)
         : await api.removeTrainingPlanFromCalendar(preview.previewId, true);
       onComplete(result);
     } catch (cause) {

--- a/src/training-library/WorkoutWorkspace.tsx
+++ b/src/training-library/WorkoutWorkspace.tsx
@@ -23,6 +23,7 @@ import type {
   RunWorkoutEditorNode,
   TrainingCollection,
   TrainingLibraryWorkout,
+  UnitSystem,
   WorkoutEditPreview,
   WorkoutEditorDocument
 } from "../../electron/types";
@@ -34,6 +35,8 @@ import { SportBadge, sportAccentStyle, sportChipStyle, sportTheme } from "./spor
 import { SelectDropdown } from "../components/SelectDropdown";
 import { WorkoutEditorModal } from "../calendar/WorkoutEditorModal";
 import { AddWorkoutModal } from "../calendar/AddWorkoutModal";
+import { useUnitSystem } from "../units/UnitSystemProvider";
+import { formatDistanceValue, formatElevationValue } from "../units/units";
 
 interface WorkoutWorkspaceProps {
   api: CorosLinkApi;
@@ -77,6 +80,7 @@ const SHAPE_SEGMENT_LIMIT = 96;
 const SHAPE_BATCH = 3;
 /** Draws the comb a beat before the tile lands, so it is never seen filling in. */
 const SHAPE_PREFETCH_MARGIN = "160px";
+const DISTANCE_VOLUME_PATTERN = /([\d.]+)\s*(km|mi|yd|m)\b/i;
 
 /** Legend wording for the step kinds the shape bar can draw, in session order. */
 const STEP_KIND_LABELS: Record<string, string> = {
@@ -95,10 +99,27 @@ function metricFromVolume(volume: string | undefined, kind: "duration" | "distan
     const minutes = Number(value.match(/([\d.]+)\s*m(?:in)?/)?.[1] ?? 0);
     return hours * 3600 + minutes * 60;
   }
-  const distance = Number(value.match(/([\d.]+)\s*(km|mi|m)\b/)?.[1] ?? 0);
+  const distance = Number(value.match(DISTANCE_VOLUME_PATTERN)?.[1] ?? 0);
   if (value.includes(" km")) return distance * 1000;
   if (value.includes(" mi")) return distance * 1609.344;
+  if (value.includes(" yd")) return distance * 0.9144;
   return distance;
+}
+
+function formatWorkoutVolume(
+  volume: string | undefined,
+  unitSystem: UnitSystem,
+  swim = false
+): string | undefined {
+  if (!volume || !DISTANCE_VOLUME_PATTERN.test(volume)) return volume;
+  const meters = metricFromVolume(volume, "distance");
+  if (unitSystem === "metric" && !swim && meters < 1000) {
+    return `${Math.round(meters)} m`;
+  }
+  return formatDistanceValue(meters, unitSystem, {
+    swim,
+    ...(swim ? { digits: 0 } : {})
+  });
 }
 
 function tomorrow(): string {
@@ -126,17 +147,27 @@ function isSetVolume(volume: string | undefined): boolean {
   return /set/i.test(volume ?? "");
 }
 
-function targetLabel(node: RunWorkoutEditorNode): string {
+function targetLabel(
+  node: RunWorkoutEditorNode,
+  unitSystem: UnitSystem,
+  swim = false
+): string {
   if (node.nodeType === "repeat") return `${node.repeat} rounds`;
   const target = node.target;
   if (target.type === "time") return `${Math.round(target.seconds / 60)} min`;
   if (target.type === "distance") {
-    return target.meters >= 1000 ? `${(target.meters / 1000).toFixed(1)} km` : `${target.meters} m`;
+    if (unitSystem === "metric" && !swim && target.meters < 1000) {
+      return `${Math.round(target.meters)} m`;
+    }
+    return formatDistanceValue(target.meters, unitSystem, {
+      swim,
+      ...(swim ? { digits: 0 } : {})
+    });
   }
   if (target.type === "load") return `${target.load} load`;
   if (target.type === "reps") return `${target.count} reps`;
   if (target.type === "routes") return `${target.count} routes`;
-  if (target.type === "elevationGain") return `${target.meters} m gain`;
+  if (target.type === "elevationGain") return `${formatElevationValue(target.meters, unitSystem)} gain`;
   if (target.type === "hrRecovery") return `${target.bpm} bpm recovery`;
   return "Open";
 }
@@ -157,7 +188,11 @@ interface ShapeSegment {
  * proportional to how long the step runs, shaded by the step's declared kind.
  * Repeats expand, so an interval set reads as a comb.
  */
-function workoutShape(nodes: RunWorkoutEditorNode[]): ShapeSegment[] {
+function workoutShape(
+  nodes: RunWorkoutEditorNode[],
+  unitSystem: UnitSystem,
+  swim = false
+): ShapeSegment[] {
   const segments: ShapeSegment[] = [];
 
   const push = (node: RunWorkoutEditorNode) => {
@@ -171,7 +206,11 @@ function workoutShape(nodes: RunWorkoutEditorNode[]): ShapeSegment[] {
           : target.type === "reps"
             ? target.count * 4
             : 120;
-    segments.push({ kind: node.kind, share: Math.max(weight, 1), label: `${node.name} · ${targetLabel(node)}` });
+    segments.push({
+      kind: node.kind,
+      share: Math.max(weight, 1),
+      label: `${node.name} · ${targetLabel(node, unitSystem, swim)}`
+    });
   };
 
   for (const node of nodes) {
@@ -227,6 +266,7 @@ export function WorkoutWorkspace({
   onMessage,
   onError
 }: WorkoutWorkspaceProps) {
+  const { unitSystem } = useUnitSystem();
   const [query, setQuery] = useState("");
   const [scope, setScope] = useState("all");
   const [sort, setSort] = useState<WorkoutSort>({ column: "name", descending: false });
@@ -355,8 +395,8 @@ export function WorkoutWorkspace({
       batch.map(async (id) => {
         let segments: ShapeSegment[] = [];
         try {
-          const document = await api.getWorkoutForEdit({ kind: "library", programId: id }, "metric");
-          segments = workoutShape(document.draft.nodes);
+          const document = await api.getWorkoutForEdit({ kind: "library", programId: id }, unitSystem);
+          segments = workoutShape(document.draft.nodes, unitSystem, document.draft.sport === "swim");
         } catch {
           /* A tile that cannot draw its shape falls back to its load bar. */
         }
@@ -370,7 +410,7 @@ export function WorkoutWorkspace({
     return () => {
       cancelled = true;
     };
-  }, [api, shapeQueue]);
+  }, [api, shapeQueue, unitSystem]);
 
   /*
    * An edit rewrites one workout's steps. Queue that id directly rather than
@@ -389,8 +429,10 @@ export function WorkoutWorkspace({
 
   const active = workouts.find((workout) => workout.id === activeId);
   const shape = useMemo(
-    () => (previewDocument ? workoutShape(previewDocument.draft.nodes) : []),
-    [previewDocument]
+    () => previewDocument
+      ? workoutShape(previewDocument.draft.nodes, unitSystem, previewDocument.draft.sport === "swim")
+      : [],
+    [previewDocument, unitSystem]
   );
   /** Kinds actually drawn, in session order, so the legend never lists a ghost. */
   const shapeKinds = useMemo(
@@ -409,19 +451,22 @@ export function WorkoutWorkspace({
     setPreviewDocument(null);
     setPreviewMetrics(null);
     void api
-      .getWorkoutForEdit({ kind: "library", programId: activeId }, "metric")
+      .getWorkoutForEdit({ kind: "library", programId: activeId }, unitSystem)
       .then(async (document) => {
         if (cancelled) return;
         setPreviewDocument(document);
         /* The reader just paid for this workout's steps; its tile draws for free. */
         requestedShapes.current.add(activeId);
-        setShapes((current) => ({ ...current, [activeId]: workoutShape(document.draft.nodes) }));
+        setShapes((current) => ({
+          ...current,
+          [activeId]: workoutShape(document.draft.nodes, unitSystem, document.draft.sport === "swim")
+        }));
         try {
           const metrics = await api.previewWorkoutEdit(
             document.ref,
             document.revision,
             document.draft,
-            "metric"
+            unitSystem
           );
           if (!cancelled) setPreviewMetrics(metrics);
         } catch {
@@ -437,7 +482,7 @@ export function WorkoutWorkspace({
     return () => {
       cancelled = true;
     };
-  }, [api, activeId, onError]);
+  }, [api, activeId, onError, unitSystem]);
 
   const updateMetadata = async (ids: string[], patch: Parameters<CorosLinkApi["updateWorkoutMetadata"]>[1]) => {
     setBusy("metadata");
@@ -554,13 +599,16 @@ export function WorkoutWorkspace({
   const readerTime = previewMetrics?.durationSeconds
     ? `${Math.round(previewMetrics.durationSeconds / 60)}m`
     : null;
+  const activeSport = workoutSportFromType(active?.sportType);
   const readerDistance = previewMetrics?.distanceMeters
-    ? `${(previewMetrics.distanceMeters / 1000).toFixed(1)} km`
-    : (active?.volume ?? null);
+    ? formatDistanceValue(previewMetrics.distanceMeters, unitSystem, {
+        swim: activeSport === "swim",
+        ...(activeSport === "swim" ? { digits: 0 } : {})
+      })
+    : (formatWorkoutVolume(active?.volume, unitSystem, activeSport === "swim") ?? null);
   const readerLoadSource = previewMetrics?.trainingLoad || active?.trainingLoad;
   const readerLoad = readerLoadSource ? Math.round(readerLoadSource) : null;
   const readerSteps = previewDocument?.draft.nodes.length ?? null;
-  const activeSport = workoutSportFromType(active?.sportType);
   const ActiveSportIcon = sportTheme(activeSport).icon;
 
   return (
@@ -754,7 +802,7 @@ export function WorkoutWorkspace({
                     <span className="tl-wk-foot">
                       <span>
                         <VolumeIcon size={11} aria-hidden="true" />
-                        <b>{workout.volume ?? "No volume"}</b>
+                        <b>{formatWorkoutVolume(workout.volume, unitSystem, workoutSportFromType(workout.sportType) === "swim") ?? "No volume"}</b>
                       </span>
                       <span>
                         <Link2 size={11} aria-hidden="true" />
@@ -850,7 +898,7 @@ export function WorkoutWorkspace({
                       </span>
                     </button>
                     <span className={`tl-fig${workout.volume ? "" : " is-nil"}`}>
-                      {workout.volume ?? "—"}
+                      {formatWorkoutVolume(workout.volume, unitSystem, workoutSportFromType(workout.sportType) === "swim") ?? "—"}
                     </span>
                     <span className={`tl-fig${workout.trainingLoad ? "" : " is-nil"}`}>
                       {workout.trainingLoad ? Math.round(workout.trainingLoad) : "—"}
@@ -979,14 +1027,14 @@ export function WorkoutWorkspace({
                       <span className="tl-step-head">
                         <b>{node.name}</b>
                         <small className={node.nodeType === "repeat" ? "is-rounds" : ""}>
-                          {targetLabel(node)}
+                          {targetLabel(node, unitSystem, previewDocument?.draft.sport === "swim")}
                         </small>
                       </span>
                       {node.nodeType === "repeat" ? (
                         <span className="tl-step-children">
                           {node.steps.map((step) => (
                             <em key={step.id}>
-                              {step.name} <small>{targetLabel(step)}</small>
+                              {step.name} <small>{targetLabel(step, unitSystem, previewDocument?.draft.sport === "swim")}</small>
                             </em>
                           ))}
                         </span>

--- a/src/training-library/WorkoutWorkspace.tsx
+++ b/src/training-library/WorkoutWorkspace.tsx
@@ -37,6 +37,11 @@ import { WorkoutEditorModal } from "../calendar/WorkoutEditorModal";
 import { AddWorkoutModal } from "../calendar/AddWorkoutModal";
 import { useUnitSystem } from "../units/UnitSystemProvider";
 import { formatDistanceValue, formatElevationValue } from "../units/units";
+import {
+  defineSelectionPreference,
+  selectionIsOneOf,
+  useSelectionPreference
+} from "../preferences/selectionPreferences";
 
 interface WorkoutWorkspaceProps {
   api: CorosLinkApi;
@@ -67,6 +72,34 @@ const WORKOUT_SORT_OPTIONS: Array<{ value: WorkoutColumn; label: string }> = [
   { value: "load", label: "Training load" },
   { value: "used", label: "Most used" }
 ];
+
+const WORKOUT_SCOPE_PREFERENCE = defineSelectionPreference<string>({
+  key: "trainingLibrary.workouts.scope",
+  defaultValue: "all",
+  validate: (value): value is string =>
+    typeof value === "string" &&
+    (["all", "favorite", "unsettled"].includes(value) || /^sport:\d+$/.test(value))
+});
+
+const WORKOUT_SORT_PREFERENCE = defineSelectionPreference<WorkoutSort>({
+  key: "trainingLibrary.workouts.sort",
+  defaultValue: { column: "name", descending: false },
+  validate: (value): value is WorkoutSort => {
+    if (typeof value !== "object" || value === null) return false;
+    const candidate = value as Record<string, unknown>;
+    return (
+      ["name", "total", "load", "used"].includes(String(candidate.column)) &&
+      typeof candidate.descending === "boolean"
+    );
+  }
+});
+
+const WORKOUT_LAYOUT_PREFERENCE =
+  defineSelectionPreference<"grid" | "list">({
+    key: "trainingLibrary.workouts.layout",
+    defaultValue: "grid",
+    validate: selectionIsOneOf(["grid", "list"])
+  });
 
 const UNSETTLED_SYNC = new Set(["pending", "conflicted", "failed", "stale"]);
 /** Enough segments to read an interval comb without drawing thousands of them. */
@@ -268,9 +301,13 @@ export function WorkoutWorkspace({
 }: WorkoutWorkspaceProps) {
   const { unitSystem } = useUnitSystem();
   const [query, setQuery] = useState("");
-  const [scope, setScope] = useState("all");
-  const [sort, setSort] = useState<WorkoutSort>({ column: "name", descending: false });
-  const [layout, setLayout] = useState<"grid" | "list">("grid");
+  const [scope, setScope] = useSelectionPreference(
+    WORKOUT_SCOPE_PREFERENCE
+  );
+  const [sort, setSort] = useSelectionPreference(WORKOUT_SORT_PREFERENCE);
+  const [layout, setLayout] = useSelectionPreference(
+    WORKOUT_LAYOUT_PREFERENCE
+  );
   const [selected, setSelected] = useState<string[]>([]);
   const [activeId, setActiveId] = useState<string | null>(workouts[0]?.id ?? null);
   const [visibleCount, setVisibleCount] = useState(60);
@@ -309,6 +346,11 @@ export function WorkoutWorkspace({
     }
     return options;
   }, [workouts]);
+
+  const scopeAvailable = scopes.some((option) => option.id === scope);
+  useEffect(() => {
+    if (!scopeAvailable) setScope("all");
+  }, [scopeAvailable, setScope]);
 
   const filtered = useMemo(() => {
     const needle = query.trim().toLowerCase();

--- a/src/training/chartConfig.ts
+++ b/src/training/chartConfig.ts
@@ -11,9 +11,25 @@ export interface TrainingChartColors {
   grid: string;
   text: string;
   cursor: string;
+  cursorBand: string;
   dotStroke: string;
   tooltipBg: string;
   tooltipBorder: string;
+}
+
+export type TrainingMetricKey = "load" | "rpe" | "hrv" | "sleep";
+
+export interface TrainingMetricPalette {
+  /** Series stroke + resting dot color. */
+  stroke: string;
+  /** Translucent ring rendered behind the hover (active) dot. */
+  halo: string;
+  /** Soft tinted background for the header delta chip. */
+  soft: string;
+  /** Text/icon color rendered on top of `soft`. */
+  chip: string;
+  /** Vertical gradient stops for the area fill. */
+  stops: { top: string; mid: string; bottom: string };
 }
 
 const DARK_CHART_COLORS: TrainingChartColors = {
@@ -25,6 +41,7 @@ const DARK_CHART_COLORS: TrainingChartColors = {
   grid: "rgba(255, 255, 255, 0.05)",
   text: "#a1a1a6",
   cursor: "rgba(255, 255, 255, 0.1)",
+  cursorBand: "rgba(255, 255, 255, 0.05)",
   dotStroke: "rgba(12, 14, 13, 0.85)",
   tooltipBg: "rgba(18, 18, 20, 0.96)",
   tooltipBorder: "rgba(255, 255, 255, 0.12)"
@@ -39,6 +56,7 @@ const PAPER_CHART_COLORS: TrainingChartColors = {
   grid: "rgba(38, 34, 28, 0.08)",
   text: "#57544e",
   cursor: "rgba(38, 34, 28, 0.08)",
+  cursorBand: "rgba(38, 34, 28, 0.06)",
   dotStroke: "rgba(255, 255, 255, 0.9)",
   tooltipBg: "rgba(255, 255, 255, 0.98)",
   tooltipBorder: "rgba(38, 34, 28, 0.12)"
@@ -65,6 +83,75 @@ export function getTrainingChartActiveDot(theme: Theme) {
     stroke: colors.dotStroke,
     strokeWidth: 2
   };
+}
+
+const DARK_METRIC_PALETTES: Record<TrainingMetricKey, TrainingMetricPalette> = {
+  load: {
+    stroke: "#4fd6a6",
+    halo: "rgba(79, 214, 166, 0.3)",
+    soft: "rgba(79, 214, 166, 0.14)",
+    chip: "#8becc8",
+    stops: { top: "#4fd6a6", mid: "#2d9a74", bottom: "#2d9a74" }
+  },
+  rpe: {
+    stroke: "#b79bff",
+    halo: "rgba(183, 155, 255, 0.3)",
+    soft: "rgba(183, 155, 255, 0.15)",
+    chip: "#d2c1ff",
+    stops: { top: "#b79bff", mid: "#7b61c9", bottom: "#7b61c9" }
+  },
+  hrv: {
+    stroke: "#74c08f",
+    halo: "rgba(116, 192, 143, 0.3)",
+    soft: "rgba(116, 192, 143, 0.14)",
+    chip: "#a5ddb9",
+    stops: { top: "#74c08f", mid: "#2d9a74", bottom: "#2d9a74" }
+  },
+  sleep: {
+    stroke: "#7ab8ff",
+    halo: "rgba(122, 184, 255, 0.3)",
+    soft: "rgba(122, 184, 255, 0.15)",
+    chip: "#aacfff",
+    stops: { top: "#7ab8ff", mid: "#4a7fd6", bottom: "#4a7fd6" }
+  }
+};
+
+const PAPER_METRIC_PALETTES: Record<TrainingMetricKey, TrainingMetricPalette> = {
+  load: {
+    stroke: "#0f8a66",
+    halo: "rgba(15, 138, 102, 0.24)",
+    soft: "rgba(15, 138, 102, 0.12)",
+    chip: "#0b6b4f",
+    stops: { top: "#12946e", mid: "#0f7f5f", bottom: "#0f7f5f" }
+  },
+  rpe: {
+    stroke: "#7c5cd6",
+    halo: "rgba(124, 92, 214, 0.24)",
+    soft: "rgba(124, 92, 214, 0.12)",
+    chip: "#5f44ad",
+    stops: { top: "#8b6ce0", mid: "#6d4fc4", bottom: "#6d4fc4" }
+  },
+  hrv: {
+    stroke: "#0f7f5f",
+    halo: "rgba(15, 127, 95, 0.24)",
+    soft: "rgba(15, 127, 95, 0.12)",
+    chip: "#0b6550",
+    stops: { top: "#12946e", mid: "#0f7f5f", bottom: "#0f7f5f" }
+  },
+  sleep: {
+    stroke: "#3d6fd6",
+    halo: "rgba(61, 111, 214, 0.24)",
+    soft: "rgba(61, 111, 214, 0.12)",
+    chip: "#2f56ab",
+    stops: { top: "#4a80e0", mid: "#3d6fd6", bottom: "#3d6fd6" }
+  }
+};
+
+/** Per-metric series palette — gives each trend chart its own color identity. */
+export function getTrainingMetricPalettes(
+  theme: Theme
+): Record<TrainingMetricKey, TrainingMetricPalette> {
+  return theme === "paper" ? PAPER_METRIC_PALETTES : DARK_METRIC_PALETTES;
 }
 
 /** Back-compat static exports (dark palette) for any non-theme-aware callers. */

--- a/src/training/components/ActivityRouteMap.tsx
+++ b/src/training/components/ActivityRouteMap.tsx
@@ -12,6 +12,12 @@ import {
 } from "../../maps/routes/constants";
 import { MapLayerControl } from "../../maps/routes/panels";
 import { useTheme } from "../../theme/ThemeProvider";
+import {
+  defineSelectionPreference,
+  selectionIsArrayOf,
+  selectionIsOneOf,
+  useSelectionPreference
+} from "../../preferences/selectionPreferences";
 
 interface ActivityRouteMapProps {
   track?: TrainingHubActivityTrack;
@@ -27,6 +33,30 @@ const ROUTE_COLOR_PAPER = "#0f7f5f";
 const START_COLOR = "#4da3ff";
 const END_COLOR = "#d89b22";
 const ROUTE_ANIMATION_MS = 2200;
+
+const ACTIVITY_ROUTE_BASE_LAYER_PREFERENCE =
+  defineSelectionPreference<RouteBaseLayer>({
+    key: "training.activityRoute.baseLayer",
+    defaultValue: "outdoors",
+    validate: selectionIsOneOf([
+      "street",
+      "outdoors",
+      "light",
+      "dark",
+      "topo",
+      "satellite"
+    ])
+  });
+
+const ACTIVITY_ROUTE_OVERLAYS_PREFERENCE =
+  defineSelectionPreference<RouteOverlayId[]>({
+    key: "training.activityRoute.overlays",
+    defaultValue: [],
+    validate: selectionIsArrayOf(
+      selectionIsOneOf(["hiking", "cycling", "mtb"]),
+      { unique: true }
+    )
+  });
 
 function easeOutCubic(progress: number): number {
   return 1 - (1 - progress) ** 3;
@@ -355,10 +385,13 @@ function RouteLegend() {
 export function ActivityRouteMap({ track }: ActivityRouteMapProps) {
   const { theme } = useTheme();
   const [expanded, setExpanded] = useState(false);
-  const [baseLayer, setBaseLayer] = useState<RouteBaseLayer>(() =>
+  const [baseLayer, setBaseLayer] = useSelectionPreference(
+    ACTIVITY_ROUTE_BASE_LAYER_PREFERENCE,
     themeBaseLayer(theme)
   );
-  const [overlays, setOverlays] = useState<RouteOverlayId[]>([]);
+  const [overlays, setOverlays] = useSelectionPreference(
+    ACTIVITY_ROUTE_OVERLAYS_PREFERENCE
+  );
   const route = useMemo(
     () => (track?.points ? buildRouteGeometry(track.points) : null),
     [track]

--- a/src/training/components/FitnessTrendPanel.tsx
+++ b/src/training/components/FitnessTrendPanel.tsx
@@ -15,6 +15,22 @@ import {
   type WeeklyActivityMetric
 } from "../weeklyActivity";
 import { useUnitSystem } from "../../units/UnitSystemProvider";
+import {
+  defineSelectionPreference,
+  selectionIsArrayOf,
+  selectionIsOneOf,
+  useSelectionPreference
+} from "../../preferences/selectionPreferences";
+
+const FITNESS_METRICS_PREFERENCE =
+  defineSelectionPreference<WeeklyActivityMetric[]>({
+    key: "training.weeklyMetrics",
+    defaultValue: ["distance"],
+    validate: selectionIsArrayOf(selectionIsOneOf(WEEKLY_ACTIVITY_METRICS), {
+      minLength: 1,
+      unique: true
+    })
+  });
 
 interface FitnessTrendPanelProps {
   snapshot: TrainingHubSnapshot | null;
@@ -165,8 +181,8 @@ export function FitnessTrendPanel({
 }: FitnessTrendPanelProps) {
   const { unitSystem } = useUnitSystem();
   const [barsVisible, setBarsVisible] = useState(false);
-  const [selectedMetrics, setSelectedMetrics] = useState<WeeklyActivityMetric[]>(
-    ["distance"]
+  const [selectedMetrics, setSelectedMetrics] = useSelectionPreference(
+    FITNESS_METRICS_PREFERENCE
   );
   const dayList = useMemo(
     () =>

--- a/src/training/components/PersonalRecordsPanel.tsx
+++ b/src/training/components/PersonalRecordsPanel.tsx
@@ -13,6 +13,10 @@ import {
 } from "../formatters";
 import { useUnitSystem } from "../../units/UnitSystemProvider";
 import { formatDistanceValue } from "../../units/units";
+import {
+  defineSelectionPreference,
+  useSelectionPreference
+} from "../../preferences/selectionPreferences";
 
 interface PersonalRecordsPanelProps {
   dashboard: TrainingHubDashboard | null;
@@ -20,6 +24,13 @@ interface PersonalRecordsPanelProps {
 
 const RECORD_TYPE_LONGEST_RUN = 101;
 const RECORD_TYPE_ELEVATION_GAIN = 103;
+
+const PERSONAL_RECORD_GROUP_PREFERENCE = defineSelectionPreference<number>({
+  key: "training.personalRecordGroup",
+  defaultValue: 1,
+  validate: (value): value is number =>
+    typeof value === "number" && Number.isInteger(value) && value > 0
+});
 
 function recordIcon(type: number) {
   if (type === RECORD_TYPE_LONGEST_RUN) {
@@ -155,7 +166,9 @@ function LaurelBadge() {
 
 export function PersonalRecordsPanel({ dashboard }: PersonalRecordsPanelProps) {
   const groups = dashboard?.personalRecords ?? [];
-  const [activeGroupType, setActiveGroupType] = useState<number>(1);
+  const [activeGroupType, setActiveGroupType] = useSelectionPreference(
+    PERSONAL_RECORD_GROUP_PREFERENCE
+  );
 
   useEffect(() => {
     if (groups.length === 0) {

--- a/src/training/components/SleepSummaryPanel.tsx
+++ b/src/training/components/SleepSummaryPanel.tsx
@@ -1,4 +1,9 @@
-import { Loader2, MoonStar } from "lucide-react";
+import {
+  Loader2,
+  Moon,
+  MoonStar,
+  Sunrise
+} from "lucide-react";
 import { formatSleepClockRange, formatSleepNightLabel } from "../formatters";
 import type { TrainingHubSleepRecord, TrainingHubSleepSummary } from "../../../electron/types";
 
@@ -90,19 +95,72 @@ function stageTotal(record: TrainingHubSleepRecord): number {
 
 function formatNapSummary(record: TrainingHubSleepRecord): string {
   if (record.napMinutes === undefined) {
-    return "–";
+    return "No data";
   }
 
-  const duration = formatSleepDuration(record.napMinutes);
-  if (record.napStart && record.napEnd) {
-    return `${duration} · ${record.napStart}–${record.napEnd}`;
-  }
-
-  return duration;
+  return formatSleepDuration(record.napMinutes);
 }
 
-function formatSleepWindow(record: TrainingHubSleepRecord): string {
-  return formatSleepClockRange(record.sleepStart, record.sleepEnd) ?? "–";
+function formatSleepWindow(
+  record: TrainingHubSleepRecord
+): { start: string; end: string } | undefined {
+  const range = formatSleepClockRange(record.sleepStart, record.sleepEnd);
+  if (!range) {
+    return undefined;
+  }
+
+  const [start, end] = range.split(" – ");
+  return start && end ? { start, end } : undefined;
+}
+
+function formatSleepMetricDuration(minutes?: number): string {
+  const duration = formatSleepDuration(minutes);
+  return duration === "–" ? "No data" : duration;
+}
+
+function SleepMetric({
+  label,
+  value
+}: {
+  label: string;
+  value: string | number;
+}) {
+  return (
+    <div className="sleep-metric">
+      <dt>{label}</dt>
+      <dd title={String(value)}>{value}</dd>
+    </div>
+  );
+}
+
+function SleepWindowMetric({ record }: { record: TrainingHubSleepRecord }) {
+  const window = formatSleepWindow(record);
+
+  return (
+    <div className="sleep-metric is-window">
+      <dt>Sleep window</dt>
+      <dd
+        className="sleep-window-value"
+        title={window ? `${window.start} to ${window.end}` : "No data"}
+      >
+        {window ? (
+          <>
+            <span className="sleep-window-time">
+              <Moon size={13} strokeWidth={2} aria-hidden="true" />
+              {window.start}
+            </span>
+            <span className="sleep-window-arrow" aria-hidden="true">→</span>
+            <span className="sleep-window-time">
+              <Sunrise size={13} strokeWidth={2} aria-hidden="true" />
+              {window.end}
+            </span>
+          </>
+        ) : (
+          "No data"
+        )}
+      </dd>
+    </div>
+  );
 }
 
 function formatPercent(value?: number): string {
@@ -243,24 +301,21 @@ export function SleepSummaryPanel({
             </p>
           ) : null}
 
-          <div className="sleep-panel-metrics">
-            <div>
-              <span>Window</span>
-              <strong>{formatSleepWindow(latest)}</strong>
-            </div>
-            <div>
-              <span>Awake</span>
-              <strong>{formatSleepDuration(latest.awakeMinutes)}</strong>
-            </div>
-            <div>
-              <span>Awake &gt;5m</span>
-              <strong>{latest.awakeCountOverFiveMinutes ?? "–"}</strong>
-            </div>
-            <div>
-              <span>Naps</span>
-              <strong>{formatNapSummary(latest)}</strong>
-            </div>
-          </div>
+          <dl className="sleep-panel-metrics" aria-label="Sleep details">
+            <SleepWindowMetric record={latest} />
+            <SleepMetric
+              label="Awake"
+              value={formatSleepMetricDuration(latest.awakeMinutes)}
+            />
+            <SleepMetric
+              label="Wake-ups > 5m"
+              value={latest.awakeCountOverFiveMinutes ?? "No data"}
+            />
+            <SleepMetric
+              label="Naps"
+              value={formatNapSummary(latest)}
+            />
+          </dl>
         </>
       ) : null}
 

--- a/src/training/components/TrainingHeatmapPanel.tsx
+++ b/src/training/components/TrainingHeatmapPanel.tsx
@@ -38,6 +38,17 @@ import type {
 } from "../types";
 import type { UnitSystem } from "../../../electron/types";
 import { useUnitSystem } from "../../units/UnitSystemProvider";
+import {
+  defineSelectionPreference,
+  selectionIsOneOf,
+  useSelectionPreference
+} from "../../preferences/selectionPreferences";
+
+const HEATMAP_METRIC_PREFERENCE = defineSelectionPreference<HeatmapMetric>({
+  key: "training.heatmapMetric",
+  defaultValue: "trainingLoad",
+  validate: selectionIsOneOf(["trainingLoad", "rpeLoad"])
+});
 
 interface TrainingHeatmapPanelProps {
   snapshot: TrainingHubSnapshot | null;
@@ -128,7 +139,9 @@ export function TrainingHeatmapPanel({
 }: TrainingHeatmapPanelProps) {
   const { unitSystem } = useUnitSystem();
   const reducedMotion = usePrefersReducedMotion();
-  const [metric, setMetric] = useState<HeatmapMetric>("trainingLoad");
+  const [metric, setMetric] = useSelectionPreference(
+    HEATMAP_METRIC_PREFERENCE
+  );
   const gridRef = useRef<HTMLDivElement>(null);
   const pointerFrameRef = useRef<number | null>(null);
   const pointerClientRef = useRef({ x: 0, y: 0 });

--- a/src/training/components/TrainingTrendChart.tsx
+++ b/src/training/components/TrainingTrendChart.tsx
@@ -133,9 +133,16 @@ function TrendChartTooltip({
     (payload[0]?.payload as TrainingTrendPoint | undefined)?.date,
     label
   );
+  const accentColor = payload[0]?.color ?? "var(--accent)";
 
   return (
     <div className="training-chart-tooltip">
+      <span
+        className="training-chart-tooltip-accent"
+        style={{
+          background: `linear-gradient(90deg, transparent, ${accentColor}, transparent)`
+        }}
+      />
       {heading ? (
         <span className="training-chart-tooltip-label">{heading}</span>
       ) : null}
@@ -186,16 +193,28 @@ export function ChartAreaGradient({
 
 function EmptyChartNotice({
   icon: Icon,
+  palette,
+  title,
   children
 }: {
   icon: LucideIcon;
+  palette: TrainingMetricPalette;
+  title: string;
   children: string;
 }) {
   return (
-    <p className="training-empty-chart training-chart-empty">
-      <Icon size={20} aria-hidden="true" />
-      <span>{children}</span>
-    </p>
+    <div className="training-chart-empty">
+      <span
+        className="training-chart-empty-icon"
+        style={{ background: palette.soft, color: palette.chip }}
+      >
+        <Icon size={18} aria-hidden="true" />
+      </span>
+      <span className="training-chart-empty-text">
+        <strong>{title}</strong>
+        <span>{children}</span>
+      </span>
+    </div>
   );
 }
 
@@ -396,8 +415,12 @@ export function TrainingTrendCharts({ points }: TrainingTrendChartsProps) {
             </ResponsiveContainer>
           </div>
         ) : (
-          <EmptyChartNotice icon={Activity}>
-            No training load data this week.
+          <EmptyChartNotice
+            icon={Activity}
+            palette={metrics.load}
+            title="No training load yet"
+          >
+            Complete a workout and sync from COROS to see your load trend.
           </EmptyChartNotice>
         )}
       </section>
@@ -445,8 +468,12 @@ export function TrainingTrendCharts({ points }: TrainingTrendChartsProps) {
             </ResponsiveContainer>
           </div>
         ) : (
-          <EmptyChartNotice icon={Gauge}>
-            No RPE data yet — rate activities in COROS.
+          <EmptyChartNotice
+            icon={Gauge}
+            palette={metrics.rpe}
+            title="No RPE data yet"
+          >
+            Rate your activities in COROS to track perceived effort.
           </EmptyChartNotice>
         )}
       </section>
@@ -514,8 +541,12 @@ export function TrainingTrendCharts({ points }: TrainingTrendChartsProps) {
             </ResponsiveContainer>
           </div>
         ) : (
-          <EmptyChartNotice icon={HeartPulse}>
-            No HRV data this week.
+          <EmptyChartNotice
+            icon={HeartPulse}
+            palette={metrics.hrv}
+            title="No HRV readings"
+          >
+            Wear your device during sleep to capture nightly HRV.
           </EmptyChartNotice>
         )}
       </section>
@@ -567,8 +598,12 @@ export function TrainingTrendCharts({ points }: TrainingTrendChartsProps) {
             </ResponsiveContainer>
           </div>
         ) : (
-          <EmptyChartNotice icon={MoonStar}>
-            No sleep duration data this week.
+          <EmptyChartNotice
+            icon={MoonStar}
+            palette={metrics.sleep}
+            title="No sleep data"
+          >
+            Sync sleep sessions from COROS to see duration trends.
           </EmptyChartNotice>
         )}
       </section>

--- a/src/training/components/TrainingTrendChart.tsx
+++ b/src/training/components/TrainingTrendChart.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useState } from "react";
 import {
+  Activity,
+  ArrowDownRight,
+  ArrowUpRight,
+  Gauge,
+  HeartPulse,
+  MoonStar
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import {
   Area,
   AreaChart,
   CartesianGrid,
@@ -15,11 +24,60 @@ import {
   trainingChartMargin,
   trainingChartTooltipStyle
 } from "../chartConfig";
+import type { TrainingMetricPalette } from "../chartConfig";
 import { useChartColors } from "../useChartColors";
 import type { TrainingTrendPoint } from "../types";
 
 interface TrainingTrendChartsProps {
   points: TrainingTrendPoint[];
+}
+
+type ChartValueFormatter = (value: number) => string;
+
+function formatRoundedValue(value: number): string {
+  return new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: 1
+  }).format(value);
+}
+
+function formatSleepDuration(value: number): string {
+  const totalMinutes = Math.max(0, Math.round(value));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours === 0) {
+    return `${minutes}m`;
+  }
+
+  return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+}
+
+function formatSleepAxisTick(value: number): string {
+  return `${formatRoundedValue(value / 60)}h`;
+}
+
+function formatTooltipValue(
+  value: unknown,
+  valueFormatter?: ChartValueFormatter
+): string {
+  const numericValue =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number(value)
+        : Number.NaN;
+
+  if (Number.isFinite(numericValue)) {
+    return valueFormatter
+      ? valueFormatter(numericValue)
+      : formatRoundedValue(numericValue);
+  }
+
+  if (Array.isArray(value)) {
+    return value.join(" – ");
+  }
+
+  return value === undefined || value === null ? "—" : String(value);
 }
 
 function usePrefersReducedMotion() {
@@ -38,31 +96,159 @@ function usePrefersReducedMotion() {
   return reducedMotion;
 }
 
-function TrendChartTooltip({ active, payload, label }: TooltipContentProps) {
+function formatTooltipHeading(date: unknown, fallback: unknown): string {
+  const raw =
+    typeof date === "string" && /^\d{8}$/.test(date) ? date : undefined;
+
+  if (!raw) {
+    return typeof fallback === "string" || typeof fallback === "number"
+      ? String(fallback)
+      : "";
+  }
+
+  const parsed = new Date(
+    Number(raw.slice(0, 4)),
+    Number(raw.slice(4, 6)) - 1,
+    Number(raw.slice(6, 8))
+  );
+
+  return parsed.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric"
+  });
+}
+
+function TrendChartTooltip({
+  active,
+  payload,
+  label,
+  valueFormatter
+}: TooltipContentProps & { valueFormatter?: ChartValueFormatter }) {
   if (!active || !payload?.length) {
     return null;
   }
 
+  const heading = formatTooltipHeading(
+    (payload[0]?.payload as TrainingTrendPoint | undefined)?.date,
+    label
+  );
+
   return (
-    <div className="training-zone-tooltip training-chart-tooltip">
-      {label ? <span>{label}</span> : null}
-      {payload.map((entry) => (
-        <strong key={String(entry.dataKey ?? entry.name)}>
-          {entry.name}: {entry.value}
-        </strong>
-      ))}
+    <div className="training-chart-tooltip">
+      {heading ? (
+        <span className="training-chart-tooltip-label">{heading}</span>
+      ) : null}
+      <ul className="training-chart-tooltip-rows">
+        {payload.map((entry) => {
+          const dotColor = entry.color ?? "var(--accent)";
+          return (
+            <li
+              className="training-chart-tooltip-row"
+              key={String(entry.dataKey ?? entry.name)}
+            >
+              <span className="training-chart-tooltip-key">
+                <i
+                  aria-hidden="true"
+                  style={{
+                    background: dotColor,
+                    boxShadow: `0 0 8px ${dotColor}`
+                  }}
+                />
+                {entry.name}
+              </span>
+              <strong>{formatTooltipValue(entry.value, valueFormatter)}</strong>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }
 
-export function ChartAreaGradient({ id }: { id: string }) {
+export function ChartAreaGradient({
+  id,
+  stops
+}: {
+  id: string;
+  stops?: { top: string; mid: string; bottom: string };
+}) {
   const { fillStops } = useChartColors();
+  const resolved = stops ?? fillStops;
   return (
     <linearGradient id={id} x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stopColor={fillStops.top} stopOpacity={0.5} />
-      <stop offset="55%" stopColor={fillStops.mid} stopOpacity={0.16} />
-      <stop offset="100%" stopColor={fillStops.bottom} stopOpacity={0} />
+      <stop offset="0%" stopColor={resolved.top} stopOpacity={0.5} />
+      <stop offset="55%" stopColor={resolved.mid} stopOpacity={0.16} />
+      <stop offset="100%" stopColor={resolved.bottom} stopOpacity={0} />
     </linearGradient>
+  );
+}
+
+function EmptyChartNotice({
+  icon: Icon,
+  children
+}: {
+  icon: LucideIcon;
+  children: string;
+}) {
+  return (
+    <p className="training-empty-chart training-chart-empty">
+      <Icon size={20} aria-hidden="true" />
+      <span>{children}</span>
+    </p>
+  );
+}
+
+interface ChartLatestStatProps {
+  points: TrainingTrendPoint[];
+  dataKey: keyof Pick<
+    TrainingTrendPoint,
+    "trainingLoad" | "rpeLoad" | "avgSleepHrv" | "sleepMinutes"
+  >;
+  palette: TrainingMetricPalette;
+  formatValue: ChartValueFormatter;
+  formatDelta: (delta: number) => string;
+}
+
+function ChartLatestStat({
+  points,
+  dataKey,
+  palette,
+  formatValue,
+  formatDelta
+}: ChartLatestStatProps) {
+  const values = points
+    .map((point) => point[dataKey])
+    .filter(
+      (value): value is number =>
+        typeof value === "number" && Number.isFinite(value)
+    );
+
+  if (values.length === 0) {
+    return null;
+  }
+
+  const latest = values[values.length - 1]!;
+  const previous = values.length > 1 ? values[values.length - 2]! : undefined;
+  const delta = previous === undefined ? undefined : latest - previous;
+
+  return (
+    <div className="training-chart-stat">
+      <span className="training-chart-stat-value">{formatValue(latest)}</span>
+      {delta !== undefined && Math.abs(delta) > 1e-9 ? (
+        <span
+          className="training-chart-stat-delta"
+          style={{ background: palette.soft, color: palette.chip }}
+        >
+          {delta > 0 ? (
+            <ArrowUpRight size={12} strokeWidth={2.5} aria-hidden="true" />
+          ) : (
+            <ArrowDownRight size={12} strokeWidth={2.5} aria-hidden="true" />
+          )}
+          {formatDelta(Math.abs(delta))}
+        </span>
+      ) : null}
+    </div>
   );
 }
 
@@ -81,14 +267,34 @@ function HrvChartLegend() {
   );
 }
 
-function TrendChartAxes() {
+type TrendAxisDomain = [
+  number | ((dataMin: number) => number),
+  number | ((dataMax: number) => number)
+];
+
+/** Zero-based domain with a little headroom so peaks never touch the panel. */
+function paddedZeroDomain(dataMax: number): number {
+  return Math.ceil(dataMax * 1.15) || 1;
+}
+
+function TrendChartAxes({
+  tooltipValueFormatter,
+  yAxisTickFormatter,
+  yAxisWidth = 36,
+  yAxisDomain
+}: {
+  tooltipValueFormatter?: ChartValueFormatter;
+  yAxisTickFormatter?: ChartValueFormatter;
+  yAxisWidth?: number;
+  yAxisDomain?: TrendAxisDomain;
+}) {
   const { colors } = useChartColors();
   return (
     <>
       <CartesianGrid
         stroke={colors.grid}
         vertical={false}
-        strokeDasharray="3 6"
+        strokeDasharray="2 8"
       />
       <XAxis
         dataKey="label"
@@ -96,17 +302,26 @@ function TrendChartAxes() {
         axisLine={false}
         tickLine={false}
         dy={8}
+        padding={{ left: 14, right: 14 }}
       />
       <YAxis
         tick={{ fill: colors.text, fontSize: 11, fontWeight: 500 }}
         axisLine={false}
         tickLine={false}
-        width={36}
+        tickFormatter={yAxisTickFormatter}
+        width={yAxisWidth}
+        tickCount={5}
+        domain={yAxisDomain ?? [0, paddedZeroDomain]}
       />
       <Tooltip
-        content={(props) => <TrendChartTooltip {...props} />}
+        content={(props) => (
+          <TrendChartTooltip
+            {...props}
+            valueFormatter={tooltipValueFormatter}
+          />
+        )}
         contentStyle={trainingChartTooltipStyle}
-        cursor={{ stroke: colors.cursor, strokeWidth: 1 }}
+        cursor={{ stroke: colors.cursorBand, strokeWidth: 26 }}
       />
     </>
   );
@@ -114,13 +329,21 @@ function TrendChartAxes() {
 
 export function TrainingTrendCharts({ points }: TrainingTrendChartsProps) {
   const reducedMotion = usePrefersReducedMotion();
-  const { colors, activeDot } = useChartColors();
-  const trendDot = {
+  const { colors, metrics } = useChartColors();
+
+  const metricDot = (palette: TrainingMetricPalette) => ({
     r: 3,
-    fill: colors.accentGlow,
+    fill: palette.stroke,
     stroke: colors.dotStroke,
     strokeWidth: 2
-  };
+  });
+  const metricActiveDot = (palette: TrainingMetricPalette) => ({
+    r: 5,
+    fill: palette.stroke,
+    stroke: palette.halo,
+    strokeWidth: 6
+  });
+
   const loadPoints = points.filter((point) => point.trainingLoad !== undefined);
   const rpePoints = points.filter((point) => point.rpeLoad !== undefined);
   const hrvPoints = points.filter(
@@ -130,30 +353,42 @@ export function TrainingTrendCharts({ points }: TrainingTrendChartsProps) {
 
   return (
     <div className="training-chart-grid">
-      <section className="panel training-chart-panel">
-        <div className="section-heading compact">
+      <section className="panel training-chart-panel" data-metric="load">
+        <div className="section-heading compact training-chart-heading">
           <div>
             <p className="eyebrow">Training Load</p>
             <h2>Last 7 days</h2>
           </div>
+          {loadPoints.length > 0 ? (
+            <ChartLatestStat
+              points={loadPoints}
+              dataKey="trainingLoad"
+              palette={metrics.load}
+              formatValue={formatRoundedValue}
+              formatDelta={formatRoundedValue}
+            />
+          ) : null}
         </div>
         {loadPoints.length > 0 ? (
           <div className="training-chart-shell">
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={loadPoints} margin={trainingChartMargin}>
                 <defs>
-                  <ChartAreaGradient id="trainingLoadFill" />
+                  <ChartAreaGradient
+                    id="trainingLoadFill"
+                    stops={metrics.load.stops}
+                  />
                 </defs>
                 <TrendChartAxes />
                 <Area
                   type="monotone"
                   dataKey="trainingLoad"
-                  name="Load"
-                  stroke={colors.accentBright}
+                  name="Training load"
+                  stroke={metrics.load.stroke}
                   fill="url(#trainingLoadFill)"
                   strokeWidth={2.5}
-                  dot={trendDot}
-                  activeDot={activeDot}
+                  dot={metricDot(metrics.load)}
+                  activeDot={metricActiveDot(metrics.load)}
                   isAnimationActive={!reducedMotion}
                   animationDuration={900}
                 />
@@ -161,34 +396,47 @@ export function TrainingTrendCharts({ points }: TrainingTrendChartsProps) {
             </ResponsiveContainer>
           </div>
         ) : (
-          <p className="training-empty-chart">No training load data this week.</p>
+          <EmptyChartNotice icon={Activity}>
+            No training load data this week.
+          </EmptyChartNotice>
         )}
       </section>
 
-      <section className="panel training-chart-panel">
-        <div className="section-heading compact">
+      <section className="panel training-chart-panel" data-metric="rpe">
+        <div className="section-heading compact training-chart-heading">
           <div>
-            <p className="eyebrow">RPE Load</p>
+            <p className="eyebrow">RPE Load · AU</p>
             <h2>Last 7 days</h2>
           </div>
+          {rpePoints.length > 0 ? (
+            <ChartLatestStat
+              points={rpePoints}
+              dataKey="rpeLoad"
+              palette={metrics.rpe}
+              formatValue={(value) => `${formatRoundedValue(value)} AU`}
+              formatDelta={(delta) => `${formatRoundedValue(delta)} AU`}
+            />
+          ) : null}
         </div>
         {rpePoints.length > 0 ? (
           <div className="training-chart-shell">
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={rpePoints} margin={trainingChartMargin}>
                 <defs>
-                  <ChartAreaGradient id="rpeLoadFill" />
+                  <ChartAreaGradient id="rpeLoadFill" stops={metrics.rpe.stops} />
                 </defs>
-                <TrendChartAxes />
+                <TrendChartAxes
+                  tooltipValueFormatter={(value) => `${formatRoundedValue(value)} AU`}
+                />
                 <Area
                   type="monotone"
                   dataKey="rpeLoad"
-                  name="RPE"
-                  stroke={colors.accentBright}
+                  name="RPE load"
+                  stroke={metrics.rpe.stroke}
                   fill="url(#rpeLoadFill)"
                   strokeWidth={2.5}
-                  dot={trendDot}
-                  activeDot={activeDot}
+                  dot={metricDot(metrics.rpe)}
+                  activeDot={metricActiveDot(metrics.rpe)}
                   connectNulls
                   isAnimationActive={!reducedMotion}
                   animationDuration={900}
@@ -197,37 +445,54 @@ export function TrainingTrendCharts({ points }: TrainingTrendChartsProps) {
             </ResponsiveContainer>
           </div>
         ) : (
-          <p className="training-empty-chart">
+          <EmptyChartNotice icon={Gauge}>
             No RPE data yet — rate activities in COROS.
-          </p>
+          </EmptyChartNotice>
         )}
       </section>
 
-      <section className="panel training-chart-panel">
+      <section className="panel training-chart-panel" data-metric="hrv">
         <div className="section-heading compact training-chart-heading">
           <div>
-            <p className="eyebrow">HRV vs Baseline</p>
+            <p className="eyebrow">HRV vs Baseline · ms</p>
             <h2>Last 7 days</h2>
           </div>
-          <HrvChartLegend />
+          <div className="training-chart-heading-side">
+            {hrvPoints.length > 0 ? (
+              <ChartLatestStat
+                points={hrvPoints}
+                dataKey="avgSleepHrv"
+                palette={metrics.hrv}
+                formatValue={(value) => `${formatRoundedValue(value)} ms`}
+                formatDelta={(delta) => `${formatRoundedValue(delta)} ms`}
+              />
+            ) : null}
+            <HrvChartLegend />
+          </div>
         </div>
         {hrvPoints.length > 0 ? (
           <div className="training-chart-shell">
             <ResponsiveContainer width="100%" height="100%">
               <ComposedChart data={hrvPoints} margin={trainingChartMargin}>
                 <defs>
-                  <ChartAreaGradient id="hrvFill" />
+                  <ChartAreaGradient id="hrvFill" stops={metrics.hrv.stops} />
                 </defs>
-                <TrendChartAxes />
+                <TrendChartAxes
+                  tooltipValueFormatter={(value) => `${formatRoundedValue(value)} ms`}
+                  yAxisDomain={[
+                    (dataMin: number) => Math.max(0, Math.floor(dataMin - 14)),
+                    (dataMax: number) => Math.ceil(dataMax + 12) || 1
+                  ]}
+                />
                 <Area
                   type="monotone"
                   dataKey="avgSleepHrv"
                   name="HRV"
-                  stroke={colors.accentBright}
+                  stroke={metrics.hrv.stroke}
                   fill="url(#hrvFill)"
                   strokeWidth={2.5}
-                  dot={trendDot}
-                  activeDot={activeDot}
+                  dot={metricDot(metrics.hrv)}
+                  activeDot={metricActiveDot(metrics.hrv)}
                   connectNulls
                   isAnimationActive={!reducedMotion}
                   animationDuration={850}
@@ -249,34 +514,52 @@ export function TrainingTrendCharts({ points }: TrainingTrendChartsProps) {
             </ResponsiveContainer>
           </div>
         ) : (
-          <p className="training-empty-chart">No HRV data this week.</p>
+          <EmptyChartNotice icon={HeartPulse}>
+            No HRV data this week.
+          </EmptyChartNotice>
         )}
       </section>
 
-      <section className="panel training-chart-panel">
-        <div className="section-heading compact">
+      <section className="panel training-chart-panel" data-metric="sleep">
+        <div className="section-heading compact training-chart-heading">
           <div>
-            <p className="eyebrow">Sleep Duration</p>
+            <p className="eyebrow">Sleep Duration · hours</p>
             <h2>Last 7 days</h2>
           </div>
+          {sleepPoints.length > 0 ? (
+            <ChartLatestStat
+              points={sleepPoints}
+              dataKey="sleepMinutes"
+              palette={metrics.sleep}
+              formatValue={formatSleepDuration}
+              formatDelta={formatSleepDuration}
+            />
+          ) : null}
         </div>
         {sleepPoints.length > 0 ? (
           <div className="training-chart-shell">
             <ResponsiveContainer width="100%" height="100%">
               <AreaChart data={sleepPoints} margin={trainingChartMargin}>
                 <defs>
-                  <ChartAreaGradient id="sleepDurationFill" />
+                  <ChartAreaGradient
+                    id="sleepDurationFill"
+                    stops={metrics.sleep.stops}
+                  />
                 </defs>
-                <TrendChartAxes />
+                <TrendChartAxes
+                  tooltipValueFormatter={formatSleepDuration}
+                  yAxisTickFormatter={formatSleepAxisTick}
+                  yAxisWidth={42}
+                />
                 <Area
                   type="monotone"
                   dataKey="sleepMinutes"
-                  name="Sleep"
-                  stroke={colors.accentBright}
+                  name="Sleep duration"
+                  stroke={metrics.sleep.stroke}
                   fill="url(#sleepDurationFill)"
                   strokeWidth={2.5}
-                  dot={trendDot}
-                  activeDot={activeDot}
+                  dot={metricDot(metrics.sleep)}
+                  activeDot={metricActiveDot(metrics.sleep)}
                   isAnimationActive={!reducedMotion}
                   animationDuration={900}
                 />
@@ -284,7 +567,9 @@ export function TrainingTrendCharts({ points }: TrainingTrendChartsProps) {
             </ResponsiveContainer>
           </div>
         ) : (
-          <p className="training-empty-chart">No sleep duration data this week.</p>
+          <EmptyChartNotice icon={MoonStar}>
+            No sleep duration data this week.
+          </EmptyChartNotice>
         )}
       </section>
     </div>

--- a/src/training/components/TrainingZoneDistributionCharts.tsx
+++ b/src/training/components/TrainingZoneDistributionCharts.tsx
@@ -21,6 +21,11 @@ import { formatDistanceMeters, formatDurationSeconds } from "../formatters";
 import type { UnitSystem } from "../../../electron/types";
 import { useUnitSystem } from "../../units/UnitSystemProvider";
 import { distanceUnit, metersToDisplayDistance } from "../../units/units";
+import {
+  defineSelectionPreference,
+  selectionIsOneOf,
+  useSelectionPreference
+} from "../../preferences/selectionPreferences";
 
 interface TrainingZoneDistributionChartsProps {
   lthrZones: TrainingHubThresholdZone[];
@@ -153,6 +158,26 @@ const RPE_METRIC_OPTIONS: MetricDropdownOption<RpeMetric>[] = [
   { value: "srpe", label: RPE_METRIC_LABELS.srpe },
   { value: "time", label: RPE_METRIC_LABELS.time }
 ];
+
+const HEART_RATE_METRIC_PREFERENCE =
+  defineSelectionPreference<ActivityMetric>({
+    key: "training.heartRateDistributionMetric",
+    defaultValue: "trainingLoad",
+    validate: selectionIsOneOf(["trainingLoad", "distance", "time"])
+  });
+
+const DISTANCE_METRIC_PREFERENCE =
+  defineSelectionPreference<DistanceMetric>({
+    key: "training.distanceDistributionMetric",
+    defaultValue: "frequency",
+    validate: selectionIsOneOf(["frequency", "trainingLoad", "time"])
+  });
+
+const RPE_METRIC_PREFERENCE = defineSelectionPreference<RpeMetric>({
+  key: "training.rpeDistributionMetric",
+  defaultValue: "frequency",
+  validate: selectionIsOneOf(["frequency", "srpe", "time"])
+});
 
 const FOUR_WEEKS_MS = 28 * 24 * 60 * 60 * 1000;
 
@@ -953,10 +978,12 @@ export function TrainingZoneDistributionCharts({
   analytics
 }: TrainingZoneDistributionChartsProps) {
   const { unitSystem } = useUnitSystem();
-  const [heartRateMetric, setHeartRateMetric] =
-    useState<ActivityMetric>("trainingLoad");
-  const [distanceMetric, setDistanceMetric] =
-    useState<DistanceMetric>("frequency");
+  const [heartRateMetric, setHeartRateMetric] = useSelectionPreference(
+    HEART_RATE_METRIC_PREFERENCE
+  );
+  const [distanceMetric, setDistanceMetric] = useSelectionPreference(
+    DISTANCE_METRIC_PREFERENCE
+  );
 
   return (
     <section className="training-load-profile">
@@ -1021,7 +1048,9 @@ export function TrainingZoneDistributionCharts({
 export function PerceivedEffortPanel({
   distribution
 }: PerceivedEffortPanelProps) {
-  const [rpeMetric, setRpeMetric] = useState<RpeMetric>("frequency");
+  const [rpeMetric, setRpeMetric] = useSelectionPreference(
+    RPE_METRIC_PREFERENCE
+  );
   const coverage = distribution?.coverage;
   const coverageNote =
     coverage && coverage.total > 0

--- a/src/training/useChartColors.ts
+++ b/src/training/useChartColors.ts
@@ -3,7 +3,8 @@ import { useTheme } from "../theme/ThemeProvider";
 import {
   getTrainingChartActiveDot,
   getTrainingChartColors,
-  getTrainingChartFillStops
+  getTrainingChartFillStops,
+  getTrainingMetricPalettes
 } from "./chartConfig";
 
 /** Theme-aware chart palette derived from the active app theme. */
@@ -13,7 +14,8 @@ export function useChartColors() {
     () => ({
       colors: getTrainingChartColors(theme),
       fillStops: getTrainingChartFillStops(theme),
-      activeDot: getTrainingChartActiveDot(theme)
+      activeDot: getTrainingChartActiveDot(theme),
+      metrics: getTrainingMetricPalettes(theme)
     }),
     [theme]
   );

--- a/src/watchfaces/WatchfacesView.tsx
+++ b/src/watchfaces/WatchfacesView.tsx
@@ -92,6 +92,11 @@ import multidataElevFace from "../assets/watchfaces/multidata-elev.png";
 import planetFace from "../assets/watchfaces/planet.png";
 import preClassicFace from "../assets/watchfaces/pre-classic.png";
 import snowingFace from "../assets/watchfaces/snowing.png";
+import {
+  defineSelectionPreference,
+  selectionIsOneOf,
+  useSelectionPreference
+} from "../preferences/selectionPreferences";
 import "./watchfaces.css";
 
 const AUTH_WATCH_FACE_PREVIEWS = [
@@ -126,6 +131,42 @@ interface WatchfacesViewProps {
 
 type WatchfaceSurface = "sign-in" | "hub" | "studio";
 type HubTab = "browse" | "projects" | "templates";
+
+const WATCHFACE_HUB_TAB_PREFERENCE = defineSelectionPreference<HubTab>({
+  key: "watchfaces.hubTab",
+  defaultValue: "templates",
+  validate: selectionIsOneOf(["browse", "projects", "templates"])
+});
+
+const WATCHFACE_CATALOG_PREFERENCE =
+  defineSelectionPreference<CorosWatchfaceThemeCatalog>({
+    key: "watchfaces.templateCatalog",
+    defaultValue: "editable",
+    validate: selectionIsOneOf(["editable", "official", "custom"])
+  });
+
+function isShortFilterValue(value: unknown): value is string {
+  return typeof value === "string" && value.length <= 120;
+}
+
+const COMMUNITY_MODEL_PREFERENCE = defineSelectionPreference<string>({
+  key: "watchfaces.community.model",
+  defaultValue: "",
+  validate: isShortFilterValue
+});
+
+const COMMUNITY_STYLE_PREFERENCE = defineSelectionPreference<string>({
+  key: "watchfaces.community.style",
+  defaultValue: "",
+  validate: isShortFilterValue
+});
+
+const COMMUNITY_SORT_PREFERENCE =
+  defineSelectionPreference<"newest" | "title">({
+    key: "watchfaces.community.sort",
+    defaultValue: "newest",
+    validate: selectionIsOneOf(["newest", "title"])
+  });
 
 interface StudioSession {
   id: string;
@@ -199,7 +240,9 @@ export function WatchfacesView({
 }: WatchfacesViewProps) {
   const [status, setStatus] = useState<CorosWatchfaceStatus | null>(null);
   const [surface, setSurface] = useState<WatchfaceSurface>("hub");
-  const [hubTab, setHubTab] = useState<HubTab>("templates");
+  const [hubTab, setHubTab] = useSelectionPreference(
+    WATCHFACE_HUB_TAB_PREFERENCE
+  );
   const [studioSession, setStudioSession] = useState<StudioSession | null>(null);
   const [conversionDraft, setConversionDraft] =
     useState<WatchfaceConversionDraft | null>(null);
@@ -225,8 +268,9 @@ export function WatchfacesView({
   const [backgroundImageId, setBackgroundImageId] = useState("13");
   const [language, setLanguage] = useState("en-US");
   const [maxWatchFaceVersion, setMaxWatchFaceVersion] = useState("5");
-  const [themeCatalog, setThemeCatalog] =
-    useState<CorosWatchfaceThemeCatalog>("editable");
+  const [themeCatalog, setThemeCatalog] = useSelectionPreference(
+    WATCHFACE_CATALOG_PREFERENCE
+  );
   const [watchSerial, setWatchSerial] = useState("x");
   const [modelVersion, setModelVersion] = useState(DEFAULT_MODEL_VERSION);
   const [themes, setThemes] = useState<CorosWatchfaceTheme[]>([]);
@@ -1723,9 +1767,14 @@ function CommunityWatchfaceBrowser({
 }) {
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
-  const [model, setModel] = useState(connectedModel ?? "");
-  const [style, setStyle] = useState("");
-  const [sort, setSort] = useState<"newest" | "title">("newest");
+  const [model, setModel, modelPreference] = useSelectionPreference(
+    COMMUNITY_MODEL_PREFERENCE,
+    connectedModel ?? ""
+  );
+  const [style, setStyle] = useSelectionPreference(
+    COMMUNITY_STYLE_PREFERENCE
+  );
+  const [sort, setSort] = useSelectionPreference(COMMUNITY_SORT_PREFERENCE);
   const [page, setPage] = useState(1);
   const [catalog, setCatalog] =
     useState<CommunityWatchfaceCatalogPage | null>(null);
@@ -1733,7 +1782,7 @@ function CommunityWatchfaceBrowser({
   const [loadError, setLoadError] = useState<string | null>(null);
   const [retry, setRetry] = useState(0);
   const [selected, setSelected] = useState<CommunityWatchface | null>(null);
-  const modelTouchedRef = useRef(false);
+  const modelTouchedRef = useRef(modelPreference.restored);
 
   useEffect(() => {
     const timeout = window.setTimeout(() => {
@@ -1780,6 +1829,30 @@ function CommunityWatchfaceBrowser({
       cancelled = true;
     };
   }, [api, debouncedSearch, model, page, retry, sort, style]);
+
+  const modelAvailable =
+    !model ||
+    !catalog ||
+    catalog.facets.models.some((available) => available === model);
+  const styleAvailable =
+    !style ||
+    !catalog ||
+    catalog.facets.styles.some((available) => available.value === style);
+
+  useEffect(() => {
+    if (!modelAvailable) {
+      modelTouchedRef.current = true;
+      setModel("");
+      setPage(1);
+    }
+  }, [modelAvailable, setModel]);
+
+  useEffect(() => {
+    if (!styleAvailable) {
+      setStyle("");
+      setPage(1);
+    }
+  }, [setStyle, styleAvailable]);
 
   const percent =
     progress?.totalBytes && progress.totalBytes > 0


### PR DESCRIPTION
## What changed

- Improve calendar positioning, sidebar navigation, conversation history, and generated-plan review.
- Add model selection and persisted provider/model settings for supported chat backends.
- Refresh the training dashboard with richer trend charts, sleep summaries, chart colors, tooltips, and responsive presentation.
- Remember durable view choices across sessions, including analytics ranges and metrics, tabs, filters, sorting, layouts, map layers, calendar mode, library views, and watch-face catalog filters.
- Pass the selected metric or imperial unit system through Training Library calendar installs and format workout summaries consistently.

## Why

Several frequently used views reset to hard-coded defaults after navigation or restart, chat model choice was not surfaced consistently, and the training dashboard needed clearer visual hierarchy. Generated-plan installs also bypassed the selected unit system in parts of the COROS calendar workflow.

## User impact

Users keep their preferred views and filters, can choose the appropriate chat model, get a clearer training dashboard, and review generated plans with better navigation. Calendar-installed workouts now respect the selected unit system while existing linked workouts retain their saved units.

## Validation

- `npm run build`
- `npm run test:chat-service`
- `npm run test:selection-preferences`
- `npm run test:training-library`
- `npm run test:training-formatters`
- `npm run test:units`
- `git diff --check`
