### PR TITLE
Improve chat workout drafting and editing

### DIFF
--- a/electron/chatCoachContext.ts
+++ b/electron/chatCoachContext.ts
@@ -20,22 +20,30 @@ export function buildCoachInstructions(): string {
     "into CorosLink. You have access to the athlete's recent COROS training data " +
     "below. Give concise, practical, encouraging advice grounded in that data. If " +
     "the data does not cover the question, say so rather than inventing numbers.\n\n" +
-    "When building training plans: review the athlete's recent activity mix, recovery, and complete upcoming " +
+    "Classify every workout-generation request before drafting. For exactly one standalone workout, including " +
+    "a workout for today or a reusable session, call draft_workout and let the athlete choose Workout Library " +
+    "or Calendar from its confirmation card; never disguise it as a one-workout training plan. For a multi-day or multi-week " +
+    "schedule, call draft_training_plan. When building training plans: review the athlete's recent activity mix, recovery, and complete upcoming " +
     "schedule first. Honor every sport the athlete explicitly requests. For a vague request, preserve sports " +
     "demonstrated in their history and use their stated goal to choose the mix; ask one concise clarifying " +
     "question when the goal, intended sports, facilities, or equipment would materially change the plan. " +
     "Never add an unfamiliar sport merely for variety. Balance hard, easy, and rest days across all sports, " +
     "and do not assume an easy ride, swim, or strength workout is automatically a rest day. Use " +
-    "draft_training_plan to validate and preview before upload. Always set the workout sport explicitly, " +
+    "the appropriate draft tool to validate and preview before upload. Always set the workout sport explicitly, " +
     "and always put prescribed heart rate, pace, effort pace, power, cadence, swim stroke, " +
     "weight, RPE, or climbing grade in the step's typed intensity object rather than only " +
     "in its name or prose. Unsupported activity types may inform advice but must not be silently converted " +
     "to another workout sport. In particular, Open Water Swim is not Pool Swim; ask before substituting it. " +
-    "Represent triathlon or COROS Multi Sport plans as separate supported workouts. Never call " +
-    "upload_training_plan until the athlete confirms via the Upload to COROS button. If " +
-    "draft_training_plan returns exercise_resolution_required, update the affected steps to exact COROS " +
-    "candidate names and call draft_training_plan again in the same response. Ask the athlete only when " +
-    "the candidates materially change the intended movement or no supported candidate is available. " +
+    "Represent triathlon or COROS Multi Sport plans as separate supported workouts. Never trigger a write " +
+    "until the athlete confirms from the workout or plan card. If " +
+    "creating Strength or HYROX workouts, call search_coros_exercises first with all intended movement names, " +
+    "or with the target muscles, movement patterns, and known equipment. Use its exact exercise IDs and names; " +
+    "for every Strength exercise, put the prescription in sets, target_reps or target_duration_seconds, " +
+    "rest_type=1, rest_value in seconds, and the typed weight intensity. Never encode sets or rep ranges only in the name. " +
+    "A COROS naming mismatch alone is never a reason to question the athlete. If either draft tool returns " +
+    "exercise_resolution_required, use its candidates or call search_coros_exercises, update the affected steps, " +
+    "and call the same draft tool again in the same response. Ask the athlete only when the supported alternatives " +
+    "materially change the intended movement, conflict with known equipment, or require a real training decision. " +
     "Whenever you need the athlete to choose or clarify something, call request_coach_input with " +
     "2–5 concise choices instead of asking only in prose. Put the recommended answer first, call it " +
     "at most once per turn, and wait for the athlete's response before continuing.\n\n" +

--- a/electron/chatHistoryStore.ts
+++ b/electron/chatHistoryStore.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import {
   deleteChatSessionRow,
+  getChatPlanDraft,
   getChatSessionRow,
   insertChatSessionRow,
   listChatSessionRows,
@@ -23,6 +24,7 @@ import type {
   PersistedChatSource,
   PlanDraftPreview,
   PlanDraftPreviewEntry,
+  PlanWorkoutEntryInput,
   TrainingHubActivitySeriesPoint,
   TrainingHubThresholdZone,
   TrainingHubTrackPoint,
@@ -173,6 +175,92 @@ function parseCoachInputPrompt(value: unknown): CoachInputPrompt | null {
   };
 }
 
+const PERSISTED_WORKOUT_SPORTS = new Set([
+  "run",
+  "trailRun",
+  "bike",
+  "swim",
+  "strength",
+  "xcSki",
+  "indoorClimb",
+  "bouldering",
+  "hyrox"
+]);
+
+type PersistedPlanStep = NonNullable<PlanWorkoutEntryInput["steps"]>[number];
+
+function parsePersistedPlanStep(value: unknown): PersistedPlanStep | null {
+  if (!isRecord(value)) return null;
+
+  if (typeof value.repeat === "number") {
+    if (!Array.isArray(value.steps)) return null;
+    const children = value.steps.filter(
+      (step): step is Record<string, unknown> =>
+        isRecord(step) && typeof step.kind === "string"
+    );
+    if (children.length !== value.steps.length) return null;
+    return {
+      ...value,
+      steps: children.map((step) => ({ ...step }))
+    } as unknown as PersistedPlanStep;
+  }
+
+  if (typeof value.kind !== "string") return null;
+  return { ...value } as unknown as PersistedPlanStep;
+}
+
+function parsePlanWorkoutSource(
+  value: unknown
+): PlanWorkoutEntryInput | undefined {
+  if (
+    !isRecord(value) ||
+    typeof value.key !== "string" ||
+    typeof value.name !== "string"
+  ) {
+    return undefined;
+  }
+
+  const parsedSteps = Array.isArray(value.steps)
+    ? value.steps.map(parsePersistedPlanStep)
+    : undefined;
+  const steps = parsedSteps?.every(
+    (step): step is PersistedPlanStep => step !== null
+  )
+    ? parsedSteps
+    : undefined;
+  const sport =
+    typeof value.sport === "string" && PERSISTED_WORKOUT_SPORTS.has(value.sport)
+      ? value.sport as PlanWorkoutEntryInput["sport"]
+      : undefined;
+
+  return {
+    key: value.key,
+    name: value.name,
+    ...(typeof value.description === "string"
+      ? { description: value.description }
+      : {}),
+    ...(sport ? { sport } : {}),
+    ...(isRecord(value.sport_options)
+      ? {
+          sport_options: {
+            ...value.sport_options
+          } as PlanWorkoutEntryInput["sport_options"]
+        }
+      : {}),
+    ...(steps ? { steps } : {}),
+    ...(typeof value.distance_km === "number"
+      ? { distance_km: value.distance_km }
+      : {}),
+    ...(typeof value.schedule_date === "string"
+      ? { schedule_date: value.schedule_date }
+      : {}),
+    ...(typeof value.sort_no === "number" ? { sort_no: value.sort_no } : {}),
+    ...(typeof value.save_to_library === "boolean"
+      ? { save_to_library: value.save_to_library }
+      : {})
+  };
+}
+
 function parsePlanDraftEntry(value: unknown): PlanDraftPreviewEntry | null {
   if (!isRecord(value)) {
     return null;
@@ -187,6 +275,7 @@ function parsePlanDraftEntry(value: unknown): PlanDraftPreviewEntry | null {
     return null;
   }
 
+  const source = parsePlanWorkoutSource(value.source);
   return {
     key: value.key,
     name: value.name,
@@ -199,7 +288,8 @@ function parsePlanDraftEntry(value: unknown): PlanDraftPreviewEntry | null {
     saveToLibrary: value.saveToLibrary,
     workoutType: value.workoutType,
     stepsSummary:
-      typeof value.stepsSummary === "string" ? value.stepsSummary : undefined
+      typeof value.stepsSummary === "string" ? value.stepsSummary : undefined,
+    ...(source ? { source } : {})
   };
 }
 
@@ -235,6 +325,7 @@ function parsePlanDraft(value: unknown): PlanDraftPreview | null {
 
   return {
     draftId: value.draftId,
+    artifactType: value.artifactType === "workout" ? "workout" : "plan",
     name: value.name,
     summary: value.summary,
     entries,
@@ -248,7 +339,23 @@ function parsePlanDraft(value: unknown): PlanDraftPreview | null {
       typeof value.uploadResult.workoutsCreated === "number"
         ? {
             workoutsScheduled: value.uploadResult.workoutsScheduled,
-            workoutsCreated: value.uploadResult.workoutsCreated
+            workoutsCreated: value.uploadResult.workoutsCreated,
+            destination:
+              value.uploadResult.destination === "workoutLibrary" ||
+              value.uploadResult.destination === "calendar" ||
+              value.uploadResult.destination === "nativePlan" ||
+              value.uploadResult.destination === "localTemplate" ||
+              value.uploadResult.destination === "nativePlanAndCalendar"
+                ? value.uploadResult.destination
+                : undefined,
+            localPlanId:
+              typeof value.uploadResult.localPlanId === "string"
+                ? value.uploadResult.localPlanId
+                : undefined,
+            groupedPlanCreated:
+              typeof value.uploadResult.groupedPlanCreated === "boolean"
+                ? value.uploadResult.groupedPlanCreated
+                : undefined
           }
         : undefined
   };
@@ -695,6 +802,53 @@ export function parseChatTranscriptJson(raw: string): PersistedChatEntry[] {
     .filter((entry): entry is PersistedChatEntry => entry !== null);
 }
 
+/**
+ * Older chat rows were normalized without each preview entry's canonical
+ * workout source. The separate Coach draft store retained that full preview,
+ * so use it to restore structured cards without replacing chat-local upload
+ * state or destination choices.
+ */
+export function restoreChatPlanDraftSources(
+  entries: PersistedChatEntry[],
+  loadPreviewJson: (draftId: string) => string | undefined
+): PersistedChatEntry[] {
+  return entries.map((entry) => {
+    if (
+      entry.kind !== "planDraft" ||
+      entry.draft.entries.every((draftEntry) => draftEntry.source)
+    ) {
+      return entry;
+    }
+
+    const rawPreview = loadPreviewJson(entry.draft.draftId);
+    if (!rawPreview) return entry;
+
+    let recovered: PlanDraftPreview | null = null;
+    try {
+      recovered = parsePlanDraft(JSON.parse(rawPreview));
+    } catch {
+      return entry;
+    }
+    if (!recovered) return entry;
+
+    const recoveredByKey = new Map(
+      recovered.entries.map((draftEntry) => [draftEntry.key, draftEntry])
+    );
+    return {
+      kind: "planDraft",
+      draft: {
+        ...entry.draft,
+        artifactType: recovered.artifactType ?? entry.draft.artifactType,
+        entries: entry.draft.entries.map((draftEntry) => ({
+          ...draftEntry,
+          source:
+            draftEntry.source ?? recoveredByKey.get(draftEntry.key)?.source
+        }))
+      }
+    };
+  });
+}
+
 function normalizeEntries(entries: PersistedChatEntry[]): PersistedChatEntry[] {
   return entries
     .map((entry) => parseEntry(entry))
@@ -792,7 +946,12 @@ export function getChatSession(
   if (!row) {
     return [];
   }
-  return parseChatTranscriptJson(row.messages_json);
+  const entries = parseChatTranscriptJson(row.messages_json);
+  if (database !== defaultDatabase) return entries;
+  return restoreChatPlanDraftSources(
+    entries,
+    (draftId) => getChatPlanDraft(draftId)?.previewJson
+  );
 }
 
 export function createChatSession(

--- a/electron/chatService.ts
+++ b/electron/chatService.ts
@@ -964,9 +964,15 @@ export function cancelChat(requestId: string): void {
 export async function uploadTrainingPlanDraft(
   draftId: string,
   unitSystem: UnitSystem = "metric",
-  destination: import("./types").TrainingPlanDestination = "workoutLibrary"
+  destination: import("./types").TrainingPlanDestination = "workoutLibrary",
+  scheduleDate?: string
 ): Promise<UploadPlanResult> {
-  return uploadPlanDraftById(draftId, normalizeUnitSystem(unitSystem), destination);
+  return uploadPlanDraftById(
+    draftId,
+    normalizeUnitSystem(unitSystem),
+    destination,
+    scheduleDate
+  );
 }
 
 export async function confirmWorkoutDelete(
@@ -1037,7 +1043,11 @@ export function getClaudeCodeTools(
     ) {
       return permissions.upcomingWorkouts;
     }
-    return tool.name === "draft_training_plan";
+    return (
+      tool.name === "draft_workout" ||
+      tool.name === "draft_training_plan" ||
+      tool.name === "search_coros_exercises"
+    );
   });
 
   return [
@@ -1348,9 +1358,15 @@ function withLiveToolInstructions(
   if (planTools.length > 0) {
     sections.push(
       "",
-      "## Training plan tools",
-      `Plan authoring tools: ${planTools.map((tool) => tool.name).join(", ")}. ` +
-        "Use draft_training_plan to build multi-day schedules across the supported sports. " +
+      "## Workout and training plan tools",
+      `Authoring tools: ${planTools.map((tool) => tool.name).join(", ")}. ` +
+        "Use draft_workout for exactly one standalone workout. Its card lets the athlete choose Workout Library or Calendar; set calendar_date only when the athlete names a date. " +
+        "Use draft_training_plan only for multi-day or multi-week schedules. Never wrap a one-off workout in a plan. " +
+        "Before drafting Strength or HYROX workouts, call search_coros_exercises once with all intended " +
+        "exercise queries, or with target muscles, movement patterns, and known equipment; then use the " +
+        "returned exact exercise IDs and names. A COROS naming mismatch alone never requires an athlete question. " +
+        "For Strength exercises, set sets explicitly, use target_reps or target_duration_seconds per set, " +
+        "and set rest_type=1 plus rest_value in seconds. Do not hide the prescription only in the step name. " +
         "Always provide sport on every new workout, including sport=run. " +
         "Use distance_km only for a simple Run or Trail Run; use steps for anything structured. " +
         "Pick each step's target " +
@@ -1359,8 +1375,8 @@ function withLiveToolInstructions(
         "(no value, run-until-lap) for by-feel warmups/cooldowns or fartlek surges. Put every " +
         "prescribed HR, pace, effort pace, power, cadence, stroke, weight, RPE, or grade in " +
         "the typed intensity field; do not leave it only in workout prose or the name. " +
-        "Include schedule_date " +
-        "(YYYYMMDD) for calendar placement. The athlete must confirm before upload. " +
+        "For draft_training_plan entries intended for calendar placement, include schedule_date " +
+        "(YYYYMMDD). The athlete must confirm the destination and any one-off workout date before upload. " +
         "Use list_scheduled_workouts + delete_workout to stage deletions. " +
         "The athlete confirms via the Delete from COROS button in chat.",
       "",

--- a/electron/chatWorkoutTools.ts
+++ b/electron/chatWorkoutTools.ts
@@ -12,6 +12,7 @@ import {
   getTrainingHubStatus,
   listScheduledWorkoutEntries,
   resolveTrainingPlanExercises,
+  searchWorkoutExercises,
   uploadTrainingPlan
 } from "./trainingHubService";
 import {
@@ -33,10 +34,22 @@ import type {
   WorkoutDeletePreview,
   UnitSystem
 } from "./types";
-import { buildDraftTrainingPlanInputSchema } from "./workoutCapabilities";
+import {
+  buildDraftTrainingPlanInputSchema,
+  buildDraftWorkoutInputSchema
+} from "./workoutCapabilities";
 import { formatDistanceValue } from "./unitSystem.js";
 import { createTrainingPlan } from "./trainingPlanDomain";
 import { saveLocalTrainingPlan } from "./trainingLibraryService";
+import {
+  EXERCISE_SEARCH_EQUIPMENT,
+  EXERCISE_SEARCH_MOVEMENTS,
+  EXERCISE_SEARCH_MUSCLES,
+  type ExerciseSearchEquipment,
+  type ExerciseSearchMovement,
+  type ExerciseSearchMuscle,
+  type WorkoutExerciseSearchResult
+} from "./exerciseCatalogSearch";
 
 interface StoredPlanDraft {
   draftId: string;
@@ -129,6 +142,8 @@ export function hydratePlanDraftStoreFromDatabase(): void {
 }
 
 export const CHAT_WORKOUT_TOOL_NAMES = [
+  "search_coros_exercises",
+  "draft_workout",
   "draft_training_plan",
   "upload_training_plan",
   "list_scheduled_workouts",
@@ -149,12 +164,78 @@ export function getChatWorkoutTools(): CorosMcpTool[] {
 
   return [
     {
+      name: "search_coros_exercises",
+      description:
+        "Search the athlete's live COROS Strength/HYROX exercise catalog and return exact exercise IDs and names. " +
+        "Call this before drafting strength or HYROX workouts whenever exact COROS exercise IDs are not already known. " +
+        "Search several intended movements in one call with queries, or discover exercises by target muscles, movement patterns, and available equipment. " +
+        "Use returned exercise_id and exercise_name values in whichever draft tool matches the request. Catalog naming differences are not a reason to ask the athlete.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          sport: {
+            type: "string",
+            enum: ["strength", "hyrox"],
+            description: "Catalog context. HYROX functional stations use the COROS Strength catalog. Default strength."
+          },
+          query: {
+            type: "string",
+            description: "One intended exercise or natural-language movement, such as 'machine chest press'."
+          },
+          queries: {
+            type: "array",
+            minItems: 1,
+            maxItems: 8,
+            items: { type: "string" },
+            description: "Several intended exercises to resolve in one tool call."
+          },
+          target_muscles: {
+            type: "array",
+            uniqueItems: true,
+            items: { type: "string", enum: [...EXERCISE_SEARCH_MUSCLES] },
+            description: "Accept exercises targeting any of these muscles."
+          },
+          movement_patterns: {
+            type: "array",
+            uniqueItems: true,
+            items: { type: "string", enum: [...EXERCISE_SEARCH_MOVEMENTS] },
+            description: "Accept exercises matching any of these movement patterns."
+          },
+          equipment: {
+            type: "array",
+            uniqueItems: true,
+            items: { type: "string", enum: [...EXERCISE_SEARCH_EQUIPMENT] },
+            description: "Accept exercises using any of this available equipment. Omit when equipment is unrestricted."
+          },
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 12,
+            description: "Maximum results per query, or for the filtered discovery search. Default 5 for queries and 10 otherwise."
+          }
+        }
+      }
+    },
+    {
+      name: "draft_workout",
+      description:
+        "Validate and store one standalone workout for athlete review. " +
+        "Use this for one-off requests such as today's run, a single gym session, or one workout to reuse later; " +
+        "do not wrap a one-off workout in draft_training_plan. Set calendar_date only when the athlete names a date. " +
+        "Put prescribed HR, pace, power, cadence, stroke, weight, RPE, or grade in each step's typed intensity field. " +
+        "For Strength and HYROX, call search_coros_exercises first and pass its exact exercise IDs and names. " +
+        "Returns a workout card where the athlete can choose Workout Library or Calendar and confirm.",
+      inputSchema: buildDraftWorkoutInputSchema()
+    },
+    {
       name: "draft_training_plan",
       description:
-        "Validate and store a sport-aware training plan draft for athlete review. " +
+        "Validate and store a multi-day or multi-week sport-aware training plan draft for athlete review. " +
+        "Use draft_workout instead when the athlete asks for only one standalone workout. " +
         "Put prescribed HR, pace, power, cadence, stroke, weight, RPE, or grade in each step's typed intensity field. " +
-        "Strength and HYROX exercise names are checked against the COROS catalog; if candidates are returned, " +
-        "revise the affected steps and call this tool again. Always call this before upload. Returns a draftId and human-readable preview.",
+        "Strength and HYROX exercise names are checked against the COROS catalog; use search_coros_exercises first " +
+        "and pass its exact IDs and names. If candidates are returned, revise the affected steps and call this tool again. " +
+        "Always call this before upload. Returns a draftId and human-readable preview.",
       inputSchema: buildDraftTrainingPlanInputSchema()
     },
     {
@@ -165,7 +246,7 @@ export function getChatWorkoutTools(): CorosMcpTool[] {
       inputSchema: {
         type: "object",
         properties: {
-          draft_id: { type: "string", description: "draftId from draft_training_plan" },
+          draft_id: { type: "string", description: "draftId from a workout or plan draft tool" },
           confirmed: {
             type: "boolean",
             description: "Must be true only after explicit athlete confirmation"
@@ -259,6 +340,17 @@ export async function handleChatWorkoutTool(
       options?.unitSystem ?? "metric"
     );
   }
+  if (name === "draft_workout") {
+    return handleDraftWorkout(
+      args,
+      options?.onPlanDraft,
+      options?.allowUpcomingWorkouts !== false,
+      options?.unitSystem ?? "metric"
+    );
+  }
+  if (name === "search_coros_exercises") {
+    return handleSearchCorosExercises(args);
+  }
   if (name === "upload_training_plan") {
     return handleUploadTrainingPlan(args, options?.unitSystem ?? "metric");
   }
@@ -266,6 +358,104 @@ export async function handleChatWorkoutTool(
     return handleListScheduledWorkouts(args, options?.unitSystem ?? "metric");
   }
   return handleDeleteWorkout(args, options?.onWorkoutDelete);
+}
+
+function allowedStringList<T extends string>(
+  value: unknown,
+  allowed: readonly T[]
+): T[] {
+  const allowedValues = new Set<string>(allowed);
+  return [...new Set(
+    (Array.isArray(value) ? value : [])
+      .map((entry) => String(entry ?? "").trim())
+      .filter((entry): entry is T => allowedValues.has(entry))
+  )];
+}
+
+function exerciseSearchResultForChat(result: WorkoutExerciseSearchResult) {
+  return {
+    exercise_id: result.id,
+    exercise_name: result.name,
+    target_muscles: result.targetMuscles,
+    movement_patterns: result.movementPatterns,
+    equipment: result.equipment,
+    match_reasons: result.matchReasons
+  };
+}
+
+async function handleSearchCorosExercises(
+  args: Record<string, unknown>
+): Promise<string> {
+  const sport = args.sport === "hyrox" ? "hyrox" : "strength";
+  const singleQuery = typeof args.query === "string" ? args.query.trim() : "";
+  const queries = [...new Set([
+    ...(singleQuery ? [singleQuery] : []),
+    ...(Array.isArray(args.queries)
+      ? args.queries.map((entry) => String(entry ?? "").trim()).filter(Boolean)
+      : [])
+  ])].slice(0, 8);
+  const targetMuscles = allowedStringList<ExerciseSearchMuscle>(
+    args.target_muscles,
+    EXERCISE_SEARCH_MUSCLES
+  );
+  const movementPatterns = allowedStringList<ExerciseSearchMovement>(
+    args.movement_patterns,
+    EXERCISE_SEARCH_MOVEMENTS
+  );
+  const equipment = allowedStringList<ExerciseSearchEquipment>(
+    args.equipment,
+    EXERCISE_SEARCH_EQUIPMENT
+  );
+  const requestedLimit = Number(args.limit);
+  const limit = Number.isFinite(requestedLimit)
+    ? Math.min(12, Math.max(1, Math.round(requestedLimit)))
+    : queries.length > 0
+      ? 5
+      : 10;
+
+  if (
+    queries.length === 0 &&
+    targetMuscles.length === 0 &&
+    movementPatterns.length === 0 &&
+    equipment.length === 0
+  ) {
+    return JSON.stringify({
+      ok: false,
+      error_code: "exercise_search_intent_required",
+      action:
+        "Call again with query/queries or at least one target_muscles, movement_patterns, or equipment filter."
+    });
+  }
+
+  const sharedInput = { targetMuscles, movementPatterns, equipment, limit };
+  if (queries.length > 0) {
+    const searches = [];
+    // Keep these sequential: the first call fills the short-lived live-catalog
+    // cache, so resolving several movements still performs one COROS request.
+    for (const query of queries) {
+      const results = await searchWorkoutExercises(sport, { ...sharedInput, query });
+      searches.push({
+        query,
+        results: results.map(exerciseSearchResultForChat)
+      });
+    }
+    return JSON.stringify({
+      ok: true,
+      sport,
+      searches,
+      action:
+        "Choose the closest result for each intended movement and use its exact exercise_id and exercise_name in the matching draft tool. Ask the athlete only if the available movement or equipment would materially change the workout."
+    });
+  }
+
+  const results = await searchWorkoutExercises(sport, sharedInput);
+  return JSON.stringify({
+    ok: true,
+    sport,
+    results: results.map(exerciseSearchResultForChat),
+    action:
+      "Use exact exercise_id and exercise_name values from these results in the matching draft tool. Refine the search if a needed movement is not represented."
+  });
 }
 
 function toPlanDraft(args: Record<string, unknown>): CorosTrainingPlanDraft {
@@ -276,6 +466,7 @@ function toPlanDraft(args: Record<string, unknown>): CorosTrainingPlanDraft {
     return {
       key: String(entry.key ?? `workout-${index + 1}`).trim(),
       name: String(entry.name ?? `Workout ${index + 1}`).trim(),
+      description: entry.description?.trim(),
       sport: entry.sport ?? "run",
       sport_options: entry.sport_options,
       steps: entry.steps as PlanWorkoutEntry["steps"],
@@ -288,6 +479,41 @@ function toPlanDraft(args: Record<string, unknown>): CorosTrainingPlanDraft {
     };
   });
   return { name, workouts };
+}
+
+function handleDraftWorkout(
+  args: Record<string, unknown>,
+  onPlanDraft?: (preview: PlanDraftPreview) => void,
+  allowUpcomingWorkouts = true,
+  unitSystem: UnitSystem = "metric"
+): Promise<string> {
+  const rawWorkout = args.workout;
+  if (!rawWorkout || typeof rawWorkout !== "object" || Array.isArray(rawWorkout)) {
+    return Promise.resolve(JSON.stringify({
+      ok: false,
+      errors: ["workout is required."]
+    }));
+  }
+
+  const workout = rawWorkout as Record<string, unknown>;
+  const workoutName = String(workout.name ?? "").trim();
+  const calendarDate = args.calendar_date
+    ? String(args.calendar_date).replace(/-/g, "").trim()
+    : undefined;
+  return handleDraftTrainingPlan(
+    {
+      name: workoutName,
+      workouts: [{
+        ...workout,
+        schedule_date: calendarDate,
+        save_to_library: true
+      }]
+    },
+    onPlanDraft,
+    allowUpcomingWorkouts,
+    unitSystem,
+    "workout"
+  );
 }
 
 export function buildTrainingPlanUploadInput(
@@ -372,9 +598,10 @@ function saveDraftAsLocalTemplate(
   return saveLocalTrainingPlan(document);
 }
 
-function inputForDestination(
+export function buildTrainingPlanDestinationInput(
   plan: CorosTrainingPlanDraft,
-  destination: TrainingPlanDestination
+  destination: TrainingPlanDestination,
+  scheduleDate?: string
 ): CorosTrainingPlanDraftInput {
   const input = buildTrainingPlanUploadInput(plan);
   if (destination === "workoutLibrary") {
@@ -388,7 +615,15 @@ function inputForDestination(
     };
   }
   if (destination === "calendar") {
-    const unscheduled = input.workouts.filter((workout) => !workout.schedule_date);
+    const normalizedDate = scheduleDate?.replace(/-/g, "").trim();
+    if (normalizedDate && input.workouts.length !== 1) {
+      throw new Error("A calendar date override is only supported for one-off workouts.");
+    }
+    const calendarWorkouts = input.workouts.map((workout) => ({
+      ...workout,
+      schedule_date: normalizedDate || workout.schedule_date
+    }));
+    const unscheduled = calendarWorkouts.filter((workout) => !workout.schedule_date);
     if (unscheduled.length > 0) {
       throw new Error(
         `${unscheduled.length} workout${unscheduled.length === 1 ? " is" : "s are"} missing a date. Add dates before choosing Calendar.`
@@ -396,7 +631,7 @@ function inputForDestination(
     }
     return {
       ...input,
-      workouts: input.workouts.map((workout) => ({
+      workouts: calendarWorkouts.map((workout) => ({
         ...workout,
         save_to_library: false
       }))
@@ -448,7 +683,8 @@ async function handleDraftTrainingPlan(
   args: Record<string, unknown>,
   onPlanDraft?: (preview: PlanDraftPreview) => void,
   allowUpcomingWorkouts = true,
-  unitSystem: UnitSystem = "metric"
+  unitSystem: UnitSystem = "metric",
+  artifactType: "plan" | "workout" = "plan"
 ): Promise<string> {
   const draft = toPlanDraft(args);
   const validation = validatePlanDraft(draft, {
@@ -460,6 +696,9 @@ async function handleDraftTrainingPlan(
 
   const exerciseResolution = await resolveTrainingPlanExercises(draft);
   if (exerciseResolution.issues.length > 0) {
+    const retryTool = artifactType === "workout"
+      ? "draft_workout"
+      : "draft_training_plan";
     return JSON.stringify({
       ok: false,
       error_code: "exercise_resolution_required",
@@ -473,8 +712,8 @@ async function handleDraftTrainingPlan(
         message: issue.message
       })),
       action: exerciseResolution.issues.every((issue) => issue.candidates.length > 0)
-        ? "Update each affected step to the exact best-matching candidate and call draft_training_plan again now. If the candidates materially change the intended movement, call request_coach_input with the exact candidates as clickable choices."
-        : "At least one exercise is unavailable. Call request_coach_input with supported alternatives as clickable choices, then wait for the athlete before calling draft_training_plan again."
+        ? `Update each affected step to the exact best-matching candidate and call ${retryTool} again now. If the candidates materially change the intended movement, call request_coach_input with the exact candidates as clickable choices.`
+        : `At least one exercise name is unavailable. Call search_coros_exercises now using the intended movement, target muscles, and known equipment; use an exact returned ID/name and call ${retryTool} again. Ask the athlete only if the available movement or equipment would materially change the workout.`
     });
   }
   const resolvedDraft = exerciseResolution.draft;
@@ -485,7 +724,8 @@ async function handleDraftTrainingPlan(
   const draftId = crypto.randomUUID();
   const preview = buildPlanPreview(draftId, resolvedDraft, {
     scheduleConflicts: conflicts,
-    unitSystem
+    unitSystem,
+    artifactType
   });
   preview.conflicts = conflicts;
 
@@ -509,9 +749,9 @@ async function handleDraftTrainingPlan(
       conflicts: preview.conflicts,
       warnings: preview.warnings
     },
-    message:
-      "Draft saved. Tell the athlete to review the plan preview and click Upload to COROS " +
-      "when ready. Do not call upload_training_plan until they confirm."
+    message: artifactType === "workout"
+      ? "Workout draft saved. Tell the athlete to review it, choose Workout Library or Calendar, and confirm. The workout is not a training plan."
+      : "Draft saved. Tell the athlete to review the plan preview and click Upload to COROS when ready. Do not call upload_training_plan until they confirm."
   });
 }
 
@@ -835,7 +1075,8 @@ export async function confirmWorkoutDeleteById(
 export async function uploadPlanDraftById(
   draftId: string,
   unitSystem: UnitSystem = "metric",
-  destination: TrainingPlanDestination = "workoutLibrary"
+  destination: TrainingPlanDestination = "workoutLibrary",
+  scheduleDate?: string
 ): Promise<UploadPlanResult> {
   const stored = loadStoredPlanDraft(draftId);
   if (!stored) {
@@ -867,7 +1108,14 @@ export async function uploadPlanDraftById(
       remoteWrites: []
     };
   } else {
-    const input = inputForDestination(stored.plan, destination);
+    if (scheduleDate && stored.preview.artifactType !== "workout") {
+      throw new Error("A calendar date can only override a one-off workout draft.");
+    }
+    const input = buildTrainingPlanDestinationInput(
+      stored.plan,
+      destination,
+      scheduleDate
+    );
     const uploaded = await uploadTrainingPlan(input, unitSystem);
     result = {
       ...uploaded,

--- a/electron/corosWorkoutBuilder.ts
+++ b/electron/corosWorkoutBuilder.ts
@@ -139,6 +139,8 @@ export interface PlanDraftPreviewEntry {
 
 export interface PlanDraftPreview {
   draftId: string;
+  /** Distinguishes a multi-workout plan from a reusable one-off workout. */
+  artifactType?: "plan" | "workout";
   name: string;
   summary: string;
   entries: PlanDraftPreviewEntry[];
@@ -1060,17 +1062,24 @@ function formatEntryVolume(
   }
   let totalMeters = 0;
   let repeatSets = 0;
+  let strengthSets = 0;
 
   for (const step of entry.steps) {
     if ("repeat" in step) {
       repeatSets += step.repeat;
       for (const sub of step.steps) {
+        if (entry.sport === "strength" && sub.kind === "training") {
+          strengthSets += (sub.sets ?? 1) * step.repeat;
+        }
         if (sub.target_distance_meters) {
           totalMeters += sub.target_distance_meters * step.repeat;
         }
       }
-    } else if (step.target_distance_meters) {
-      totalMeters += step.target_distance_meters;
+    } else {
+      if (entry.sport === "strength" && step.kind === "training") {
+        strengthSets += step.sets ?? 1;
+      }
+      if (step.target_distance_meters) totalMeters += step.target_distance_meters;
     }
   }
 
@@ -1078,6 +1087,9 @@ function formatEntryVolume(
     return formatDistanceValue(totalMeters, unitSystem, {
       swim: entry.sport === "swim"
     });
+  }
+  if (strengthSets > 0) {
+    return `${strengthSets} ${strengthSets === 1 ? "set" : "sets"}`;
   }
   if (repeatSets > 0) {
     return `${repeatSets} set(s)`;
@@ -1155,7 +1167,14 @@ function formatRunStepSummary(
     : step.pace
       ? `@ ${formatLegacyPaceForUnits(step.pace, unitSystem)}`
       : undefined;
-  return [kind, target, intensity].filter(Boolean).join(" ");
+  const exercise = step.exercise_name?.trim();
+  const prescribedTarget = target && step.sets && step.sets > 1
+    ? `${step.sets} × ${target}`
+    : target;
+  const rest = step.rest_value !== undefined && step.sets && step.sets > 1
+    ? `(${step.rest_value} sec rest)`
+    : undefined;
+  return [exercise || kind, prescribedTarget, intensity, rest].filter(Boolean).join(" ");
 }
 
 function formatWorkoutIntensityForUnits(
@@ -1314,6 +1333,7 @@ export function buildPlanPreview(
     existingSchedule?: Map<string, string[]>;
     scheduleConflicts?: string[];
     unitSystem?: UnitSystem;
+    artifactType?: "plan" | "workout";
   }
 ): PlanDraftPreview {
   const entries: PlanDraftPreviewEntry[] = draft.workouts.map((entry) => ({
@@ -1353,20 +1373,26 @@ export function buildPlanPreview(
   const sportSummary = [...sportCounts.entries()]
     .map(([sport, count]) => `${count} ${formatWorkoutSport(sport)}`)
     .join(" / ");
+  const workoutSportSummary = formatWorkoutSport(
+    draft.workouts[0]?.sport ?? "run"
+  );
 
-  const summaryParts = [
-    `${draft.workouts.length} workout${draft.workouts.length === 1 ? "" : "s"}`,
-    scheduled.length > 0
-      ? `${scheduled.length} scheduled`
-      : "none scheduled",
-    libraryOnly.length > 0
-      ? `${libraryOnly.length} library-only`
-      : undefined,
-    sportSummary
-  ].filter(Boolean);
+  const artifactType = options?.artifactType ?? "plan";
+  const summaryParts = artifactType === "workout"
+    ? [workoutSportSummary, entries[0]?.volume, entries[0]?.workoutType].filter(Boolean)
+    : [
+        `${draft.workouts.length} workout${draft.workouts.length === 1 ? "" : "s"}`,
+        scheduled.length > 0
+          ? `${scheduled.length} scheduled`
+          : "none scheduled",
+        libraryOnly.length > 0
+          ? `${libraryOnly.length} library-only`
+          : undefined,
+        sportSummary
+      ].filter(Boolean);
 
   const warnings: string[] = [];
-  if (scheduled.length === 0) {
+  if (artifactType === "plan" && scheduled.length === 0) {
     warnings.push(
       "No workouts have schedule_date set — they will only be saved to your COROS library."
     );
@@ -1374,6 +1400,7 @@ export function buildPlanPreview(
 
   return {
     draftId,
+    artifactType,
     name: draft.name,
     summary: summaryParts.join(" · "),
     entries,

--- a/electron/corosWorkoutEditor.ts
+++ b/electron/corosWorkoutEditor.ts
@@ -121,6 +121,12 @@ function friendlyStepName(kind: RunWorkoutEditorStepKind): string {
   }
 }
 
+function editableStepOverview(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const overview = value.trim();
+  return overview && !/^sid_[a-z0-9_]+$/i.test(overview) ? overview : undefined;
+}
+
 function parseTarget(
   exercise: Record<string, unknown>,
   kind: RunWorkoutEditorStepKind
@@ -255,6 +261,16 @@ function parseStep(
     ...(rawName ? { exerciseName: rawName } : {}),
     ...(numberValue(exercise.exerciseKind) !== undefined
       ? { exerciseKind: numberValue(exercise.exerciseKind) }
+      : {}),
+    ...(sport === "strength" && kind === "training"
+      ? {
+          sets: Math.max(1, Math.min(99, Math.round(numberValue(exercise.sets) ?? 1))),
+          restType: Math.round(numberValue(exercise.restType) ?? 1),
+          restValue: Math.max(0, Math.round(numberValue(exercise.restValue) ?? 60))
+        }
+      : {}),
+    ...(editableStepOverview(exercise.overview)
+      ? { overview: editableStepOverview(exercise.overview) }
       : {}),
     ...(numberValue(exercise.packageTime) !== undefined
       ? { sendOffSeconds: numberValue(exercise.packageTime) }
@@ -561,10 +577,17 @@ export function workoutDraftToCorosProgram(
       exercise.exerciseKind = 0;
     }
     if (step.sendOffSeconds !== undefined) exercise.packageTime = Math.round(step.sendOffSeconds);
-    exercise.sets = 1;
-    exercise.restType = step.kind === "rest" ? 3 : numberValue(exercise.restType) ?? 3;
-    exercise.restValue = numberValue(exercise.restValue) ?? 0;
-    exercise.overview = defaultOverview(draft.sport, step.kind, step.target);
+    const strengthExercise = draft.sport === "strength" && step.kind === "training";
+    exercise.sets = strengthExercise ? step.sets ?? 1 : 1;
+    exercise.restType = step.kind === "rest"
+      ? 3
+      : strengthExercise
+        ? step.restType ?? 1
+        : numberValue(exercise.restType) ?? 3;
+    exercise.restValue = strengthExercise
+      ? step.restValue ?? 60
+      : numberValue(exercise.restValue) ?? 0;
+    exercise.overview = step.overview?.trim() || defaultOverview(draft.sport, step.kind, step.target);
     applyTarget(exercise, step, context, draft.sport);
     applyIntensity(exercise, step.intensity, context);
     return exercise;
@@ -637,7 +660,11 @@ export function workoutDraftToCorosProgram(
   program.exercises = flattened;
   program.exerciseNum = flattened.length;
   program.totalSets = flattened.reduce(
-    (total, exercise) => total + (exercise.isGroup ? Number(exercise.sets ?? 1) : 1),
+    (total, exercise) => {
+      const sets = Math.max(1, Number(exercise.sets ?? 1));
+      if (exercise.isGroup) return total + sets;
+      return String(exercise.groupId ?? "0") === "0" ? total + sets : total + 1;
+    },
     0
   );
   program.sets = program.totalSets;
@@ -703,6 +730,14 @@ function normalizedDraft(draft: RunWorkoutEditorDraft): unknown {
             intensity: normalizeIntensity(node.intensity),
             exerciseId: node.exerciseId,
             exerciseKind: node.exerciseKind,
+            ...(draft.sport === "strength" && node.kind === "training"
+              ? {
+                  sets: node.sets ?? 1,
+                  restType: node.restType ?? 1,
+                  restValue: node.restValue ?? 60
+                }
+              : {}),
+            overview: node.overview,
             sendOffSeconds: node.sendOffSeconds,
             editable: node.editable
           }
@@ -717,6 +752,14 @@ function normalizedDraft(draft: RunWorkoutEditorDraft): unknown {
               intensity: normalizeIntensity(step.intensity),
               exerciseId: step.exerciseId,
               exerciseKind: step.exerciseKind,
+              ...(draft.sport === "strength" && step.kind === "training"
+                ? {
+                    sets: step.sets ?? 1,
+                    restType: step.restType ?? 1,
+                    restValue: step.restValue ?? 60
+                  }
+                : {}),
+              overview: step.overview,
               sendOffSeconds: step.sendOffSeconds,
               editable: step.editable
             }))

--- a/electron/exerciseCatalogSearch.ts
+++ b/electron/exerciseCatalogSearch.ts
@@ -1,0 +1,234 @@
+import {
+  normalizeWorkoutExerciseName,
+  workoutExerciseId,
+  workoutExerciseName,
+  workoutExerciseNameSimilarity
+} from "./workoutCapabilities";
+
+export const EXERCISE_SEARCH_MUSCLES = [
+  "neck",
+  "traps",
+  "shoulders",
+  "chest",
+  "lats",
+  "biceps",
+  "triceps",
+  "forearms",
+  "abs",
+  "obliques",
+  "lower_back",
+  "glutes",
+  "quads",
+  "hamstrings",
+  "adductors",
+  "calves"
+] as const;
+
+export type ExerciseSearchMuscle = (typeof EXERCISE_SEARCH_MUSCLES)[number];
+
+export const EXERCISE_SEARCH_MOVEMENTS = [
+  "push",
+  "pull",
+  "squat",
+  "hinge",
+  "lunge",
+  "core",
+  "carry",
+  "conditioning",
+  "mobility",
+  "climb"
+] as const;
+
+export type ExerciseSearchMovement = (typeof EXERCISE_SEARCH_MOVEMENTS)[number];
+
+export const EXERCISE_SEARCH_EQUIPMENT = [
+  "bodyweight",
+  "machine",
+  "dumbbell",
+  "barbell",
+  "cable",
+  "resistance_band",
+  "kettlebell",
+  "medicine_ball",
+  "exercise_ball",
+  "suspension",
+  "bosu",
+  "sled",
+  "rope"
+] as const;
+
+export type ExerciseSearchEquipment = (typeof EXERCISE_SEARCH_EQUIPMENT)[number];
+
+export interface WorkoutExerciseSearchInput {
+  query?: string;
+  targetMuscles?: readonly ExerciseSearchMuscle[];
+  movementPatterns?: readonly ExerciseSearchMovement[];
+  equipment?: readonly ExerciseSearchEquipment[];
+  limit?: number;
+}
+
+export interface WorkoutExerciseSearchResult {
+  id: string;
+  name: string;
+  targetMuscles: ExerciseSearchMuscle[];
+  movementPatterns: ExerciseSearchMovement[];
+  equipment: ExerciseSearchEquipment[];
+  relevance: number;
+  matchReasons: string[];
+}
+
+interface ExerciseClassification {
+  targetMuscles: ExerciseSearchMuscle[];
+  movementPatterns: ExerciseSearchMovement[];
+  equipment: ExerciseSearchEquipment[];
+}
+
+interface MuscleRule {
+  match: RegExp;
+  muscles: readonly ExerciseSearchMuscle[];
+}
+
+const MUSCLE_RULES: readonly MuscleRule[] = [
+  { match: /neck resistance|neck bridge|press the neck|head harness/, muscles: ["neck"] },
+  { match: /shrug|upright row/, muscles: ["traps"] },
+  { match: /wrist|farmer|hangboard|grip|bar hangs?/, muscles: ["forearms"] },
+  { match: /calf|tibialis|ankle eversion|ankle inversion|jump rope|skipping rope/, muscles: ["calves"] },
+  { match: /adductor|inner thigh|hip adduction|copenhagen/, muscles: ["adductors"] },
+  { match: /oblique|side bend|russian twist|wood ?chop|rotation|side plank|windmill/, muscles: ["obliques", "abs"] },
+  { match: /crunch|sit up|leg raise|v up|v sit|l sit|dead bug|ab wheel|plank|mountain climber|knee tuck/, muscles: ["abs"] },
+  { match: /back extension|hyperexten|good morning|superman|bird dog/, muscles: ["lower_back", "glutes", "hamstrings"] },
+  { match: /deadlift|leg curl|nordic hamstring|pull through|kettlebell swing/, muscles: ["hamstrings", "glutes", "lower_back"] },
+  { match: /hip thrust|glute bridge|glute kickback|donkey kick|hip extension|clamshell|hip abduction|lateral band walk/, muscles: ["glutes", "hamstrings"] },
+  { match: /squat|leg press|leg extension|lunge|step up|box jump|wall sit|high knee/, muscles: ["quads", "glutes", "hamstrings"] },
+  { match: /bench press|chest press|floor press|pec deck|chest fly|dumbbell fly|cable fly|crossover|push up|\bdips?\b|pullover/, muscles: ["chest", "triceps", "shoulders"] },
+  { match: /pull up|chin up|pulldown|pull down|\brows?\b|pullover|back fly/, muscles: ["lats", "biceps", "forearms"] },
+  { match: /face pull|reverse fly|rear delt|lateral raise|front raise|shoulder press|military press|arnold press|overhead press|seated front press|upright row|battle rope/, muscles: ["shoulders", "triceps", "traps"] },
+  { match: /tricep|pushdown|skull ?crusher|kickback/, muscles: ["triceps"] },
+  { match: /bicep|\bcurls?\b|preacher/, muscles: ["biceps", "forearms"] },
+  { match: /burpee|thruster|snatch|power clean|turkish get up|wallball/, muscles: ["quads", "glutes", "shoulders", "chest", "abs"] }
+];
+
+const MOVEMENT_RULES: readonly {
+  match: RegExp;
+  movement: ExerciseSearchMovement;
+}[] = [
+  { match: /stretch|foam roll|warm ?up|cool down|mobility|cat cow|balance/, movement: "mobility" },
+  { match: /climb|hangboard|crimp|bar hangs?/, movement: "climb" },
+  { match: /farmer|carry|walk with/, movement: "carry" },
+  { match: /crunch|sit up|leg raise|v up|plank|rotation|wood ?chop|side bend|dead bug|ab wheel|bird dog/, movement: "core" },
+  { match: /lunge|step up|step down/, movement: "lunge" },
+  { match: /deadlift|good morning|hip thrust|glute bridge|leg curl|nordic|pull through|kettlebell swing|back extension|hyperexten/, movement: "hinge" },
+  { match: /squat|leg press|leg extension|wall sit/, movement: "squat" },
+  { match: /pull up|chin up|pulldown|pull down|\brows?\b|face pull|reverse fly|back fly|shrug|\bcurls?\b|preacher/, movement: "pull" },
+  { match: /press|push up|\bdips?\b|fly|crossover|pushdown|tricep|lateral raise|front raise/, movement: "push" },
+  { match: /burpee|jump|battle rope|skipping rope|jump rope|sled|wallball|thruster|snatch|clean/, movement: "conditioning" }
+];
+
+const EQUIPMENT_RULES: readonly {
+  match: RegExp;
+  equipment: ExerciseSearchEquipment;
+}[] = [
+  { match: /dumbbell/, equipment: "dumbbell" },
+  { match: /smith machine|\bmachine\b|pec deck|leg press|leg extension|leg curl|thigh abduct|thigh adduct|hack squat/, equipment: "machine" },
+  { match: /barbell|t bar/, equipment: "barbell" },
+  { match: /cable|pulley|pushdown|crossover/, equipment: "cable" },
+  { match: /resistance band|with bands?|banded|band walk/, equipment: "resistance_band" },
+  { match: /kettlebell/, equipment: "kettlebell" },
+  { match: /medicine ball|ball throw|ball slam|wallball/, equipment: "medicine_ball" },
+  { match: /exercise ball/, equipment: "exercise_ball" },
+  { match: /trx|suspended/, equipment: "suspension" },
+  { match: /bosu/, equipment: "bosu" },
+  { match: /sled/, equipment: "sled" },
+  { match: /battle rope|skipping rope|jump rope/, equipment: "rope" },
+  { match: /push up|pull up|chin up|sit up|crunch|plank|burpee|mountain climber|\bdips?\b|leg raise|jumping jack/, equipment: "bodyweight" }
+];
+
+function unique<T>(values: readonly T[]): T[] {
+  return [...new Set(values)];
+}
+
+export function classifyWorkoutExerciseName(name: string): ExerciseClassification {
+  const normalized = normalizeWorkoutExerciseName(name);
+  return {
+    targetMuscles: unique(
+      MUSCLE_RULES.filter((rule) => rule.match.test(normalized)).flatMap((rule) => rule.muscles)
+    ),
+    movementPatterns: unique(
+      MOVEMENT_RULES.filter((rule) => rule.match.test(normalized)).map((rule) => rule.movement)
+    ),
+    equipment: unique(
+      EQUIPMENT_RULES.filter((rule) => rule.match.test(normalized)).map((rule) => rule.equipment)
+    )
+  };
+}
+
+function overlapCount<T>(left: readonly T[], right: ReadonlySet<T>): number {
+  return left.filter((value) => right.has(value)).length;
+}
+
+export function searchWorkoutExerciseCatalog(
+  catalog: readonly Record<string, unknown>[],
+  input: WorkoutExerciseSearchInput
+): WorkoutExerciseSearchResult[] {
+  const query = input.query?.trim() ?? "";
+  const requestedMuscles = new Set(input.targetMuscles ?? []);
+  const requestedMovements = new Set(input.movementPatterns ?? []);
+  const requestedEquipment = new Set(input.equipment ?? []);
+  const limit = Math.min(12, Math.max(1, Math.round(input.limit ?? 8)));
+
+  const results = catalog.flatMap((row) => {
+    const id = workoutExerciseId(row);
+    const name = workoutExerciseName(row);
+    if (!id || !name) return [];
+    const classification = classifyWorkoutExerciseName(name);
+    const muscleMatches = overlapCount(classification.targetMuscles, requestedMuscles);
+    const movementMatches = overlapCount(classification.movementPatterns, requestedMovements);
+    const equipmentMatches = overlapCount(classification.equipment, requestedEquipment);
+    const nameSimilarity = query ? workoutExerciseNameSimilarity(query, name) : 0;
+
+    if (requestedMuscles.size > 0 && muscleMatches === 0) return [];
+    if (requestedMovements.size > 0 && movementMatches === 0) return [];
+    if (requestedEquipment.size > 0 && equipmentMatches === 0) return [];
+    if (
+      query &&
+      nameSimilarity < 0.22 &&
+      requestedMuscles.size === 0 &&
+      requestedMovements.size === 0
+    ) {
+      return [];
+    }
+
+    const reasons = [
+      nameSimilarity === 1
+        ? "same words as requested"
+        : nameSimilarity >= 0.6
+          ? "strong name match"
+          : nameSimilarity >= 0.22
+            ? "related name"
+            : undefined,
+      muscleMatches > 0
+        ? `targets ${classification.targetMuscles.filter((muscle) => requestedMuscles.has(muscle)).join(", ")}`
+        : undefined,
+      movementMatches > 0
+        ? `${classification.movementPatterns.filter((movement) => requestedMovements.has(movement)).join(", ")} movement`
+        : undefined,
+      equipmentMatches > 0
+        ? `uses ${classification.equipment.filter((item) => requestedEquipment.has(item)).join(", ")}`
+        : undefined
+    ].filter((reason): reason is string => Boolean(reason));
+
+    return [{
+      id,
+      name,
+      ...classification,
+      relevance:
+        nameSimilarity * 100 + muscleMatches * 18 + movementMatches * 14 + equipmentMatches * 12,
+      matchReasons: reasons
+    }];
+  });
+
+  return [...new Map(results.map((result) => [result.id, result])).values()]
+    .sort((left, right) => right.relevance - left.relevance || left.name.localeCompare(right.name))
+    .slice(0, limit)
+    .map((result) => ({ ...result, relevance: Math.round(result.relevance) }));
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1396,8 +1396,13 @@ function registerIpcHandlers(): void {
     await disconnectMcpServer(id, { clearAuthorization: false });
   });
 
-  ipcMain.handle("chat:uploadPlanDraft", (_event, draftId: string, unitSystem?: UnitSystem, destination?: import("./types").TrainingPlanDestination) =>
-    uploadTrainingPlanDraft(draftId, normalizeUnitSystem(unitSystem), destination)
+  ipcMain.handle("chat:uploadPlanDraft", (_event, draftId: string, unitSystem?: UnitSystem, destination?: import("./types").TrainingPlanDestination, scheduleDate?: string) =>
+    uploadTrainingPlanDraft(
+      draftId,
+      normalizeUnitSystem(unitSystem),
+      destination,
+      scheduleDate
+    )
   );
 
   ipcMain.handle("chat:confirmWorkoutDelete", (_event, requestId: string) =>

--- a/electron/planWorkoutEditor.ts
+++ b/electron/planWorkoutEditor.ts
@@ -56,6 +56,16 @@ function editorStep(step: RunWorkoutCreateStep, sport: WorkoutSport): RunWorkout
     exerciseId: step.exercise_id,
     exerciseName: step.exercise_name,
     exerciseKind: step.exercise_kind,
+    sets: sport === "strength" && (step.kind === "training" || step.kind === "interval")
+      ? step.sets ?? 1
+      : step.sets,
+    restType: sport === "strength" && (step.kind === "training" || step.kind === "interval")
+      ? step.rest_type ?? 1
+      : step.rest_type,
+    restValue: sport === "strength" && (step.kind === "training" || step.kind === "interval")
+      ? step.rest_value ?? 60
+      : step.rest_value,
+    overview: step.overview,
     sendOffSeconds: step.send_off_seconds,
     editable: true
   };
@@ -129,6 +139,10 @@ function inputStep(step: RunWorkoutEditorStep): RunWorkoutCreateStep {
     ...(step.exerciseId?.trim() ? { exercise_id: step.exerciseId.trim() } : {}),
     ...(step.exerciseName?.trim() ? { exercise_name: step.exerciseName.trim() } : {}),
     ...(step.exerciseKind !== undefined ? { exercise_kind: step.exerciseKind } : {}),
+    ...(step.sets !== undefined ? { sets: step.sets } : {}),
+    ...(step.restType !== undefined ? { rest_type: step.restType } : {}),
+    ...(step.restValue !== undefined ? { rest_value: step.restValue } : {}),
+    ...(step.overview?.trim() ? { overview: step.overview.trim() } : {}),
     ...(step.sendOffSeconds !== undefined ? { send_off_seconds: step.sendOffSeconds } : {})
   };
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1011,9 +1011,16 @@ const api = {
   uploadTrainingPlanDraft: (
     draftId: string,
     unitSystem: UnitSystem,
-    destination?: TrainingPlanDestination
+    destination?: TrainingPlanDestination,
+    scheduleDate?: string
   ): Promise<UploadPlanResult> =>
-    ipcRenderer.invoke("chat:uploadPlanDraft", draftId, unitSystem, destination),
+    ipcRenderer.invoke(
+      "chat:uploadPlanDraft",
+      draftId,
+      unitSystem,
+      destination,
+      scheduleDate
+    ),
   confirmWorkoutDelete: (requestId: string): Promise<DeleteWorkoutResult> =>
     ipcRenderer.invoke("chat:confirmWorkoutDelete", requestId),
   setWindowBackground: (color: string): Promise<void> =>

--- a/electron/trainingHubService.ts
+++ b/electron/trainingHubService.ts
@@ -108,6 +108,11 @@ import {
   workoutExerciseName,
   workoutSportFromType
 } from "./workoutCapabilities";
+import {
+  searchWorkoutExerciseCatalog,
+  type WorkoutExerciseSearchInput,
+  type WorkoutExerciseSearchResult
+} from "./exerciseCatalogSearch";
 import { TRAINING_HUB_EXPORT_FORMATS } from "./types";
 import { signRequest, sha256Hex } from "./awsSigV4";
 import { createStoreZip } from "./zipStore";
@@ -2502,15 +2507,32 @@ function exerciseCatalogRows(value: unknown): Record<string, unknown>[] {
   ];
 }
 
+const WORKOUT_EXERCISE_CATALOG_CACHE_MS = 5 * 60_000;
+const workoutExerciseCatalogCache = new Map<
+  string,
+  { expiresAt: number; rows: Record<string, unknown>[] }
+>();
+
 async function loadWorkoutExerciseCatalog(sport: WorkoutSport): Promise<Record<string, unknown>[]> {
   if (sport !== "strength" && sport !== "hyrox") return [];
   const auth = getStoredAuth();
+  const catalogSport = workoutSportTypeForService(sport);
+  const cacheKey = `${auth?.userId ?? "anonymous"}:${catalogSport}`;
+  const cached = workoutExerciseCatalogCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.rows;
+  }
   const raw = await trainingHubGet<unknown>("/training/exercise/query", {
-    sportType: workoutSportTypeForService(sport),
+    sportType: catalogSport,
     ...(auth?.userId ? { userId: auth.userId } : {}),
     keyword: ""
   });
-  return exerciseCatalogRows(raw);
+  const rows = exerciseCatalogRows(raw);
+  workoutExerciseCatalogCache.set(cacheKey, {
+    expiresAt: Date.now() + WORKOUT_EXERCISE_CATALOG_CACHE_MS,
+    rows
+  });
+  return rows;
 }
 
 export async function listWorkoutExercises(
@@ -2533,6 +2555,13 @@ export async function listWorkoutExercises(
     };
     return [[id, option] as const];
   })).values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export async function searchWorkoutExercises(
+  sport: WorkoutSport,
+  input: WorkoutExerciseSearchInput
+): Promise<WorkoutExerciseSearchResult[]> {
+  return searchWorkoutExerciseCatalog(await loadWorkoutExerciseCatalog(sport), input);
 }
 
 export interface TrainingPlanExerciseResolutionIssue {
@@ -2570,15 +2599,21 @@ export async function resolveTrainingPlanExercises(
     const plainSteps = entry.steps.flatMap((step) =>
       "repeat" in step ? step.steps : [step]
     );
-    const unresolved = plainSteps.filter(
-      (step) => step.kind === "training" && !step.exercise_id && step.exercise_name
+    const exerciseSteps = plainSteps.filter(
+      (step) => step.kind === "training" && (step.exercise_id || step.exercise_name)
     );
-    if (!unresolved.length) continue;
+    if (!exerciseSteps.length) continue;
     const catalog = await catalogFor(sport);
 
-    for (const step of unresolved) {
-      const exerciseName = step.exercise_name!;
-      const resolution = resolveWorkoutExerciseName(catalog, exerciseName);
+    for (const step of exerciseSteps) {
+      const requestedId = step.exercise_id?.trim();
+      const exerciseName = step.exercise_name?.trim() || (requestedId ? `ID ${requestedId}` : "Exercise");
+      const idMatch = requestedId
+        ? catalog.find((row) => workoutExerciseId(row) === requestedId)
+        : undefined;
+      const resolution = idMatch || !step.exercise_name
+        ? { match: idMatch, candidates: [] }
+        : resolveWorkoutExerciseName(catalog, step.exercise_name);
       const match = resolution.match;
       const id = match ? workoutExerciseId(match) : undefined;
       if (!match || !id) {
@@ -6161,6 +6196,7 @@ function buildTrainingHubHeaders(
 }
 
 function clearTrainingHubAuth(): void {
+  workoutExerciseCatalogCache.clear();
   deleteSettings([
     SETTINGS.accessToken,
     SETTINGS.userId,

--- a/electron/trainingLibraryService.ts
+++ b/electron/trainingLibraryService.ts
@@ -476,8 +476,6 @@ export function buildTrainingPlanCalendarProjection(
     throw new Error("Native COROS plans are read-only in the Training Library.");
   }
   const startDay = normalizedCalendarDay(startDate);
-  const start = parsePlanDay(startDay)!;
-  if (start.getDay() !== 1) throw new Error("The plan start date must be a Monday.");
   if (startDay < today) throw new Error("A training plan cannot be installed in the past.");
   const projectedPlan = shiftTrainingPlan(plan, dashedCalendarDay(startDay));
   const planRevision = trainingPlanCalendarRevision(projectedPlan);

--- a/electron/trainingPlanDomain.ts
+++ b/electron/trainingPlanDomain.ts
@@ -105,8 +105,7 @@ export function trainingPlanFromDraftPreview(
   if (request.availableDayIndexes.some((day) => !Number.isInteger(day) || day < 0 || day > 6)) throw new Error("Available days must be Monday through Sunday.");
   if (request.availableDayIndexes.length < request.sessionsPerWeek) throw new Error("Choose at least as many available days as weekly sessions.");
   if (request.maxSessionMinutes !== undefined && request.maxSessionMinutes <= 0) throw new Error("The session-duration limit must be greater than zero.");
-  const start = normalizedPlanDate(request.startDate);
-  if (!start || start.getDay() !== 1) throw new Error("Week 1 must start on a Monday.");
+  if (!normalizedPlanDate(request.startDate)) throw new Error("Choose a valid plan start date.");
   if (!preview.name.trim()) throw new Error("Training Coach returned a plan without a name.");
 
   const document = createTrainingPlan(preview.name, "coach");
@@ -126,7 +125,9 @@ export function trainingPlanFromDraftPreview(
       throw new Error(`Generated workout "${entry.name}" falls outside the requested plan dates.`);
     }
     const dayIndex = offset % 7;
-    if (!request.availableDayIndexes.includes(dayIndex)) {
+    const scheduledDay = normalizedPlanDate(scheduleDate)!;
+    const scheduledWeekdayIndex = (scheduledDay.getDay() + 6) % 7;
+    if (!request.availableDayIndexes.includes(scheduledWeekdayIndex)) {
       throw new Error(`Generated workout "${entry.name}" was placed on an unavailable day.`);
     }
     const sport = entry.source.sport ?? "run";
@@ -501,7 +502,7 @@ export function validateTrainingPlan(
       issues.push({ path: `entries.${entry.id}`, message: "A workout is outside the plan range.", severity: "error" });
     }
     if (entry.dayIndex !== undefined && (entry.dayIndex < 0 || entry.dayIndex > 6)) {
-      issues.push({ path: `entries.${entry.id}.dayIndex`, message: "Day must be Monday through Sunday.", severity: "error" });
+      issues.push({ path: `entries.${entry.id}.dayIndex`, message: "Plan day must be between Day 1 and Day 7.", severity: "error" });
     }
     if (entry.kind === "workout" && !entry.workout && !entry.programId) {
       issues.push({ path: `entries.${entry.id}`, message: "Workout entry has no reusable workout definition.", severity: "error" });

--- a/electron/types.ts
+++ b/electron/types.ts
@@ -2672,7 +2672,7 @@ export interface TrainingPlanEntry {
   id: string;
   kind: TrainingPlanEntryKind;
   weekIndex: number;
-  /** Undefined dayIndex places the workout in the holding area. */
+  /** Zero-based day within the plan week; undefined places the entry in the holding area. */
   dayIndex?: number;
   sortOrder: number;
   title?: string;
@@ -2692,7 +2692,7 @@ export interface TrainingPlanGenerationRequest {
   difficulty: TrainingPlanDifficulty;
   weeks: number;
   sessionsPerWeek: number;
-  /** ISO date for Week 1 Monday. */
+  /** ISO date for Day 1 of Week 1. */
   startDate: string;
   /** Monday = 0 through Sunday = 6. */
   availableDayIndexes: number[];
@@ -3061,6 +3061,8 @@ export interface PlanDraftPreviewEntry {
 
 export interface PlanDraftPreview {
   draftId: string;
+  /** Distinguishes a multi-workout plan from a reusable one-off workout. */
+  artifactType?: "plan" | "workout";
   name: string;
   summary: string;
   entries: PlanDraftPreviewEntry[];
@@ -3400,6 +3402,14 @@ export interface RunWorkoutEditorStep {
   exerciseId?: string;
   exerciseName?: string;
   exerciseKind?: number;
+  /** Number of sets for a standalone Strength exercise. */
+  sets?: number;
+  /** COROS recovery mode used between sets. Strength uses timed rest (1). */
+  restType?: number;
+  /** Recovery duration between sets, in seconds. */
+  restValue?: number;
+  /** Optional per-step instructions. COROS localization keys are not exposed here. */
+  overview?: string;
   sendOffSeconds?: number;
   editable: boolean;
   unsupportedReason?: string;

--- a/electron/workoutCapabilities.ts
+++ b/electron/workoutCapabilities.ts
@@ -244,7 +244,7 @@ export function workoutExerciseId(row: Record<string, unknown>): string | undefi
     : String(value);
 }
 
-function normalizeExerciseName(value: string): string {
+export function normalizeWorkoutExerciseName(value: string): string {
   const singularize = (token: string): string => {
     if (token.length > 4 && token.endsWith("ies")) return `${token.slice(0, -3)}y`;
     if (token.length > 4 && /(ches|shes|xes|zes)$/.test(token)) return token.slice(0, -2);
@@ -262,6 +262,44 @@ function normalizeExerciseName(value: string): string {
     .filter(Boolean)
     .map(singularize)
     .join(" ");
+}
+
+function workoutExerciseNameTokens(value: string): string[] {
+  return normalizeWorkoutExerciseName(value).split(" ").filter(Boolean);
+}
+
+function workoutExerciseTokenKey(value: string): string {
+  return [...new Set(workoutExerciseNameTokens(value))].sort().join(" ");
+}
+
+/**
+ * Token-aware similarity for user/AI exercise phrasing. COROS frequently puts
+ * equipment at the end ("Chest Press Machine") while natural language puts it
+ * first ("machine chest press"), so ordered substring matching is insufficient.
+ */
+export function workoutExerciseNameSimilarity(
+  requestedName: string,
+  catalogName: string
+): number {
+  const requested = [...new Set(workoutExerciseNameTokens(requestedName))];
+  const candidate = [...new Set(workoutExerciseNameTokens(catalogName))];
+  if (requested.length === 0 || candidate.length === 0) return 0;
+  if (workoutExerciseTokenKey(requestedName) === workoutExerciseTokenKey(catalogName)) {
+    return 1;
+  }
+
+  const candidateTokens = new Set(candidate);
+  const overlap = requested.filter((token) => candidateTokens.has(token)).length;
+  if (overlap === 0) return 0;
+  const recall = overlap / requested.length;
+  const precision = overlap / candidate.length;
+  const orderedRequested = normalizeWorkoutExerciseName(requestedName);
+  const orderedCandidate = normalizeWorkoutExerciseName(catalogName);
+  const containmentBonus =
+    orderedRequested.includes(orderedCandidate) || orderedCandidate.includes(orderedRequested)
+      ? 0.08
+      : 0;
+  return Math.min(0.99, recall * 0.68 + precision * 0.32 + containmentBonus);
 }
 
 const COROS_EXERCISE_IMAGE_PREFIX = "/source/exercise_img/";
@@ -343,20 +381,37 @@ export function resolveWorkoutExerciseName(
 ): WorkoutExerciseResolution {
   const literal = (value: string): string => value.trim().toLocaleLowerCase();
   const queryLiteral = literal(requestedName);
-  const query = normalizeExerciseName(requestedName);
+  const query = normalizeWorkoutExerciseName(requestedName);
   if (!query) return { candidates: [] };
   const literalExact = catalog.filter(
     (row) => literal(workoutExerciseName(row)) === queryLiteral
   );
   const canonicalExact = catalog.filter((row) => {
-    const candidate = normalizeExerciseName(workoutExerciseName(row));
+    const candidate = normalizeWorkoutExerciseName(workoutExerciseName(row));
     return candidate === query || candidate.replace(/\s/g, "") === query.replace(/\s/g, "");
   });
+  const tokenExact = catalog.filter(
+    (row) => workoutExerciseTokenKey(workoutExerciseName(row)) === workoutExerciseTokenKey(requestedName)
+  );
+  const ranked = catalog
+    .map((row) => ({
+      row,
+      score: workoutExerciseNameSimilarity(requestedName, workoutExerciseName(row))
+    }))
+    .filter(({ score }) => score >= 0.48)
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        workoutExerciseName(left.row).localeCompare(workoutExerciseName(right.row))
+    )
+    .map(({ row }) => row);
   const matches = literalExact.length
     ? literalExact
     : canonicalExact.length
       ? canonicalExact
-      : catalog.filter((row) => normalizeExerciseName(workoutExerciseName(row)).includes(query));
+      : tokenExact.length
+        ? tokenExact
+        : ranked;
   const unique = [...new Map(
     matches.map((row) => [workoutExerciseId(row) ?? workoutExerciseName(row), row])
   ).values()];
@@ -1066,8 +1121,18 @@ export function validateWorkoutDraftShared(
     if (intensityError) errors[`${path}.intensity`] = intensityError;
     const needsExercise = draft.sport === "strength" ||
       (draft.sport === "hyrox" && step.exerciseKind !== undefined);
-    if (needsExercise && step.kind === "training" && !step.exerciseId && !step.exerciseName) {
-      errors[`${path}.exercise`] = `${capability.label} training steps require an exercise.`;
+    if (needsExercise && step.kind === "training" && !step.exerciseId) {
+      errors[`${path}.exercise`] = `Select an exact COROS exercise for this ${capability.label} step.`;
+    }
+    if (draft.sport === "strength" && step.kind === "training") {
+      const sets = step.sets ?? 1;
+      if (!Number.isInteger(sets) || sets < 1 || sets > 99) {
+        errors[`${path}.sets`] = "Sets must be a whole number from 1 to 99.";
+      }
+      const restValue = step.restValue ?? 0;
+      if (!Number.isInteger(restValue) || restValue < 0 || restValue > 3_600) {
+        errors[`${path}.rest`] = "Rest between sets must be from 0 to 3600 seconds.";
+      }
     }
   };
   draft.nodes.forEach((node, index) => {
@@ -1238,7 +1303,11 @@ export function buildDraftTrainingPlanInputSchema(): Record<string, unknown> {
       intensity,
       exercise_id: { type: "string" },
       exercise_name: { type: "string" },
-      exercise_kind: { type: "integer" }
+      exercise_kind: { type: "integer" },
+      sets: { type: "integer", minimum: 1, maximum: 99, description: "Strength sets for this exercise." },
+      rest_type: { type: "integer", enum: [1], description: "Timed recovery between Strength sets." },
+      rest_value: { type: "integer", minimum: 0, maximum: 3600, description: "Recovery seconds between Strength sets." },
+      overview: { type: "string", maxLength: 300, description: "Optional step instructions." }
     },
     required: ["kind", "target_type"]
   };
@@ -1324,5 +1393,51 @@ export function buildDraftTrainingPlanInputSchema(): Record<string, unknown> {
       }
     },
     required: ["name", "workouts"]
+  };
+}
+
+/** JSON Schema for a single reusable workout, without plan/calendar fields. */
+export function buildDraftWorkoutInputSchema(): Record<string, unknown> {
+  const planSchema = buildDraftTrainingPlanInputSchema() as {
+    properties: {
+      workouts: {
+        items: {
+          oneOf: Array<{
+            type: string;
+            properties: Record<string, unknown>;
+            required: string[];
+          }>;
+        };
+      };
+    };
+  };
+  const workoutVariants = planSchema.properties.workouts.items.oneOf.map(
+    (variant) => {
+      const {
+        schedule_date: _scheduleDate,
+        sort_no: _sortNo,
+        save_to_library: _saveToLibrary,
+        ...properties
+      } = variant.properties;
+      return { ...variant, properties };
+    }
+  );
+
+  return {
+    type: "object",
+    properties: {
+      workout: {
+        oneOf: workoutVariants,
+        description:
+          "One complete standalone workout. Do not include schedule_date or save_to_library; the athlete chooses Workout Library or Calendar from the confirmation card."
+      },
+      calendar_date: {
+        type: "string",
+        pattern: "^\\d{8}$",
+        description:
+          "Optional suggested calendar date (YYYYMMDD) when the athlete explicitly asks for a day. The athlete can change it before confirming."
+      }
+    },
+    required: ["workout"]
   };
 }

--- a/scripts/test-chat-history-store.mjs
+++ b/scripts/test-chat-history-store.mjs
@@ -14,6 +14,7 @@ const {
   listChatSessions,
   migrateLegacyTranscriptRow,
   parseChatTranscriptJson,
+  restoreChatPlanDraftSources,
   saveChatSession
 } = await import(`${distUrl("chatHistoryStore.js")}?cacheBust=${Date.now()}`);
 
@@ -123,6 +124,88 @@ const waitingPromptEntry = {
 assert.deepEqual(
   parseChatTranscriptJson(JSON.stringify([waitingPromptEntry])),
   [waitingPromptEntry]
+);
+
+const oneOffWorkoutEntry = {
+  kind: "planDraft",
+  draft: {
+    draftId: "workout-1",
+    artifactType: "workout",
+    name: "Full Gym Push Day",
+    summary: "Strength · 16 sets · structured",
+    entries: [{
+      key: "push-day",
+      name: "Full Gym Push Day",
+      sport: "strength",
+      volume: "16 sets",
+      scheduleDate: "2026-07-31",
+      saveToLibrary: true,
+      workoutType: "structured",
+      stepsSummary: "warmup 10 min → Chest Press Machine 4 × 8 reps",
+      source: {
+        key: "push-day",
+        name: "Full Gym Push Day",
+        sport: "strength",
+        save_to_library: true,
+        steps: [
+          {
+            kind: "warmup",
+            target_type: "time",
+            target_duration_seconds: 600
+          },
+          {
+            kind: "training",
+            target_type: "reps",
+            target_reps: 8,
+            exercise_id: "1338",
+            exercise_name: "Chest Press Machine",
+            sets: 4,
+            rest_type: 1,
+            rest_value: 120,
+            intensity: { type: "weight", mode: "weight", value: 0, unit: "kg" }
+          }
+        ]
+      }
+    }],
+    conflicts: [],
+    warnings: [],
+    uploadedAt: 1234,
+    uploadResult: {
+      workoutsScheduled: 1,
+      workoutsCreated: 0,
+      destination: "calendar"
+    }
+  }
+};
+assert.equal(
+  parseChatTranscriptJson(JSON.stringify([oneOffWorkoutEntry]))[0].draft.artifactType,
+  "workout"
+);
+assert.equal(
+  parseChatTranscriptJson(JSON.stringify([oneOffWorkoutEntry]))[0].draft.uploadResult.destination,
+  "calendar"
+);
+assert.deepEqual(
+  parseChatTranscriptJson(JSON.stringify([oneOffWorkoutEntry]))[0].draft.entries[0].source,
+  oneOffWorkoutEntry.draft.entries[0].source
+);
+const flattenedWorkoutEntry = structuredClone(oneOffWorkoutEntry);
+delete flattenedWorkoutEntry.draft.entries[0].source;
+const restoredWorkoutEntry = restoreChatPlanDraftSources(
+  parseChatTranscriptJson(JSON.stringify([flattenedWorkoutEntry])),
+  (draftId) => draftId === oneOffWorkoutEntry.draft.draftId
+    ? JSON.stringify(oneOffWorkoutEntry.draft)
+    : undefined
+)[0];
+assert.deepEqual(
+  restoredWorkoutEntry.draft.entries[0].source,
+  oneOffWorkoutEntry.draft.entries[0].source
+);
+const legacyPlanEntry = structuredClone(oneOffWorkoutEntry);
+delete legacyPlanEntry.draft.artifactType;
+assert.equal(
+  parseChatTranscriptJson(JSON.stringify([legacyPlanEntry]))[0].draft.artifactType,
+  "plan"
 );
 assert.deepEqual(
   parseChatTranscriptJson(

--- a/scripts/test-chat-service.mjs
+++ b/scripts/test-chat-service.mjs
@@ -46,8 +46,14 @@ assert.match(coachInstructions, /multi-sport endurance and strength-training coa
 assert.match(coachInstructions, /Honor every sport the athlete explicitly requests/);
 assert.match(coachInstructions, /Never add an unfamiliar sport merely for variety/);
 assert.match(coachInstructions, /Open Water Swim is not Pool Swim/);
+assert.match(coachInstructions, /exactly one standalone workout/);
+assert.match(coachInstructions, /call draft_workout/);
+assert.match(coachInstructions, /Workout Library or Calendar/);
+assert.match(coachInstructions, /never disguise it as a one-workout training plan/);
 assert.match(coachInstructions, /exercise_resolution_required/);
-assert.match(coachInstructions, /call draft_training_plan again in the same response/);
+assert.match(coachInstructions, /call search_coros_exercises first/);
+assert.match(coachInstructions, /naming mismatch alone is never a reason/);
+assert.match(coachInstructions, /call the same draft tool again in the same response/);
 assert.match(coachInstructions, /request_coach_input/);
 
 const interactionTool = getChatInteractionTools()[0];

--- a/scripts/test-chat-workout-tools.mjs
+++ b/scripts/test-chat-workout-tools.mjs
@@ -12,11 +12,68 @@ const {
   formatEntryStepsSummary,
   validatePlanDraft
 } = await import(`${distUrl("corosWorkoutBuilder.js")}?cacheBust=${Date.now()}`);
-const { buildDraftTrainingPlanInputSchema } = await import(
+const { buildDraftTrainingPlanInputSchema, buildDraftWorkoutInputSchema } = await import(
   `${distUrl("workoutCapabilities.js")}?cacheBust=${Date.now()}`
 );
-const { buildTrainingPlanUploadInput } = await import(
+const {
+  buildTrainingPlanDestinationInput,
+  buildTrainingPlanUploadInput,
+  isChatWorkoutTool
+} = await import(
   `${distUrl("chatWorkoutTools.js")}?cacheBust=${Date.now()}`
+);
+const {
+  classifyWorkoutExerciseName,
+  searchWorkoutExerciseCatalog
+} = await import(`${distUrl("exerciseCatalogSearch.js")}?cacheBust=${Date.now()}`);
+
+const strengthCatalog = [
+  { originId: "1045", displayName: "Dumbbell Flys" },
+  { originId: "1334", displayName: "Lateral Raise Machine" },
+  { originId: "1337", displayName: "Shoulder Press Machine" },
+  { originId: "1338", displayName: "Chest Press Machine" },
+  { originId: "1341", displayName: "Triceps Pushdown Machine" },
+  { originId: "1004", displayName: "Push Ups" },
+  { originId: "1053", displayName: "Seated Cable Row" }
+];
+
+assert.equal(isChatWorkoutTool("search_coros_exercises"), true);
+assert.equal(isChatWorkoutTool("draft_workout"), true);
+
+assert.deepEqual(
+  classifyWorkoutExerciseName("Chest Press Machine").equipment,
+  ["machine"]
+);
+assert.deepEqual(
+  classifyWorkoutExerciseName("Dumbbell Flys").targetMuscles,
+  ["chest", "triceps", "shoulders"]
+);
+assert.equal(
+  searchWorkoutExerciseCatalog(strengthCatalog, {
+    query: "machine chest press",
+    limit: 3
+  })[0]?.id,
+  "1338"
+);
+assert.deepEqual(
+  searchWorkoutExerciseCatalog(strengthCatalog, {
+    targetMuscles: ["chest"],
+    equipment: ["machine"]
+  }).map((entry) => entry.id),
+  ["1338"]
+);
+assert.ok(
+  searchWorkoutExerciseCatalog(strengthCatalog, {
+    targetMuscles: ["triceps"],
+    equipment: ["machine"]
+  }).some((entry) => entry.id === "1341")
+);
+assert.deepEqual(
+  searchWorkoutExerciseCatalog(strengthCatalog, {
+    movementPatterns: ["pull"],
+    equipment: ["cable"]
+  }).map((entry) => entry.id),
+  ["1053"]
 );
 
 const draft = {
@@ -67,6 +124,16 @@ assert.deepEqual(
   new Set(["run", "trailRun", "bike", "swim", "strength", "xcSki", "indoorClimb", "bouldering", "hyrox"])
 );
 
+const workoutSchema = buildDraftWorkoutInputSchema();
+const workoutSportSchemas = workoutSchema.properties.workout.oneOf;
+assert.equal(workoutSportSchemas.length, 9);
+assert.equal(workoutSchema.properties.calendar_date.pattern, "^\\d{8}$");
+for (const sportSchema of workoutSportSchemas) {
+  assert.equal("schedule_date" in sportSchema.properties, false);
+  assert.equal("save_to_library" in sportSchema.properties, false);
+  assert.equal("sort_no" in sportSchema.properties, false);
+}
+
 // Representative typed result for: “Create a 5 km run at 135–145 bpm.”
 const heartRateDraft = {
   name: "Heart Rate Plan",
@@ -90,6 +157,25 @@ assert.equal(validatePlanDraft(heartRateDraft, { todayDay: "20260101" }).ok, tru
 const heartRatePreview = buildPlanPreview("draft-test-hr", heartRateDraft);
 assert.equal(heartRatePreview.entries[0]?.sport, "run");
 assert.match(heartRatePreview.entries[0]?.stepsSummary ?? "", /135–145 bpm/);
+const oneOffPreview = buildPlanPreview("draft-one-off", heartRateDraft, {
+  artifactType: "workout"
+});
+assert.equal(oneOffPreview.artifactType, "workout");
+assert.doesNotMatch(oneOffPreview.summary, /none scheduled/);
+assert.equal(oneOffPreview.warnings.length, 0);
+const oneOffCalendarInput = buildTrainingPlanDestinationInput(
+  heartRateDraft,
+  "calendar",
+  "2099-12-06"
+);
+assert.equal(oneOffCalendarInput.workouts[0].schedule_date, "20991206");
+assert.equal(oneOffCalendarInput.workouts[0].save_to_library, false);
+const oneOffLibraryInput = buildTrainingPlanDestinationInput(
+  heartRateDraft,
+  "workoutLibrary"
+);
+assert.equal(oneOffLibraryInput.workouts[0].schedule_date, undefined);
+assert.equal(oneOffLibraryInput.workouts[0].save_to_library, true);
 const heartRatePayload = buildWorkoutPayload(
   heartRateDraft.workouts[0].name,
   heartRateDraft.workouts[0].steps,

--- a/scripts/test-coros-workout-builder.mjs
+++ b/scripts/test-coros-workout-builder.mjs
@@ -445,6 +445,31 @@ assert.equal(imperialPreview.entries[0]?.volume, "5.00 mi");
 assert.equal(imperialPreview.entries[1]?.volume, "100 yd");
 assert.ok(imperialPreview.entries.every((entry) => entry.source));
 
+const strengthPreview = buildPlanPreview("draft-strength", {
+  name: "Push plan",
+  workouts: [{
+    key: "push",
+    name: "Push day",
+    sport: "strength",
+    steps: [{
+      kind: "training",
+      exercise_id: "bench-press",
+      exercise_name: "Bench Press",
+      target_type: "reps",
+      target_reps: 8,
+      sets: 4,
+      rest_type: 1,
+      rest_value: 90,
+      intensity: { type: "weight", mode: "weight", value: 70, unit: "kg" }
+    }]
+  }]
+});
+assert.equal(strengthPreview.entries[0]?.volume, "4 sets");
+assert.equal(
+  strengthPreview.entries[0]?.stepsSummary,
+  "Bench Press 4 × 8 reps @ 70 kg (90 sec rest)"
+);
+
 const reset = resetProgramForCreate({
   id: "old",
   idInPlan: "99",

--- a/scripts/test-training-library.mjs
+++ b/scripts/test-training-library.mjs
@@ -143,6 +143,23 @@ assert.equal(generated.entries[0].workout.steps[0].repeat, 4);
 assert.deepEqual(generated.entries[1].workout.steps[0].intensity, { type: "weight", mode: "weight", value: 24, unit: "kg" });
 assert.deepEqual(generated.entries[3].workout.sport_options, { poolLength: { value: 25, unit: "m" } });
 assert.match(generated.notes, /Review loads/);
+const tuesdayDraft = structuredClone(generatedDraft);
+tuesdayDraft.draftId = "tuesday-start";
+const tuesdayDates = ["20260804", "20260806", "20260811", "20260813"];
+tuesdayDraft.entries.forEach((entry, index) => {
+  entry.scheduleDate = tuesdayDates[index];
+  entry.source.schedule_date = tuesdayDates[index];
+});
+const tuesdayPlan = domain.trainingPlanFromDraftPreview(tuesdayDraft, {
+  ...generationRequest,
+  startDate: "2026-08-04",
+  availableDayIndexes: [1, 3]
+});
+assert.deepEqual(tuesdayPlan.entries.map((entry) => [entry.weekIndex, entry.dayIndex]), [[0, 0], [0, 2], [1, 0], [1, 2]]);
+assert.throws(
+  () => domain.trainingPlanFromDraftPreview(tuesdayDraft, { ...generationRequest, startDate: "2026-08-04" }),
+  /unavailable day/i
+);
 const coachLibraryPlan = domain.trainingPlanFromCoachDraftPreview(generatedDraft);
 assert.equal(coachLibraryPlan.source, "coach");
 assert.equal(coachLibraryPlan.startDate, "2026-08-03");
@@ -224,7 +241,8 @@ assert.equal(linkedEntry.programId, "remote-program", "the linked source entry r
 assert.equal(detachedEntry.workout.steps[0].exercise_id, "deadlift-1");
 for (const specialistInput of [
   { key: "pool", name: "Pool", sport: "swim", sport_options: { poolLength: { value: 50, unit: "m" } }, steps: [{ kind: "sendOff", name: "100s", target_type: "distance", target_distance_meters: 100, send_off_seconds: 105, intensity: { type: "swimStroke", stroke: "butterfly" } }] },
-  { key: "climb", name: "Boulders", sport: "bouldering", sport_options: { gradingSystem: "font" }, steps: [{ kind: "training", name: "Limit route", target_type: "routes", target_routes: 4, intensity: { type: "climbGrade", system: "font", absoluteGrade: "7B" } }] }
+  { key: "climb", name: "Boulders", sport: "bouldering", sport_options: { gradingSystem: "font" }, steps: [{ kind: "training", name: "Limit route", target_type: "routes", target_routes: 4, intensity: { type: "climbGrade", system: "font", absoluteGrade: "7B" } }] },
+  { key: "strength", name: "Push", sport: "strength", steps: [{ kind: "training", name: "Bench Press", target_type: "reps", target_reps: 8, exercise_id: "bench-press", exercise_name: "Bench Press", sets: 4, rest_type: 1, rest_value: 90, overview: "Pause on the chest", intensity: { type: "weight", mode: "weight", value: 70, unit: "kg" } }] }
 ]) {
   const specialistDraft = planWorkoutEditor.planWorkoutInputToEditorDraft(specialistInput);
   assert.deepEqual(planWorkoutEditor.editorDraftToPlanWorkoutInput(specialistDraft, specialistInput).steps, specialistInput.steps);
@@ -243,7 +261,9 @@ assert.equal(projection.conflicts[0].existing[0].name, "Existing run");
 const holdingPlan = structuredClone(calendarPlan);
 holdingPlan.entries[0].dayIndex = undefined;
 assert.match(library.buildTrainingPlanCalendarProjection(holdingPlan, "2099-08-03", [], "20990101").blockers[0], /holding area/i);
-assert.throws(() => library.buildTrainingPlanCalendarProjection(calendarPlan, "2099-08-04", [], "20990101"), /Monday/i);
+const anyDayProjection = library.buildTrainingPlanCalendarProjection(calendarPlan, "2099-08-04", [], "20990101");
+assert.equal(anyDayProjection.startDate, "2099-08-04");
+assert.deepEqual(anyDayProjection.entries.map((entry) => entry.happenDay), ["20990804", "20990806"]);
 const revisionBefore = domain.trainingPlanCalendarRevision(calendarPlan);
 calendarPlan.entries[0].title = "Edited after install";
 assert.notEqual(domain.trainingPlanCalendarRevision(calendarPlan), revisionBefore);

--- a/scripts/test-workout-intensity-codec.mjs
+++ b/scripts/test-workout-intensity-codec.mjs
@@ -188,7 +188,7 @@ const sportFixtures = [
   ["trailRun", { target_type: "elevationGain", target_elevation_gain_meters: 500, intensity: { type: "effortPacePercent", preset: "aerobicEndurance" } }],
   ["bike", { target_type: "time", target_duration_seconds: 600, intensity: { type: "ftpPercent", preset: "threshold" } }],
   ["swim", { target_type: "distance", target_distance_meters: 100, intensity: { type: "swimStroke", stroke: "mix" } }],
-  ["strength", { target_type: "reps", target_reps: 12, exercise_id: "T5067", intensity: { type: "weight", mode: "weight", value: 20, unit: "kg" } }],
+  ["strength", { target_type: "reps", target_reps: 12, exercise_id: "T5067", sets: 4, rest_type: 1, rest_value: 75, overview: "Control the lowering phase", intensity: { type: "weight", mode: "weight", value: 20, unit: "kg" } }],
   ["xcSki", { target_type: "distance", target_distance_meters: 1_000, intensity: { type: "speed", low: 15, high: 20, unit: "km/h" } }],
   ["indoorClimb", { target_type: "routes", target_routes: 4, intensity: { type: "climbGrade", system: "yds", relativeToOnsight: 0 } }],
   ["bouldering", { target_type: "routes", target_routes: 6, intensity: { type: "climbGrade", system: "vScale", absoluteGrade: "V5" } }],
@@ -206,6 +206,17 @@ for (const [sport, values] of sportFixtures) {
   if (sport === "hyrox") {
     assert.equal(program.exercises[0].subType, 2);
     assert.equal(program.exercises[0].hyroxTrainingMode, "strength");
+  }
+  if (sport === "strength") {
+    assert.equal(draft.nodes[0].sets, 4);
+    assert.equal(draft.nodes[0].restType, 1);
+    assert.equal(draft.nodes[0].restValue, 75);
+    assert.equal(draft.nodes[0].overview, "Control the lowering phase");
+    assert.equal(written.exercises[0].sets, 4);
+    assert.equal(written.exercises[0].restType, 1);
+    assert.equal(written.exercises[0].restValue, 75);
+    assert.equal(written.exercises[0].overview, "Control the lowering phase");
+    assert.equal(written.totalSets, 4);
   }
 }
 
@@ -244,6 +255,11 @@ assert.deepEqual(
   workoutSchemas.map((workout) => workout.properties.sport.const).sort(),
   [...codec.WORKOUT_SPORTS].sort()
 );
+const strengthWorkoutSchema = workoutSchemas.find((workout) => workout.properties.sport.const === "strength");
+const strengthStepSchema = strengthWorkoutSchema.properties.steps.items.oneOf[0];
+assert.equal(strengthStepSchema.properties.sets.maximum, 99);
+assert.deepEqual(strengthStepSchema.properties.rest_type.enum, [1]);
+assert.equal(strengthStepSchema.properties.rest_value.maximum, 3600);
 const bikeSchema = workoutSchemas.find((workout) => workout.properties.sport.const === "bike");
 const bikeStepSchema = bikeSchema.properties.steps.items.oneOf[0];
 assert.match(JSON.stringify(bikeStepSchema.properties.intensity), /ftpPercent/);
@@ -262,9 +278,29 @@ assert.equal(
 const exerciseCatalog = [
   { originId: "1", displayName: "Back Squat" },
   { originId: "2", displayName: "Front Squat" },
-  { originId: "3", displayName: "Deadlift" }
+  { originId: "3", displayName: "Deadlift" },
+  { originId: "1045", displayName: "Dumbbell Flys" },
+  { originId: "1337", displayName: "Shoulder Press Machine" },
+  { originId: "1338", displayName: "Chest Press Machine" },
+  { originId: "1341", displayName: "Triceps Pushdown Machine" }
 ];
 assert.equal(codec.resolveWorkoutExerciseName(exerciseCatalog, "Deadlift").match.originId, "3");
+assert.equal(
+  codec.resolveWorkoutExerciseName(exerciseCatalog, "Machine Chest Press").match.originId,
+  "1338"
+);
+assert.equal(
+  codec.resolveWorkoutExerciseName(exerciseCatalog, "Machine Shoulder Press").match.originId,
+  "1337"
+);
+assert.equal(
+  codec.resolveWorkoutExerciseName(exerciseCatalog, "Dumbbell Fly").match.originId,
+  "1045"
+);
+assert.equal(
+  codec.resolveWorkoutExerciseName(exerciseCatalog, "Machine Triceps Pushdown").match.originId,
+  "1341"
+);
 assert.deepEqual(
   codec.resolveWorkoutExerciseName(exerciseCatalog, "squat").candidates,
   ["Back Squat", "Front Squat"]

--- a/src/calendar/WorkoutEditorModal.tsx
+++ b/src/calendar/WorkoutEditorModal.tsx
@@ -49,6 +49,7 @@ import {
   swimDistanceUnit
 } from "../units/units";
 import { ExerciseCombobox } from "./ExerciseCombobox";
+import { ExercisePreview } from "./ExercisePreview";
 import {
   CLIMB_GRADES,
   CLIMB_SYSTEM_IDS,
@@ -97,10 +98,19 @@ function emptyStep(
     nodeType: "step",
     kind,
     name: kind === "rest" ? "Rest" : kind === "warmup" ? "Warm Up" : kind === "cooldown" ? "Cool Down" : "Training",
-    target: { type: "time", seconds: kind === "rest" ? 60 : 300 },
-    intensity: structuredClone(capability.defaultIntensity),
+    target: sport === "strength" && kind === "training"
+      ? { type: "reps", count: 10 }
+      : { type: "time", seconds: kind === "rest" ? 60 : 300 },
+    intensity: sport === "strength" && kind !== "training"
+      ? { type: "none" }
+      : structuredClone(capability.defaultIntensity),
     ...(capability.requiresExercise && kind === "training"
-      ? { exerciseName: "" }
+      ? {
+          exerciseName: "",
+          ...(sport === "strength"
+            ? { sets: 3, restType: 1, restValue: 60 }
+            : {})
+        }
       : {}),
     editable: true
   };
@@ -160,6 +170,43 @@ function stepTitle(kind: RunWorkoutEditorStepKind): string {
         : kind === "sendOff"
           ? "Send-off"
         : "Training";
+}
+
+const STRENGTH_REST_PRESETS = [0, 30, 45, 60, 90, 120, 180] as const;
+
+type StrengthLoadMode = "unspecified" | "bodyweight" | "added";
+
+function strengthLoadMode(intensity: RunWorkoutEditorIntensity): StrengthLoadMode {
+  if (intensity.type !== "weight") return "unspecified";
+  return intensity.mode === "bodyweight" ? "bodyweight" : "added";
+}
+
+function strengthRestLabel(seconds: number): string {
+  if (seconds === 0) return "None";
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = seconds / 60;
+  return Number.isInteger(minutes) ? `${minutes}m` : `${minutes.toFixed(1)}m`;
+}
+
+function strengthTargetSummary(target: RunWorkoutEditorTarget): string {
+  if (target.type === "reps") return `${target.count} reps`;
+  if (target.type === "time") return clockFromSeconds(target.seconds);
+  if (target.type === "open") return "Open";
+  return target.type;
+}
+
+function strengthStepSummary(
+  step: RunWorkoutEditorStep
+): string {
+  const sets = step.sets ?? 1;
+  const target = strengthTargetSummary(step.target);
+  const load = step.intensity.type === "weight"
+    ? step.intensity.mode === "bodyweight"
+      ? "bodyweight"
+      : `${step.intensity.value} ${step.intensity.unit}`
+    : "load not set";
+  const rest = step.restValue ?? 0;
+  return `${sets} ${sets === 1 ? "set" : "sets"} × ${target} @ ${load}${sets > 1 ? `, ${strengthRestLabel(rest)} rest` : ""}`;
 }
 
 function targetForType(
@@ -603,14 +650,43 @@ export function WorkoutEditorModal({
                 </div>
 
                 <div className="workout-editor-structure-header">
-                  <div><h3>Workout structure</h3><p>Drag between cards to reorder. Drop one step on another to create a repeat.</p></div>
-                  <button type="button" className="ghost-button" disabled={!document.canEdit || saving} onClick={() => setDraft({ ...draft, nodes: [...draft.nodes, emptyStep("training", draft.sport)] })}>
-                    <Plus size={15} aria-hidden="true" /> Add step
-                  </button>
+                  <div>
+                    <h3>{draft.sport === "strength" ? "Strength session" : "Workout structure"}</h3>
+                    <p>{draft.sport === "strength"
+                      ? "Each exercise saves its own sets, per-set target, load, and recovery."
+                      : "Drag between cards to reorder. Drop one step on another to create a repeat."}</p>
+                  </div>
+                  {draft.sport === "strength" ? (
+                    <div className="workout-editor-add-actions" aria-label="Add strength session step">
+                      {([
+                        ["warmup", "Warm-up"],
+                        ["training", "Exercise"],
+                        ["rest", "Rest"],
+                        ["cooldown", "Cool-down"]
+                      ] as const).map(([kind, label]) => (
+                        <button
+                          key={kind}
+                          type="button"
+                          className="ghost-button"
+                          disabled={!document.canEdit || saving}
+                          onClick={() => setDraft({
+                            ...draft,
+                            nodes: [...draft.nodes, emptyStep(kind, draft.sport)]
+                          })}
+                        >
+                          <Plus size={14} aria-hidden="true" /> {label}
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <button type="button" className="ghost-button" disabled={!document.canEdit || saving} onClick={() => setDraft({ ...draft, nodes: [...draft.nodes, emptyStep("training", draft.sport)] })}>
+                      <Plus size={15} aria-hidden="true" /> Add step
+                    </button>
+                  )}
                 </div>
 
                 {draft.nodes.length === 0 ? (
-                  <div className="workout-editor-empty"><p>No workout steps yet.</p><button type="button" className="primary-button" onClick={() => setDraft({ ...draft, nodes: [emptyStep("training", draft.sport)] })}>Add first step</button></div>
+                  <div className="workout-editor-empty"><p>No workout steps yet.</p><button type="button" className="primary-button" onClick={() => setDraft({ ...draft, nodes: [emptyStep("training", draft.sport)] })}>{draft.sport === "strength" ? "Add first exercise" : "Add first step"}</button></div>
                 ) : (
                   <div className="workout-editor-nodes">
                     {draft.nodes.map((node, index) => (
@@ -621,7 +697,11 @@ export function WorkoutEditorModal({
                             step={node} location={{ nodeId: node.id }} context={document.context} sport={draft.sport}
                             exerciseOptions={exerciseOptions}
                             exerciseOptionsLoading={exerciseOptionsLoading}
-                            error={validation.errors[`nodes.${index}.target`] ?? validation.errors[`nodes.${index}.intensity`] ?? validation.errors[`nodes.${index}.exercise`]}
+                            error={validation.errors[`nodes.${index}.target`]
+                              ?? validation.errors[`nodes.${index}.intensity`]
+                              ?? validation.errors[`nodes.${index}.exercise`]
+                              ?? validation.errors[`nodes.${index}.sets`]
+                              ?? validation.errors[`nodes.${index}.rest`]}
                             disabled={!document.canEdit || saving} draggable
                             onDragStart={(event) => event.dataTransfer.setData("text/workout-node", node.id)}
                             onDropCard={node.editable ? (sourceId) => groupByDrop(sourceId, node.id) : undefined}
@@ -657,7 +737,11 @@ export function WorkoutEditorModal({
               </div>
 
               <footer className="workout-editor-footer">
-                <EstimateFooter preview={preview} loading={previewing} error={previewError} context={document.context} />
+                {draft.sport === "strength" ? (
+                  <StrengthEstimateFooter draft={draft} />
+                ) : (
+                  <EstimateFooter preview={preview} loading={previewing} error={previewError} context={document.context} />
+                )}
                 <div className="workout-editor-footer-actions">
                   <button type="button" className="ghost-button" onClick={requestClose} disabled={saving}>Cancel</button>
                   <button type="button" className="primary-button" disabled={!document.canEdit || !dirty || !validation.valid || saving} onClick={() => void save()}>
@@ -710,14 +794,37 @@ interface StepCardProps {
 function StepCard({ step, context, sport, exerciseOptions, exerciseOptionsLoading, error, disabled, draggable, onDragStart, onDropCard, onChange, onMove, onDuplicate, onDelete, onGroup, onUngroup }: StepCardProps) {
   const locked = disabled || !step.editable;
   const capability = WORKOUT_SPORT_CAPABILITIES[sport];
+  const strengthExercise = sport === "strength" && step.kind === "training";
   const changeKind = (kind: RunWorkoutEditorStepKind) => {
     let target = step.target;
-    if (target.type === "hrRecovery" && kind !== "rest") target = { type: "time", seconds: 60 };
+    const targetTypes = workoutTargetsForStep(sport, kind, step.exerciseKind);
+    if (sport === "strength" && kind === "training" && step.kind !== "training") {
+      target = { type: "reps", count: 10 };
+    } else if (!targetTypes.includes(target.type)) {
+      target = targetForType(targetTypes[0] ?? "time", kind);
+    }
+    const intensityTypes = workoutIntensitiesForStep(sport, kind, step.exerciseKind);
+    const currentIntensityType = step.intensity.type === "lthrPercent"
+      ? "heartRatePercent"
+      : step.intensity.type;
+    const intensity = sport === "strength" && kind === "training" && step.kind !== "training"
+      ? structuredClone(capability.defaultIntensity)
+      : intensityTypes.includes(currentIntensityType)
+        ? step.intensity
+        : intensityForType(intensityTypes[0] ?? "none", context);
     onChange({
       ...step,
       kind,
       name: stepTitle(kind),
       target,
+      intensity,
+      ...(sport === "strength" && kind === "training"
+        ? {
+            sets: step.sets ?? 3,
+            restType: step.restType ?? 1,
+            restValue: step.restValue ?? 60
+          }
+        : {}),
       ...(kind === "sendOff" ? { sendOffSeconds: step.sendOffSeconds ?? 120 } : {})
     });
   };
@@ -734,7 +841,14 @@ function StepCard({ step, context, sport, exerciseOptions, exerciseOptionsLoadin
           portal
           onChange={changeKind}
         />
-        <input aria-label="Step name" value={step.name} disabled={locked} maxLength={90} onChange={(event) => onChange({ ...step, name: event.target.value })} />
+        {strengthExercise ? (
+          <div className="workout-strength-step-heading">
+            <strong>{step.exerciseName?.trim() || "Choose an exercise"}</strong>
+            <span>{strengthStepSummary(step)}</span>
+          </div>
+        ) : (
+          <input aria-label="Step name" value={step.name} disabled={locked} maxLength={90} onChange={(event) => onChange({ ...step, name: event.target.value })} />
+        )}
         <div className="workout-step-actions">
           <IconAction label="Move up" onClick={() => onMove(-1)} disabled={disabled}><ChevronUp /></IconAction>
           <IconAction label="Move down" onClick={() => onMove(1)} disabled={disabled}><ChevronDown /></IconAction>
@@ -745,14 +859,268 @@ function StepCard({ step, context, sport, exerciseOptions, exerciseOptionsLoadin
         </div>
       </header>
       {step.unsupportedReason ? <div className="workout-step-warning"><AlertTriangle size={14} aria-hidden="true" />{step.unsupportedReason}</div> : null}
-      <div className="workout-step-fields">
-        <TargetFields step={step} context={context} sport={sport} disabled={locked} onChange={onChange} />
-        <IntensityFields step={step} context={context} sport={sport} disabled={locked} onChange={onChange} />
-        {step.kind === "sendOff" ? <label className="workout-control-group"><span>Send-off interval</span><ClockInput label="Send-off interval" seconds={step.sendOffSeconds ?? 120} disabled={locked} onChange={(seconds) => onChange({ ...step, sendOffSeconds: seconds })} /></label> : null}
-        {capability.requiresExercise && step.kind === "training" ? <div className="workout-control-group workout-exercise-control"><span>Exercise</span><ExerciseCombobox value={step.exerciseName ?? ""} selectedId={step.exerciseId} options={exerciseOptions} placeholder="Search by COROS exercise name" label="Exercise" loading={exerciseOptionsLoading} disabled={locked} onChange={(selection) => onChange({ ...step, exerciseName: selection.name, exerciseId: selection.id, exerciseKind: selection.exerciseKind })} />{step.exerciseId ? <small>COROS exercise selected</small> : <small>Name must resolve to one unique COROS exercise before upload.</small>}</div> : null}
-      </div>
+      {strengthExercise ? (
+        <StrengthStepFields
+          step={step}
+          context={context}
+          exerciseOptions={exerciseOptions}
+          exerciseOptionsLoading={exerciseOptionsLoading}
+          disabled={locked}
+          onChange={onChange}
+        />
+      ) : (
+        <div className="workout-step-fields">
+          <TargetFields step={step} context={context} sport={sport} disabled={locked} onChange={onChange} />
+          <IntensityFields step={step} context={context} sport={sport} disabled={locked} onChange={onChange} />
+          {step.kind === "sendOff" ? <label className="workout-control-group"><span>Send-off interval</span><ClockInput label="Send-off interval" seconds={step.sendOffSeconds ?? 120} disabled={locked} onChange={(seconds) => onChange({ ...step, sendOffSeconds: seconds })} /></label> : null}
+          {capability.requiresExercise && step.kind === "training" ? <div className="workout-control-group workout-exercise-control"><span>Exercise</span><ExerciseCombobox value={step.exerciseName ?? ""} selectedId={step.exerciseId} options={exerciseOptions} placeholder="Search by COROS exercise name" label="Exercise" loading={exerciseOptionsLoading} disabled={locked} onChange={(selection) => onChange({ ...step, exerciseName: selection.name, exerciseId: selection.id, exerciseKind: selection.exerciseKind })} />{step.exerciseId ? <small>COROS exercise selected</small> : <small>Select one exact COROS exercise before saving.</small>}</div> : null}
+        </div>
+      )}
       {error ? <p className="workout-field-error">{error}</p> : null}
     </motion.article>
+  );
+}
+
+function StrengthStepFields({
+  step,
+  context,
+  exerciseOptions,
+  exerciseOptionsLoading,
+  disabled,
+  onChange
+}: {
+  step: RunWorkoutEditorStep;
+  context: WorkoutEditorContext;
+  exerciseOptions: WorkoutExerciseOption[];
+  exerciseOptionsLoading: boolean;
+  disabled: boolean;
+  onChange: (step: RunWorkoutEditorStep) => void;
+}) {
+  const selectedExercise = step.exerciseId
+    ? exerciseOptions.find((option) => option.id === step.exerciseId)
+    : undefined;
+  const hasExercisePreview = Boolean(
+    selectedExercise?.media?.some((media) => media.videoUrl)
+  );
+  const sets = step.sets ?? 1;
+  const restSeconds = step.restValue ?? 0;
+  const loadMode = strengthLoadMode(step.intensity);
+  const displayWeightUnit = context.distanceUnit === "imperial" ? "lb" : "kg";
+  const targetTypes = workoutTargetsForStep("strength", "training", step.exerciseKind)
+    .filter((target): target is "reps" | "time" | "open" =>
+      target === "reps" || target === "time" || target === "open"
+    );
+  const editableTarget = step.target.type === "reps"
+    || step.target.type === "time"
+    || step.target.type === "open"
+    ? step.target
+    : { type: "open" as const };
+  const totalRest = sets > 1 ? restSeconds * (sets - 1) : 0;
+  const totalSummary = sets > 1 && step.target.type === "reps"
+    ? `${sets * step.target.count} total reps${totalRest ? `, ${clockFromSeconds(totalRest)} total rest` : ""}`
+    : sets > 1 && step.target.type === "time"
+      ? `${clockFromSeconds(sets * step.target.seconds + totalRest)} including rest`
+      : undefined;
+
+  const changeTargetType = (type: "reps" | "time" | "open") => {
+    onChange({ ...step, target: targetForType(type, "training") });
+  };
+  const changeLoadMode = (mode: StrengthLoadMode) => {
+    const intensity: RunWorkoutEditorIntensity = mode === "bodyweight"
+      ? { type: "weight", mode: "bodyweight" }
+      : mode === "added"
+        ? { type: "weight", mode: "weight", value: 0, unit: displayWeightUnit }
+        : { type: "none" };
+    onChange({ ...step, intensity });
+  };
+
+  return (
+    <div className={`workout-strength-fields${hasExercisePreview ? " has-preview" : ""}`}>
+      <div className="workout-strength-form">
+        <section className="strength-block">
+          <h4>Movement</h4>
+          <ExerciseCombobox
+            value={step.exerciseName ?? ""}
+            selectedId={step.exerciseId}
+            options={exerciseOptions}
+            placeholder="Search the COROS exercise library"
+            label="Exercise"
+            loading={exerciseOptionsLoading}
+            disabled={disabled}
+            hidePreview
+            onChange={(selection) => onChange({
+              ...step,
+              ...(selection.id ? { name: selection.name } : {}),
+              exerciseName: selection.name,
+              exerciseId: selection.id,
+              exerciseKind: selection.exerciseKind
+            })}
+          />
+          {exerciseOptionsLoading ? (
+            <p className="strength-block-note">Loading the COROS exercise library.</p>
+          ) : exerciseOptions.length === 0 ? (
+            <p className="strength-block-note">Reconnect COROS to load the exercise library.</p>
+          ) : !step.exerciseId ? (
+            <p className="strength-block-note">Select one exact exercise. The watch needs its COROS ID.</p>
+          ) : null}
+        </section>
+
+        <section className="strength-block">
+          <h4>Prescription</h4>
+          <div className="set-line">
+            <label className="set-line-cell">
+              <span>Sets</span>
+              <input
+                type="number"
+                min="1"
+                max="99"
+                value={sets}
+                disabled={disabled}
+                onChange={(event) => onChange({ ...step, sets: Number(event.target.value) })}
+              />
+            </label>
+            <span className="set-line-operator" aria-hidden="true">×</span>
+            <div className="set-line-cell">
+              <span>Per set</span>
+              <div className="set-line-compound">
+                {editableTarget.type === "open" ? (
+                  <span className="set-line-open">Ends with the lap button</span>
+                ) : (
+                  <input
+                    type="number"
+                    min="1"
+                    max={editableTarget.type === "reps" ? 500 : 86_399}
+                    aria-label={editableTarget.type === "reps" ? "Repetitions per set" : "Seconds per set"}
+                    value={editableTarget.type === "reps" ? editableTarget.count : editableTarget.seconds}
+                    disabled={disabled}
+                    onChange={(event) => onChange({
+                      ...step,
+                      target: editableTarget.type === "reps"
+                        ? { type: "reps", count: Number(event.target.value) }
+                        : { type: "time", seconds: Number(event.target.value) }
+                    })}
+                  />
+                )}
+                <SelectDropdown<"reps" | "time" | "open">
+                  className="set-line-select"
+                  label="Measure each set by"
+                  value={editableTarget.type}
+                  disabled={disabled}
+                  options={targetTypes.map((type) => ({
+                    value: type,
+                    label: type === "reps" ? "Reps" : type === "time" ? "Seconds" : "Open"
+                  }))}
+                  portal
+                  onChange={changeTargetType}
+                />
+              </div>
+            </div>
+            <span className="set-line-operator" aria-hidden="true">@</span>
+            <div className="set-line-cell is-load">
+              <span>Load</span>
+              <div className="set-line-compound">
+                <SelectDropdown<StrengthLoadMode>
+                  className="set-line-select"
+                  label="Load"
+                  value={loadMode}
+                  disabled={disabled}
+                  options={[
+                    { value: "bodyweight", label: "Bodyweight" },
+                    { value: "added", label: "Added weight" },
+                    { value: "unspecified", label: "Not set" }
+                  ]}
+                  portal
+                  onChange={changeLoadMode}
+                />
+                {step.intensity.type === "weight" && step.intensity.mode === "weight" ? (
+                  <span className="set-line-weight">
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.5"
+                      aria-label={`Added weight in ${step.intensity.unit}`}
+                      value={step.intensity.value}
+                      disabled={disabled}
+                      onChange={(event) => onChange({
+                        ...step,
+                        intensity: {
+                          type: "weight",
+                          mode: "weight",
+                          value: Number(event.target.value),
+                          unit: step.intensity.type === "weight" && step.intensity.mode === "weight"
+                            ? step.intensity.unit
+                            : displayWeightUnit
+                        }
+                      })}
+                    />
+                    <em>{step.intensity.unit}</em>
+                  </span>
+                ) : null}
+              </div>
+            </div>
+          </div>
+          {totalSummary ? <p className="set-line-readout">{totalSummary}</p> : null}
+        </section>
+
+        <section className="strength-block">
+          <h4>Rest between sets</h4>
+          <div className="rest-picker">
+            {STRENGTH_REST_PRESETS.map((preset) => (
+              <button
+                key={preset}
+                type="button"
+                className={restSeconds === preset ? "is-selected" : ""}
+                aria-pressed={restSeconds === preset}
+                disabled={disabled}
+                onClick={() => onChange({ ...step, restType: 1, restValue: preset })}
+              >
+                {strengthRestLabel(preset)}
+              </button>
+            ))}
+            <label className="rest-picker-custom">
+              <input
+                type="number"
+                min="0"
+                max="3600"
+                step="5"
+                aria-label="Rest between sets in seconds"
+                value={restSeconds}
+                disabled={disabled}
+                onChange={(event) => onChange({
+                  ...step,
+                  restType: 1,
+                  restValue: Number(event.target.value)
+                })}
+              />
+              <em>sec</em>
+            </label>
+          </div>
+        </section>
+
+        <label className="workout-strength-instructions">
+          <span>Exercise instructions</span>
+          <textarea
+            rows={2}
+            maxLength={300}
+            placeholder="Optional cues or setup notes"
+            value={step.overview ?? ""}
+            disabled={disabled}
+            onChange={(event) => onChange({ ...step, overview: event.target.value })}
+          />
+          <small>{step.overview?.length ?? 0}/300</small>
+        </label>
+      </div>
+
+      {selectedExercise && hasExercisePreview ? (
+        <aside className="workout-strength-preview">
+          <ExercisePreview
+            option={selectedExercise}
+            name={step.exerciseName ?? selectedExercise.name}
+            showTargets
+          />
+        </aside>
+      ) : null}
+    </div>
   );
 }
 
@@ -916,7 +1284,7 @@ function RepeatCard({ group, nodeIndex, context, sport, exerciseOptions, exercis
   return <motion.section layout className="workout-repeat-card" draggable={!disabled} onDragStartCapture={onDragStart}>
     <header className="workout-repeat-header"><GripVertical size={18} aria-hidden="true" /><input aria-label="Repeat group name" value={group.name} disabled={locked} onChange={(event) => onChange({ ...group, name: event.target.value })} /><div className="workout-repeat-count"><span>Repeat</span><button type="button" disabled={locked || group.repeat <= 1} onClick={() => onChange({ ...group, repeat: group.repeat - 1 })}>−</button><input aria-label="Repeat count" type="number" min="1" max="99" value={group.repeat} disabled={locked} onChange={(event) => onChange({ ...group, repeat: Number(event.target.value) })} /><button type="button" disabled={locked || group.repeat >= 99} onClick={() => onChange({ ...group, repeat: group.repeat + 1 })}>+</button></div><div className="workout-step-actions"><IconAction label="Move group up" onClick={() => onMove(-1)} disabled={disabled}><ChevronUp /></IconAction><IconAction label="Move group down" onClick={() => onMove(1)} disabled={disabled}><ChevronDown /></IconAction><IconAction label="Duplicate group" onClick={onDuplicate} disabled={duplicateLocked}><Copy /></IconAction><IconAction label="Delete group" onClick={onDelete} disabled={disabled}><Trash2 /></IconAction></div></header>
     {errors[`nodes.${nodeIndex}.repeat`] ? <p className="workout-field-error">{errors[`nodes.${nodeIndex}.repeat`]}</p> : null}
-    <div className="workout-repeat-steps">{group.steps.map((step, childIndex) => <StepCard key={step.id} step={step} location={{ nodeId: group.id, childId: step.id }} context={context} sport={sport} exerciseOptions={exerciseOptions} exerciseOptionsLoading={exerciseOptionsLoading} disabled={disabled} draggable error={errors[`nodes.${nodeIndex}.steps.${childIndex}.target`] ?? errors[`nodes.${nodeIndex}.steps.${childIndex}.intensity`] ?? errors[`nodes.${nodeIndex}.steps.${childIndex}.exercise`]} onDragStart={(event) => event.dataTransfer.setData("text/workout-node", step.id)} onDropCard={(sourceId) => { const from = group.steps.findIndex((candidate) => candidate.id === sourceId); const to = group.steps.findIndex((candidate) => candidate.id === step.id); if (from >= 0 && to >= 0) onChange({ ...group, steps: moveItem(group.steps, from, to) }); }} onChange={(next) => onStepChange(step.id, next)} onMove={(direction) => onStepMove(step.id, direction)} onDuplicate={() => onStepDuplicate(step.id)} onDelete={() => onStepDelete(step.id)} onUngroup={() => onStepUngroup(step.id)} />)}</div>
+    <div className="workout-repeat-steps">{group.steps.map((step, childIndex) => <StepCard key={step.id} step={step} location={{ nodeId: group.id, childId: step.id }} context={context} sport={sport} exerciseOptions={exerciseOptions} exerciseOptionsLoading={exerciseOptionsLoading} disabled={disabled} draggable error={errors[`nodes.${nodeIndex}.steps.${childIndex}.target`] ?? errors[`nodes.${nodeIndex}.steps.${childIndex}.intensity`] ?? errors[`nodes.${nodeIndex}.steps.${childIndex}.exercise`] ?? errors[`nodes.${nodeIndex}.steps.${childIndex}.sets`] ?? errors[`nodes.${nodeIndex}.steps.${childIndex}.rest`]} onDragStart={(event) => event.dataTransfer.setData("text/workout-node", step.id)} onDropCard={(sourceId) => { const from = group.steps.findIndex((candidate) => candidate.id === sourceId); const to = group.steps.findIndex((candidate) => candidate.id === step.id); if (from >= 0 && to >= 0) onChange({ ...group, steps: moveItem(group.steps, from, to) }); }} onChange={(next) => onStepChange(step.id, next)} onMove={(direction) => onStepMove(step.id, direction)} onDuplicate={() => onStepDuplicate(step.id)} onDelete={() => onStepDelete(step.id)} onUngroup={() => onStepUngroup(step.id)} />)}</div>
     <button type="button" className="ghost-button workout-repeat-add" disabled={locked} onClick={() => onChange({ ...group, steps: [...group.steps, emptyStep("rest", sport)] })}><Plus size={14} aria-hidden="true" /> Add step to repeat</button>
   </motion.section>;
 }
@@ -934,4 +1302,33 @@ function EstimateFooter({ preview, loading, error, context }: { preview: Workout
       {preview?.intensityTrendPercent !== undefined ? <span><small>Intensity Trend</small><strong>{Math.round(preview.intensityTrendPercent)}%</strong></span> : null}
     </>}
   </div>;
+}
+
+function StrengthEstimateFooter({ draft }: { draft: RunWorkoutEditorDraft }) {
+  let exercises = 0;
+  let sets = 0;
+  let reps = 0;
+  let restSeconds = 0;
+  const countStep = (step: RunWorkoutEditorStep, multiplier: number) => {
+    if (step.kind !== "training") return;
+    exercises += 1;
+    const stepSets = Math.max(1, step.sets ?? 1);
+    sets += stepSets * multiplier;
+    if (step.target.type === "reps") {
+      reps += step.target.count * stepSets * multiplier;
+    }
+    restSeconds += Math.max(0, stepSets - 1) * Math.max(0, step.restValue ?? 0) * multiplier;
+  };
+  for (const node of draft.nodes) {
+    if (node.nodeType === "step") countStep(node, 1);
+    else node.steps.forEach((step) => countStep(step, Math.max(1, node.repeat)));
+  }
+  return (
+    <div className="workout-estimate" aria-label="Strength session totals">
+      <span><small>Exercises</small><strong>{exercises}</strong></span>
+      <span><small>Sets</small><strong>{sets}</strong></span>
+      <span><small>Reps</small><strong>{reps || "--"}</strong></span>
+      <span><small>Set rest</small><strong>{restSeconds ? clockFromSeconds(restSeconds) : "--"}</strong></span>
+    </div>
+  );
 }

--- a/src/chat/ChatView.tsx
+++ b/src/chat/ChatView.tsx
@@ -273,28 +273,61 @@ function formatPlanSourceVolume(
   });
 }
 
+type PlanSourceNode = NonNullable<PlanWorkoutEntryInput["steps"]>[number];
+type PlanSourceRepeat = Extract<PlanSourceNode, { repeat: number }>;
+type PlanSourceStep = Exclude<PlanSourceNode, { repeat: number }>;
+
+function isPlanSourceRepeat(step: PlanSourceNode): step is PlanSourceRepeat {
+  return "repeat" in step;
+}
+
+function formatPlanDuration(seconds: number): string {
+  if (seconds < 90) return `${Math.round(seconds)} sec`;
+  const minutes = seconds / 60;
+  return Number.isInteger(minutes)
+    ? `${minutes} min`
+    : `${minutes.toFixed(1)} min`;
+}
+
+function formatPlanStepTarget(
+  step: PlanSourceStep,
+  sport: PlanWorkoutEntryInput["sport"],
+  unitSystem: UnitSystem
+): string {
+  if (step.target_distance_meters) {
+    return formatDistanceValue(step.target_distance_meters, unitSystem, {
+      swim: sport === "swim"
+    });
+  }
+  if (step.target_elevation_gain_meters) {
+    return `${formatElevationValue(step.target_elevation_gain_meters, unitSystem)} gain`;
+  }
+  if (step.target_duration_seconds) {
+    return formatPlanDuration(step.target_duration_seconds);
+  }
+  if (step.target_reps) return `${step.target_reps} reps`;
+  if (step.target_routes) {
+    return `${step.target_routes} ${step.target_routes === 1 ? "route" : "routes"}`;
+  }
+  if (step.target_hr_recovery_bpm) {
+    return `to ${step.target_hr_recovery_bpm} bpm`;
+  }
+  if (step.send_off_seconds) return `${formatPlanDuration(step.send_off_seconds)} send-off`;
+  if (step.target_load) return `${step.target_load} TL`;
+  return "Open";
+}
+
 function formatPlanSourceSteps(
   source: PlanWorkoutEntryInput,
   unitSystem: UnitSystem
 ): string | undefined {
-  const swim = source.sport === "swim";
   const formatStep = (
     step: NonNullable<PlanWorkoutEntryInput["steps"]>[number]
   ): string => {
-    if ("repeat" in step) {
+    if (isPlanSourceRepeat(step)) {
       return `${step.repeat}x (${step.steps.map((child) => formatStep(child)).join(", ")})`;
     }
-    const target = step.target_distance_meters
-      ? formatDistanceValue(step.target_distance_meters, unitSystem, { swim })
-      : step.target_elevation_gain_meters
-        ? `${formatElevationValue(step.target_elevation_gain_meters, unitSystem)} gain`
-        : step.target_duration_seconds
-          ? `${Math.round(step.target_duration_seconds / 60)} min`
-          : step.target_reps
-            ? `${step.target_reps} reps`
-            : step.target_load
-              ? `${step.target_load} TL`
-              : "open";
+    const target = formatPlanStepTarget(step, source.sport, unitSystem);
     const intensity = step.intensity
       ? formatPlanIntensity(step.intensity, unitSystem)
       : step.pace
@@ -305,6 +338,114 @@ function formatPlanSourceSteps(
   return source.steps?.length
     ? source.steps.map(formatStep).join(" → ")
     : undefined;
+}
+
+function isStrengthExerciseStep(step: PlanSourceStep): boolean {
+  return step.kind === "training" || step.kind === "interval";
+}
+
+function strengthStepTitle(step: PlanSourceStep): string {
+  if (step.exercise_name?.trim()) return step.exercise_name.trim();
+  if (step.name?.trim()) return step.name.trim();
+  if (step.kind === "warmup") return "Warm-up";
+  if (step.kind === "cooldown") return "Cooldown";
+  if (step.kind === "rest") return "Recovery";
+  return "Strength exercise";
+}
+
+function strengthStepMarker(step: PlanSourceStep, exerciseNumber?: number): string {
+  if (exerciseNumber !== undefined) return String(exerciseNumber);
+  if (step.kind === "warmup") return "W";
+  if (step.kind === "cooldown") return "C";
+  if (step.kind === "rest") return "R";
+  return "S";
+}
+
+function countStrengthExercises(steps: readonly PlanSourceNode[]): number {
+  return steps.reduce((count, step) => {
+    if (isPlanSourceRepeat(step)) {
+      return count + step.steps.filter(isStrengthExerciseStep).length;
+    }
+    return count + (isStrengthExerciseStep(step) ? 1 : 0);
+  }, 0);
+}
+
+function StrengthPlanStructure({
+  source,
+  unitSystem
+}: {
+  source: PlanWorkoutEntryInput;
+  unitSystem: UnitSystem;
+}) {
+  const steps = source.steps ?? [];
+  const exerciseCount = countStrengthExercises(steps);
+  let exerciseNumber = 0;
+
+  const renderStep = (step: PlanSourceStep, key: string) => {
+    const exercise = isStrengthExerciseStep(step);
+    const currentExerciseNumber = exercise ? ++exerciseNumber : undefined;
+    const intensity = step.intensity
+      ? formatPlanIntensity(step.intensity, unitSystem)
+      : undefined;
+    const setCount = step.sets && step.sets > 1 ? `${step.sets} sets` : undefined;
+    const setRest = step.sets && step.sets > 1 && step.rest_value !== undefined
+      ? `${formatPlanDuration(step.rest_value)} rest`
+      : undefined;
+
+    return (
+      <li
+        key={key}
+        className={`chat-plan-strength-step is-${step.kind ?? "training"}`}
+      >
+        <span className="chat-plan-strength-marker" aria-hidden="true">
+          {strengthStepMarker(step, currentExerciseNumber)}
+        </span>
+        <span className="chat-plan-strength-step-copy">
+          <strong>{strengthStepTitle(step)}</strong>
+        </span>
+        <span className="chat-plan-strength-prescription">
+          {setCount ? <span>{setCount}</span> : null}
+          <strong>{formatPlanStepTarget(step, source.sport, unitSystem)}</strong>
+          {intensity ? <span>{intensity}</span> : null}
+          {setRest ? <span>{setRest}</span> : null}
+        </span>
+      </li>
+    );
+  };
+
+  return (
+    <section
+      className="chat-plan-strength-structure"
+      aria-label={`${exerciseCount} ${exerciseCount === 1 ? "exercise" : "exercises"} in strength session structure`}
+    >
+      <header className="chat-plan-strength-header">
+        <strong>Session structure</strong>
+        <span>
+          {exerciseCount} {exerciseCount === 1 ? "exercise" : "exercises"}
+        </span>
+      </header>
+      <ol className="chat-plan-strength-steps">
+        {steps.map((step, index) => {
+          if (!isPlanSourceRepeat(step)) {
+            return renderStep(step, `step-${index}`);
+          }
+          return (
+            <li key={`repeat-${index}`} className="chat-plan-strength-repeat">
+              <div className="chat-plan-strength-repeat-header">
+                <strong>{step.name?.trim() || "Repeat block"}</strong>
+                <span>{step.repeat} rounds</span>
+              </div>
+              <ol>
+                {step.steps.map((child, childIndex) =>
+                  renderStep(child, `repeat-${index}-step-${childIndex}`)
+                )}
+              </ol>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
 }
 
 function formatPlanPaceRange(
@@ -486,6 +627,263 @@ function groupPlanEntriesByWeek(entries: PlanDraftPreviewEntry[]): PlanWeekGroup
 /** Inline style hook that tints a row/chip with the sport's own colour. */
 function planSportStyle(sport: PlanDraftPreviewEntry["sport"]): CSSProperties {
   return { "--chat-plan-sport": sportTheme(sport).color } as CSSProperties;
+}
+
+function WorkoutPreviewCard({
+  draft,
+  uploading,
+  uploaded,
+  onUpload
+}: {
+  draft: PlanDraftPreview;
+  uploading: boolean;
+  uploaded?: UploadPlanResult;
+  onUpload: (
+    destination: TrainingPlanDestination,
+    scheduleDate?: string
+  ) => void;
+}) {
+  const { unitSystem } = useUnitSystem();
+  const entry = draft.entries[0];
+  const suggestedDate = entry ? planEntryScheduleDate(entry) : undefined;
+  const today = localPlanDateKey(new Date());
+  const [destination, setDestination] = useState<
+    Extract<TrainingPlanDestination, "workoutLibrary" | "calendar">
+  >(suggestedDate ? "calendar" : "workoutLibrary");
+  const [scheduleDate, setScheduleDate] = useState(suggestedDate ?? today);
+  const uploadedResult =
+    uploaded ??
+    (draft.uploadResult
+      ? {
+          planName: draft.name,
+          workoutsCreated: draft.uploadResult.workoutsCreated,
+          workoutsScheduled: draft.uploadResult.workoutsScheduled,
+          entries: [],
+          destination: draft.uploadResult.destination
+        }
+      : undefined);
+  const isUploaded = Boolean(uploadedResult || draft.uploadedAt);
+  const uploadedDestination =
+    uploadedResult?.destination ?? draft.uploadResult?.destination ?? destination;
+  const calendarDateParts = destination === "calendar"
+    ? planDateParts(scheduleDate)
+    : undefined;
+  const calendarDateInvalid =
+    destination === "calendar" && (!scheduleDate || scheduleDate < today);
+  const SportIcon = sportTheme(entry?.sport).icon;
+  const hasStrengthStructure = Boolean(
+    entry &&
+      (entry.sport === "strength" || entry.sport === "hyrox") &&
+      entry.source?.steps?.length
+  );
+  const volume = entry
+    ? (entry.source
+        ? formatPlanSourceVolume(entry.source, unitSystem)
+        : undefined) ?? entry.volume ?? "Not set"
+    : "Not set";
+  const steps = entry
+    ? (entry.source
+        ? formatPlanSourceSteps(entry.source, unitSystem)
+        : undefined) ?? entry.stepsSummary ?? "No structure provided"
+    : "No structure provided";
+
+  return (
+    <div className="chat-plan-card chat-workout-card">
+      <div className="chat-plan-card-header">
+        <div className="chat-plan-card-title">
+          <span className="chat-workout-card-kicker">One-off workout</span>
+          <h4>{draft.name}</h4>
+          <span className="chat-plan-card-summary">{draft.summary}</span>
+        </div>
+        {entry ? (
+          <span
+            className="chat-plan-sport-dot"
+            style={planSportStyle(entry.sport)}
+            title={formatWorkoutSport(entry.sport ?? "run")}
+          >
+            <SportIcon size={12} strokeWidth={2.2} aria-hidden="true" />
+          </span>
+        ) : null}
+      </div>
+      {entry ? (
+        <ul className="chat-plan-entries chat-workout-entries">
+          <li
+            className={`chat-plan-entry${hasStrengthStructure ? " is-strength" : ""}`}
+            style={planSportStyle(entry.sport)}
+          >
+            <span
+              className={`chat-plan-entry-date${calendarDateParts ? "" : " is-undated"}`}
+              title={
+                destination === "calendar"
+                  ? `Add to Calendar on ${scheduleDate}`
+                  : "Save to Workout Library"
+              }
+            >
+              {calendarDateParts ? (
+                <>
+                  <span className="chat-plan-entry-weekday">
+                    {calendarDateParts.weekday}
+                  </span>
+                  <span className="chat-plan-entry-day">
+                    {calendarDateParts.day}
+                  </span>
+                  <span className="chat-plan-entry-month">
+                    {calendarDateParts.month}
+                  </span>
+                </>
+              ) : (
+                <Bookmark size={14} aria-hidden="true" />
+              )}
+            </span>
+            <span className="chat-plan-entry-main">
+              <span className="chat-plan-entry-name">{entry.name}</span>
+              {hasStrengthStructure && entry.source ? (
+                <StrengthPlanStructure
+                  source={entry.source}
+                  unitSystem={unitSystem}
+                />
+              ) : (
+                <span className="chat-plan-entry-steps">{steps}</span>
+              )}
+            </span>
+            <span className="chat-plan-entry-meta">
+              {!hasStrengthStructure ? (
+                <span className="chat-plan-entry-volume">{volume}</span>
+              ) : null}
+              <span className="chat-plan-entry-tags">
+                <span className="chat-plan-entry-type">{entry.workoutType}</span>
+                <span className="chat-plan-entry-sport">
+                  <SportIcon size={11} strokeWidth={2.2} aria-hidden="true" />
+                  {formatWorkoutSport(entry.sport ?? "run")}
+                </span>
+              </span>
+            </span>
+          </li>
+        </ul>
+      ) : (
+        <div className="chat-plan-empty-week">
+          <Bookmark size={16} aria-hidden="true" />
+          <span>This workout does not contain any steps yet.</span>
+        </div>
+      )}
+      {isUploaded ? (
+        <p className="chat-plan-success">
+          <CircleCheck size={15} aria-hidden="true" />
+          <span>
+            {uploadedDestination === "calendar"
+              ? `Added to your COROS Calendar on ${formatPlanDateLabel(scheduleDate)}.`
+              : "Saved to your COROS Workout Library."}
+          </span>
+        </p>
+      ) : (
+        <>
+          <fieldset className="chat-plan-confirmation" disabled={uploading}>
+            <legend>Where should this workout go?</legend>
+            <div className="chat-plan-destination-options">
+              <label
+                className={`chat-plan-destination-option${
+                  destination === "workoutLibrary" ? " is-selected" : ""
+                }`}
+              >
+                <input
+                  className="sr-only"
+                  type="radio"
+                  name={`workout-destination-${draft.draftId}`}
+                  value="workoutLibrary"
+                  checked={destination === "workoutLibrary"}
+                  onChange={() => setDestination("workoutLibrary")}
+                />
+                <span className="chat-plan-destination-icon">
+                  <BookOpen size={16} aria-hidden="true" />
+                </span>
+                <span className="chat-plan-destination-copy">
+                  <strong>Workout Library</strong>
+                  <small>Save it as an unscheduled, reusable workout.</small>
+                </span>
+                <CircleCheck
+                  className="chat-plan-destination-check"
+                  size={16}
+                  aria-hidden="true"
+                />
+              </label>
+              <label
+                className={`chat-plan-destination-option${
+                  destination === "calendar" ? " is-selected" : ""
+                }`}
+              >
+                <input
+                  className="sr-only"
+                  type="radio"
+                  name={`workout-destination-${draft.draftId}`}
+                  value="calendar"
+                  checked={destination === "calendar"}
+                  onChange={() => setDestination("calendar")}
+                />
+                <span className="chat-plan-destination-icon">
+                  <CalendarDays size={16} aria-hidden="true" />
+                </span>
+                <span className="chat-plan-destination-copy">
+                  <strong>Calendar</strong>
+                  <small>Add this workout on the date you choose.</small>
+                </span>
+                <CircleCheck
+                  className="chat-plan-destination-check"
+                  size={16}
+                  aria-hidden="true"
+                />
+              </label>
+            </div>
+            {destination === "calendar" ? (
+              <label className="chat-workout-calendar-date">
+                <span>Calendar date</span>
+                <input
+                  type="date"
+                  value={scheduleDate}
+                  min={today}
+                  onChange={(event) => setScheduleDate(event.target.value)}
+                />
+              </label>
+            ) : null}
+            <p className="chat-plan-destination-summary" data-tone="ok">
+              {destination === "calendar" ? (
+                <CalendarDays size={13} aria-hidden="true" />
+              ) : (
+                <BookOpen size={13} aria-hidden="true" />
+              )}
+              <span>
+                {destination === "calendar"
+                  ? `This workout will be added to Calendar on ${formatPlanDateLabel(scheduleDate)}.`
+                  : "This workout will be saved to your Workout Library without a calendar date."}
+                {" "}It will remain a one-off workout, not a training plan.
+              </span>
+            </p>
+          </fieldset>
+          <div className="chat-plan-actions">
+            <button
+              type="button"
+              className="chat-plan-upload"
+              onClick={() => onUpload(
+                destination,
+                destination === "calendar" ? scheduleDate : undefined
+              )}
+              disabled={uploading || !entry || calendarDateInvalid}
+            >
+              {uploading ? (
+                <Loader2 className="chat-spinner" size={14} aria-hidden="true" />
+              ) : (
+                destination === "calendar" ? (
+                  <CalendarDays size={14} aria-hidden="true" />
+                ) : (
+                  <Bookmark size={14} aria-hidden="true" />
+                )
+              )}
+              {destination === "calendar" ? "Add to Calendar" : "Save to Library"}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
 }
 
 function PlanPreviewCard({
@@ -677,6 +1075,9 @@ function PlanPreviewCard({
               const SportIcon = sportTheme(entry.sport).icon;
               const scheduleDate = planEntryScheduleDate(entry);
               const dateParts = planDateParts(scheduleDate);
+              const hasStrengthStructure =
+                (entry.sport === "strength" || entry.sport === "hyrox") &&
+                Boolean(entry.source?.steps?.length);
               const volume =
                 (entry.source
                   ? formatPlanSourceVolume(entry.source, unitSystem)
@@ -688,7 +1089,7 @@ function PlanPreviewCard({
               return (
                 <li
                   key={entry.key}
-                  className="chat-plan-entry"
+                  className={`chat-plan-entry${hasStrengthStructure ? " is-strength" : ""}`}
                   style={planSportStyle(entry.sport)}
                 >
                   <span
@@ -711,10 +1112,19 @@ function PlanPreviewCard({
                   </span>
                   <span className="chat-plan-entry-main">
                     <span className="chat-plan-entry-name">{entry.name}</span>
-                    <span className="chat-plan-entry-steps">{steps}</span>
+                    {hasStrengthStructure && entry.source ? (
+                      <StrengthPlanStructure
+                        source={entry.source}
+                        unitSystem={unitSystem}
+                      />
+                    ) : (
+                      <span className="chat-plan-entry-steps">{steps}</span>
+                    )}
                   </span>
                   <span className="chat-plan-entry-meta">
-                    <span className="chat-plan-entry-volume">{volume}</span>
+                    {!hasStrengthStructure ? (
+                      <span className="chat-plan-entry-volume">{volume}</span>
+                    ) : null}
                     <span className="chat-plan-entry-tags">
                       <span className="chat-plan-entry-type">
                         {entry.workoutType}
@@ -933,6 +1343,44 @@ function PlanPreviewCard({
         </div>
       )}
     </div>
+  );
+}
+
+function CoachDraftPreviewCard({
+  draft,
+  uploading,
+  uploaded,
+  onUpload,
+  onReview
+}: {
+  draft: PlanDraftPreview;
+  uploading: boolean;
+  uploaded?: UploadPlanResult;
+  onUpload: (
+    destination: TrainingPlanDestination,
+    scheduleDate?: string
+  ) => void;
+  onReview?: () => void;
+}) {
+  if (draft.artifactType === "workout") {
+    return (
+      <WorkoutPreviewCard
+        draft={draft}
+        uploading={uploading}
+        uploaded={uploaded}
+        onUpload={onUpload}
+      />
+    );
+  }
+
+  return (
+    <PlanPreviewCard
+      draft={draft}
+      uploading={uploading}
+      uploaded={uploaded}
+      onUpload={onUpload}
+      onReview={onReview}
+    />
   );
 }
 
@@ -2092,13 +2540,30 @@ export function ChatView({
 
   const handleUploadPlanDraft = async (
     draftId: string,
-    destination: TrainingPlanDestination
+    destination: TrainingPlanDestination,
+    scheduleDate?: string
   ) => {
     if (!api || uploadingDraftId) return;
     setUploadingDraftId(draftId);
     onError(null);
     try {
-      const result = await api.uploadTrainingPlanDraft(draftId, unitSystem, destination);
+      const result = await api.uploadTrainingPlanDraft(
+        draftId,
+        unitSystem,
+        destination,
+        scheduleDate
+      );
+      const scheduledDates = new Map(
+        result.entries.flatMap((entry) => {
+          if (!entry.date) return [];
+          const normalized = entry.date.replace(/-/g, "");
+          if (!/^\d{8}$/.test(normalized)) return [];
+          return [[
+            entry.key,
+            `${normalized.slice(0, 4)}-${normalized.slice(4, 6)}-${normalized.slice(6, 8)}`
+          ] as const];
+        })
+      );
       setUploadedPlans((prev) => ({ ...prev, [draftId]: result }));
       setTimeline((prev) => {
         const next = prev.map((entry) =>
@@ -2108,6 +2573,27 @@ export function ChatView({
                 draft: {
                   ...entry.draft,
                   uploadedAt: Date.now(),
+                  entries: entry.draft.entries.map((draftEntry) => {
+                    const scheduledDate = scheduledDates.get(draftEntry.key);
+                    const clearDate =
+                      destination === "workoutLibrary" &&
+                      entry.draft.artifactType === "workout";
+                    return {
+                      ...draftEntry,
+                      scheduleDate: clearDate
+                        ? undefined
+                        : scheduledDate ?? draftEntry.scheduleDate,
+                      source: draftEntry.source
+                        ? {
+                            ...draftEntry.source,
+                            schedule_date: clearDate
+                              ? undefined
+                              : scheduledDate?.replace(/-/g, "") ??
+                                draftEntry.source.schedule_date
+                          }
+                        : undefined
+                    };
+                  }),
                   uploadResult: {
                     workoutsScheduled: result.workoutsScheduled,
                     workoutsCreated: result.workoutsCreated,
@@ -2127,7 +2613,7 @@ export function ChatView({
       onError(
         caught instanceof Error
           ? caught.message
-          : "Failed to upload training plan to COROS."
+          : "Failed to save the workout or plan to COROS."
       );
     } finally {
       setUploadingDraftId(null);
@@ -2290,9 +2776,14 @@ export function ChatView({
   const selectedPlanDraft =
     planDrafts.find((draft) => draft.draftId === selectedPlanDraftId) ??
     latestPlanDraft;
-  const selectedPlanDraftIndex = selectedPlanDraft
-    ? planDrafts.findIndex((draft) => draft.draftId === selectedPlanDraft.draftId)
-    : -1;
+  const trainingPlanDrafts = planDrafts.filter(
+    (draft) => draft.artifactType !== "workout"
+  );
+  const selectedTrainingPlanNumber = selectedPlanDraft?.artifactType !== "workout"
+    ? trainingPlanDrafts.findIndex(
+        (draft) => draft.draftId === selectedPlanDraft?.draftId
+      ) + 1
+    : 0;
 
   useEffect(() => {
     setSelectedPlanDraftId(latestPlanDraft?.draftId ?? null);
@@ -2650,6 +3141,7 @@ export function ChatView({
                 {[
                   "How was my latest activity?",
                   "Break down my latest workout by lap",
+                  "Create one workout for today and save it to my Workout Library",
                   "Build a balanced week from my recent training",
                   "Schedule bike intervals for Saturday",
                   "Add strength around my endurance sessions",
@@ -2729,12 +3221,16 @@ export function ChatView({
                     <Sparkles size={16} aria-hidden="true" />
                   </div>
                   <div className="chat-bubble chat-bubble-plan">
-                    <PlanPreviewCard
+                    <CoachDraftPreviewCard
                       draft={entry.draft}
                       uploading={uploadingDraftId === entry.draft.draftId}
                       uploaded={uploadedPlans[entry.draft.draftId]}
-                      onUpload={(destination) =>
-                        void handleUploadPlanDraft(entry.draft.draftId, destination)
+                      onUpload={(destination, scheduleDate) =>
+                        void handleUploadPlanDraft(
+                          entry.draft.draftId,
+                          destination,
+                          scheduleDate
+                        )
                       }
                       onReview={onReviewPlan ? () => handleReviewPlanDraft(entry.draft) : undefined}
                     />
@@ -2969,7 +3465,7 @@ export function ChatView({
               planPanelExpanded ? " is-expanded" : " is-list-view"
             }`}
             aria-label={
-              planPanelExpanded ? "Training plan details" : "Generated plans"
+              planPanelExpanded ? "Generated item details" : "Coach creations"
             }
           >
             {!planPanelExpanded ? (
@@ -2980,8 +3476,8 @@ export function ChatView({
                       <BookOpen size={15} aria-hidden="true" />
                     </span>
                     <div>
-                      <strong>Generated plans</strong>
-                      <span>Select a plan to review</span>
+                      <strong>Coach creations</strong>
+                      <span>Plans and one-off workouts</span>
                     </div>
                   </div>
                   <strong className="chat-plan-list-count">
@@ -2995,12 +3491,20 @@ export function ChatView({
                         draft.uploadResult ||
                         draft.uploadedAt
                     );
-                    const weeks = Math.max(
-                      1,
-                      groupPlanEntriesByWeek(draft.entries).filter(
-                        (week) => week.id !== "unscheduled"
-                      ).length
-                    );
+                    const isWorkout = draft.artifactType === "workout";
+                    const planNumber = isWorkout
+                      ? 0
+                      : planDrafts
+                          .slice(0, index + 1)
+                          .filter((item) => item.artifactType !== "workout").length;
+                    const weeks = isWorkout
+                      ? 0
+                      : Math.max(
+                          1,
+                          groupPlanEntriesByWeek(draft.entries).filter(
+                            (week) => week.id !== "unscheduled"
+                          ).length
+                        );
                     const primarySport = draft.entries[0]?.sport;
                     const SportIcon = sportTheme(primarySport).icon;
                     const selected = draft.draftId === selectedPlanDraft.draftId;
@@ -3016,7 +3520,7 @@ export function ChatView({
                             setSelectedPlanDraftId(draft.draftId);
                             setPlanPanelExpanded(true);
                           }}
-                          aria-label={`Open ${draft.name || `plan ${index + 1}`}`}
+                          aria-label={`Open ${draft.name || `${isWorkout ? "workout" : "plan"} ${index + 1}`}`}
                         >
                           <span
                             className="chat-plan-list-sport"
@@ -3030,9 +3534,11 @@ export function ChatView({
                           </span>
                           <span className="chat-plan-list-copy">
                             <span className="chat-plan-list-kicker">
-                              Plan {index + 1}
+                              {isWorkout ? "One-off workout" : `Plan ${planNumber}`}
                             </span>
-                            <strong>{draft.name || "Untitled plan"}</strong>
+                            <strong>
+                              {draft.name || (isWorkout ? "Untitled workout" : "Untitled plan")}
+                            </strong>
                             <span className="chat-plan-list-meta">
                               <span>
                                 {draft.entries.length}{" "}
@@ -3040,9 +3546,13 @@ export function ChatView({
                                   ? "workout"
                                   : "workouts"}
                               </span>
-                              <span>
-                                {weeks} {weeks === 1 ? "week" : "weeks"}
-                              </span>
+                              {!isWorkout ? (
+                                <span>
+                                  {weeks} {weeks === 1 ? "week" : "weeks"}
+                                </span>
+                              ) : (
+                                <span>Workout Library</span>
+                              )}
                               <span data-status={saved ? "saved" : "draft"}>
                                 {saved ? "Saved" : "Draft"}
                               </span>
@@ -3063,19 +3573,24 @@ export function ChatView({
                       type="button"
                       className="chat-plan-panel-back"
                       onClick={() => setPlanPanelExpanded(false)}
-                      aria-label="Back to generated plans"
-                      title="Back to generated plans"
+                      aria-label="Back to Coach creations"
+                      title="Back to Coach creations"
                     >
                       <ChevronLeft size={15} aria-hidden="true" />
-                      Plans
+                      Creations
                     </button>
                     <div className="chat-plan-panel-title is-detail-title">
                       <div>
                         <strong title={selectedPlanDraft.name}>
-                          {selectedPlanDraft.name || "Untitled plan"}
+                          {selectedPlanDraft.name ||
+                            (selectedPlanDraft.artifactType === "workout"
+                              ? "Untitled workout"
+                              : "Untitled plan")}
                         </strong>
                         <span>
-                          Plan {selectedPlanDraftIndex + 1} of {planDrafts.length}
+                          {selectedPlanDraft.artifactType === "workout"
+                            ? "One-off workout"
+                            : `Plan ${selectedTrainingPlanNumber} of ${trainingPlanDrafts.length}`}
                         </span>
                       </div>
                     </div>
@@ -3095,13 +3610,17 @@ export function ChatView({
                   </div>
                 </header>
                 <div className="chat-plan-panel-body">
-                  <PlanPreviewCard
+                  <CoachDraftPreviewCard
                     key={selectedPlanDraft.draftId}
                     draft={selectedPlanDraft}
                     uploading={uploadingDraftId === selectedPlanDraft.draftId}
                     uploaded={uploadedPlans[selectedPlanDraft.draftId]}
-                    onUpload={(destination) =>
-                      void handleUploadPlanDraft(selectedPlanDraft.draftId, destination)
+                    onUpload={(destination, scheduleDate) =>
+                      void handleUploadPlanDraft(
+                        selectedPlanDraft.draftId,
+                        destination,
+                        scheduleDate
+                      )
                     }
                     onReview={
                       onReviewPlan

--- a/src/coroslink-api.ts
+++ b/src/coroslink-api.ts
@@ -625,7 +625,8 @@ export interface CorosLinkApi {
   uploadTrainingPlanDraft: (
     draftId: string,
     unitSystem: UnitSystem,
-    destination?: TrainingPlanDestination
+    destination?: TrainingPlanDestination,
+    scheduleDate?: string
   ) => Promise<UploadPlanResult>;
   confirmWorkoutDelete: (requestId: string) => Promise<DeleteWorkoutResult>;
   setWindowBackground: (color: string) => Promise<void>;

--- a/src/styles.css
+++ b/src/styles.css
@@ -18043,6 +18043,10 @@ tr.data-intervals-row-missing {
   justify-content: space-between;
 }
 
+.chat-plan-panel .chat-plan-entry.is-strength .chat-plan-entry-meta {
+  justify-content: flex-end;
+}
+
 .chat-plan-panel .chat-plan-actions > button {
   justify-content: center;
   white-space: nowrap;
@@ -19748,7 +19752,10 @@ tr.data-intervals-row-missing {
 }
 
 .chat-model-select {
-  width: 146px;
+  flex: 0 1 auto;
+  width: max-content;
+  min-width: 146px;
+  max-width: 220px;
 }
 
 .chat-provider-select .app-select-trigger,
@@ -20652,6 +20659,17 @@ tr.data-intervals-row-missing {
   min-width: 0;
 }
 
+.chat-workout-card-kicker {
+  display: block;
+  margin-bottom: 3px;
+  color: var(--chat-signal-strong);
+  font-size: 9.5px;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
 .chat-plan-card-header h4 {
   margin: 0 0 4px;
   font-size: 14px;
@@ -21047,11 +21065,179 @@ tr.data-intervals-row-missing {
   overflow-wrap: anywhere;
 }
 
+.chat-plan-entry.is-strength {
+  align-items: start;
+  padding-block: 10px;
+}
+
+.chat-plan-entry.is-strength .chat-plan-entry-date {
+  margin-top: 1px;
+}
+
+.chat-plan-entry.is-strength .chat-plan-entry-main {
+  gap: 7px;
+}
+
+.chat-plan-entry.is-strength .chat-plan-entry-name {
+  font-size: 13px;
+}
+
+.chat-plan-strength-structure {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--glass-bg-elevated) 30%, transparent);
+}
+
+.chat-plan-strength-header,
+.chat-plan-strength-repeat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.chat-plan-strength-header {
+  min-height: 34px;
+  padding: 7px 9px;
+  border-bottom: 1px solid var(--glass-border);
+  background: color-mix(in srgb, var(--chat-plan-sport, var(--text-muted)) 7%, transparent);
+}
+
+.chat-plan-strength-header strong,
+.chat-plan-strength-repeat-header strong {
+  color: var(--text-secondary);
+  font-size: 10.5px;
+  font-weight: 700;
+}
+
+.chat-plan-strength-header > span,
+.chat-plan-strength-repeat-header > span {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.chat-plan-strength-steps,
+.chat-plan-strength-repeat > ol {
+  display: grid;
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  gap: 2px;
+}
+
+.chat-plan-strength-step {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  min-height: 38px;
+  padding: 6px 7px;
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--glass-bg) 54%, transparent);
+}
+
+.chat-plan-strength-step.is-rest {
+  min-height: 32px;
+  background: transparent;
+}
+
+.chat-plan-strength-step.is-warmup,
+.chat-plan-strength-step.is-cooldown {
+  background: color-mix(in srgb, var(--glass-bg) 28%, transparent);
+}
+
+.chat-plan-strength-marker {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid color-mix(in srgb, var(--chat-plan-sport, var(--text-muted)) 28%, var(--glass-border));
+  border-radius: 7px;
+  color: var(--chat-plan-sport, var(--text-secondary));
+  background: color-mix(in srgb, var(--chat-plan-sport, var(--text-muted)) 10%, transparent);
+  font-size: 10px;
+  font-weight: 750;
+  font-variant-numeric: tabular-nums;
+}
+
+.chat-plan-strength-step.is-rest .chat-plan-strength-marker,
+.chat-plan-strength-step.is-warmup .chat-plan-strength-marker,
+.chat-plan-strength-step.is-cooldown .chat-plan-strength-marker {
+  border-color: var(--glass-border);
+  background: var(--glass-bg);
+  color: var(--text-muted);
+}
+
+.chat-plan-strength-step-copy {
+  display: grid;
+  min-width: 0;
+}
+
+.chat-plan-strength-step-copy strong {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 11.5px;
+  font-weight: 650;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-plan-strength-prescription {
+  display: flex;
+  align-items: baseline;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 3px 8px;
+  max-width: 260px;
+  text-align: right;
+}
+
+.chat-plan-strength-prescription strong {
+  color: var(--text-primary);
+  font-size: 11.5px;
+  font-weight: 700;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.chat-plan-strength-prescription span {
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.chat-plan-strength-repeat {
+  overflow: hidden;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--chat-plan-sport, var(--text-muted)) 6%, var(--glass-bg));
+}
+
+.chat-plan-strength-repeat-header {
+  min-height: 30px;
+  padding: 6px 9px 3px;
+}
+
+.chat-plan-strength-repeat > ol {
+  padding-top: 2px;
+}
+
 .chat-plan-entry-meta {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
   gap: 5px;
+}
+
+.chat-plan-entry.is-strength .chat-plan-entry-meta {
+  align-self: start;
 }
 
 .chat-plan-entry-volume {
@@ -21286,6 +21472,44 @@ tr.data-intervals-row-missing {
   margin-top: 1px;
 }
 
+.chat-workout-calendar-date {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(150px, auto);
+  align-items: center;
+  gap: 12px;
+  padding: 9px 10px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--glass-bg-elevated) 42%, transparent);
+}
+
+.chat-workout-calendar-date > span {
+  color: var(--text-primary);
+  font-size: 11.5px;
+  font-weight: 650;
+}
+
+.chat-workout-calendar-date > input {
+  min-width: 0;
+  height: 34px;
+  padding: 0 9px;
+  border: 1px solid var(--glass-border);
+  border-radius: 7px;
+  color: var(--text-primary);
+  background: var(--glass-bg);
+  font: inherit;
+  color-scheme: dark;
+}
+
+:root[data-theme="paper"] .chat-workout-calendar-date > input {
+  color-scheme: light;
+}
+
+.chat-workout-calendar-date > input:focus-visible {
+  outline: 2px solid var(--chat-signal);
+  outline-offset: 2px;
+}
+
 .chat-plan-actions {
   display: flex;
   flex-wrap: wrap;
@@ -21407,8 +21631,33 @@ tr.data-intervals-row-missing {
     justify-content: flex-start;
   }
 
+  .chat-plan-strength-step {
+    grid-template-columns: 24px minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .chat-plan-strength-step-copy strong {
+    white-space: normal;
+  }
+
+  .chat-plan-strength-prescription {
+    grid-column: 2;
+    justify-content: flex-start;
+    max-width: none;
+    text-align: left;
+  }
+
+  .chat-plan-panel .chat-plan-entry.is-strength .chat-plan-entry-meta {
+    justify-content: flex-start;
+  }
+
   .chat-plan-destination-options {
     grid-template-columns: 1fr;
+  }
+
+  .chat-workout-calendar-date {
+    grid-template-columns: 1fr;
+    gap: 7px;
   }
 
   .chat-plan-actions > button {
@@ -29364,6 +29613,17 @@ tr.data-intervals-row-missing {
   cursor: pointer;
 }
 
+.workout-editor-add-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.workout-editor-add-actions .ghost-button {
+  padding-inline: 9px;
+}
+
 .workout-editor-nodes {
   display: flex;
   flex-direction: column;
@@ -29457,6 +29717,32 @@ tr.data-intervals-row-missing {
   background: var(--glass-bg);
 }
 
+.workout-strength-step-heading {
+  display: grid;
+  min-width: 0;
+  flex: 1;
+  gap: 2px;
+}
+
+.workout-strength-step-heading strong,
+.workout-strength-step-heading span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workout-strength-step-heading strong {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 680;
+}
+
+.workout-strength-step-heading span {
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+}
+
 .workout-step-actions {
   display: flex;
   flex: 0 0 auto;
@@ -29521,6 +29807,165 @@ tr.data-intervals-row-missing {
 
 .workout-exercise-control .exercise-combobox {
   width: 100%;
+}
+
+.workout-strength-fields {
+  display: grid;
+  min-width: 0;
+  gap: 18px;
+  padding: 14px;
+  container: workout-strength-fields / inline-size;
+}
+
+.workout-strength-form {
+  display: grid;
+  min-width: 0;
+  align-content: start;
+  gap: 15px;
+}
+
+.workout-strength-fields.has-preview {
+  grid-template-columns: minmax(0, 1fr) minmax(210px, 270px);
+}
+
+.workout-strength-preview {
+  min-width: 0;
+}
+
+.workout-strength-preview .exercise-preview {
+  position: sticky;
+  top: 0;
+}
+
+.workout-strength-instructions {
+  position: relative;
+  display: grid;
+  min-width: 0;
+  gap: 6px;
+}
+
+.workout-strength-instructions > span {
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  font-weight: 600;
+}
+
+.workout-strength-instructions textarea {
+  min-height: 62px;
+  resize: vertical;
+}
+
+.workout-strength-instructions small {
+  position: absolute;
+  right: 8px;
+  bottom: 6px;
+  color: var(--text-muted);
+  font-size: 9px;
+}
+
+.workout-step-card .set-line input {
+  width: auto;
+  min-height: 0;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  box-shadow: none;
+  color: var(--text-primary);
+  padding: 0;
+  font-size: 27px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  appearance: textfield;
+}
+
+.workout-step-card .set-line input::-webkit-inner-spin-button,
+.workout-step-card .set-line input::-webkit-outer-spin-button {
+  appearance: none;
+  margin: 0;
+}
+
+.workout-step-card .set-line input:focus {
+  border: 0;
+  box-shadow: none;
+  outline: none;
+}
+
+.workout-step-card .set-line input:focus-visible,
+.workout-step-card .rest-picker input:focus-visible,
+.workout-step-card .rest-picker button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--step-color, var(--accent)) 80%, transparent);
+  outline-offset: 3px;
+}
+
+.workout-step-card .set-line-cell > input {
+  width: 2.6em;
+}
+
+.workout-step-card .set-line-compound > input {
+  width: 3.2em;
+}
+
+.workout-step-card .set-line .set-line-select {
+  min-width: 108px;
+  flex: 0 1 auto;
+}
+
+.workout-step-card .set-line .set-line-select .app-select-trigger {
+  min-height: 0;
+  padding: 5px 8px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  background: var(--glass-bg);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.workout-step-card .set-line-weight input {
+  width: 3.4em;
+  font-size: 22px;
+}
+
+.workout-step-card .rest-picker > button {
+  min-height: 32px;
+  padding: 0 13px;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--glass-bg) 55%, transparent);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 620;
+  font-variant-numeric: tabular-nums;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.workout-step-card .rest-picker > button:hover:not(:disabled) {
+  border-color: color-mix(in srgb, var(--text-primary) 22%, var(--glass-border));
+  background: var(--glass-bg-hover);
+  color: var(--text-primary);
+}
+
+.workout-step-card .rest-picker > button.is-selected {
+  border-color: color-mix(in srgb, var(--step-color, var(--accent)) 55%, transparent);
+  background: color-mix(in srgb, var(--step-color, var(--accent)) 18%, transparent);
+  color: var(--text-primary);
+}
+
+.workout-step-card .rest-picker-custom input {
+  width: 66px;
+  min-height: 32px;
+  border-radius: var(--radius-pill);
+  padding: 0 10px;
+  font-size: 12.5px;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.workout-step-card .rest-picker-custom input:focus {
+  border-color: color-mix(in srgb, var(--step-color, var(--accent)) 70%, var(--glass-border));
+  box-shadow: none;
 }
 
 .workout-control-group > label,
@@ -29759,6 +30204,7 @@ tr.data-intervals-row-missing {
   .workout-editor-modal { height: calc(100dvh - 16px); }
   .workout-editor-basics,
   .workout-step-fields { grid-template-columns: 1fr; }
+  .workout-strength-fields.has-preview { grid-template-columns: 1fr; }
   .workout-control-group { align-items: stretch; flex-wrap: wrap; }
   .workout-step-header { flex-wrap: wrap; }
   .workout-step-header > input { order: 2; flex-basis: calc(100% - 40px); }
@@ -29776,6 +30222,8 @@ tr.data-intervals-row-missing {
   .workout-library-footer .calendar-field { max-width: none; }
   .workout-editor-scroll { padding-inline: 10px; }
   .workout-editor-header { padding-inline: 12px; }
+  .workout-editor-structure-header { align-items: stretch; flex-direction: column; }
+  .workout-editor-add-actions { justify-content: flex-start; }
   .workout-repeat-header { flex-wrap: wrap; }
   .workout-repeat-count { margin-left: 0; }
   .workout-repeat-header .workout-step-actions { margin-left: auto; }

--- a/src/training-library/PlanEditor.tsx
+++ b/src/training-library/PlanEditor.tsx
@@ -93,11 +93,12 @@ function entryDate(plan: TrainingPlanDocument, weekIndex: number, dayIndex: numb
   return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
-function mondayOf(value: string): string {
-  const date = new Date(`${value}T12:00:00`);
-  if (Number.isNaN(date.valueOf())) return value;
-  date.setDate(date.getDate() - ((date.getDay() + 6) % 7));
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+function planDayName(startDate: string | undefined, dayIndex: number): string {
+  if (!startDate) return DAY_NAMES[dayIndex]!;
+  const date = new Date(`${startDate}T12:00:00`);
+  if (Number.isNaN(date.valueOf())) return DAY_NAMES[dayIndex]!;
+  date.setDate(date.getDate() + dayIndex);
+  return date.toLocaleDateString(undefined, { weekday: "short" });
 }
 
 export function PlanEditor({ api, initialPlan, workouts, calendarEnabled, offline, onCalendar, onSave, onClose }: PlanEditorProps) {
@@ -114,6 +115,7 @@ export function PlanEditor({ api, initialPlan, workouts, calendarEnabled, offlin
   const [editingEntryId, setEditingEntryId] = useState<string | null>(null);
   const [workoutEditorError, setWorkoutEditorError] = useState<string | null>(null);
   const plan = history[historyIndex]!;
+  const planDayNames = useMemo(() => DAY_NAMES.map((_day, dayIndex) => planDayName(plan.startDate, dayIndex)), [plan.startDate]);
   const editingEntry = plan.entries.find((entry) => entry.id === editingEntryId);
   const dirty = JSON.stringify(plan) !== JSON.stringify(initialPlan);
   const validation = useMemo(() => validateTrainingPlan(plan), [plan]);
@@ -307,7 +309,7 @@ export function PlanEditor({ api, initialPlan, workouts, calendarEnabled, offlin
                 onChange={(difficulty) => patchPlan({ difficulty })}
               />
             </label>
-            <label><span>Week 1 Monday</span><span className="plan-editor-date"><CalendarRange size={15} /><input type="date" value={plan.startDate ?? ""} onChange={(event) => commit(shiftTrainingPlan(plan, mondayOf(event.target.value)))} /></span></label>
+            <label><span>Plan start date</span><span className="plan-editor-date"><CalendarRange size={15} /><input type="date" value={plan.startDate ?? ""} onChange={(event) => { if (event.target.value) commit(shiftTrainingPlan(plan, event.target.value)); }} /></span></label>
             <label><span>Notes</span><textarea value={plan.notes} onChange={(event) => patchPlan({ notes: event.target.value })} /></label>
           </section>
 
@@ -388,10 +390,10 @@ export function PlanEditor({ api, initialPlan, workouts, calendarEnabled, offlin
                   </div>
                 </header>
                 <div className="plan-week-days">
-                  {DAY_NAMES.map((day, dayIndex) => {
+                  {planDayNames.map((day, dayIndex) => {
                     const entries = weekEntries.filter((entry) => entry.dayIndex === dayIndex).sort((a, b) => a.sortOrder - b.sortOrder);
                     const dayKey = `week-${weekIndex}-day-${dayIndex}`;
-                    return <div className={`plan-day${dropTarget === dayKey ? " is-drop-target" : ""}`} key={day} {...dropTargetProps(dayKey, (event) => drop(event, weekIndex, dayIndex))}>
+                    return <div className={`plan-day${dropTarget === dayKey ? " is-drop-target" : ""}`} key={dayKey} {...dropTargetProps(dayKey, (event) => drop(event, weekIndex, dayIndex))}>
                       <div className="plan-day-heading"><span><strong>{day}</strong><small>{entryDate(plan, weekIndex, dayIndex)}</small></span><button type="button" aria-label={`Add rest day on ${day}`} onClick={() => addRest(weekIndex, dayIndex)}><CornerDownLeft size={13} /></button></div>
                       <div className="plan-day-entries">
                         {entries.map((entry) => <PlanEntryCard key={entry.id} entry={entry} onEdit={() => setEditingEntryId(entry.id)} onRemove={() => removeEntry(entry.id)} />)}

--- a/src/training-library/TrainingPlanCalendarDialog.tsx
+++ b/src/training-library/TrainingPlanCalendarDialog.tsx
@@ -26,11 +26,20 @@ interface TrainingPlanCalendarDialogProps {
   onComplete: (result: TrainingPlanCalendarMutationResult) => void;
 }
 
-function mondayOnOrAfter(value = new Date()): string {
-  const date = new Date(value);
-  const offset = (8 - date.getDay()) % 7;
-  date.setDate(date.getDate() + offset);
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+function calendarDay(value = new Date()): string {
+  return `${value.getFullYear()}-${String(value.getMonth() + 1).padStart(2, "0")}-${String(value.getDate()).padStart(2, "0")}`;
+}
+
+function installDateProblem(value: string, today: string): string | null {
+  const date = new Date(`${value}T12:00:00`);
+  if (!value || Number.isNaN(date.valueOf())) return "Choose a start date.";
+  if (value < today) return "A training plan cannot start in the past.";
+  return null;
+}
+
+function userFacingError(cause: unknown): string {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  return message.replace(/^Error invoking remote method '[^']+': Error:\s*/, "");
 }
 
 function displayDay(value: string): string {
@@ -46,9 +55,9 @@ function initialInstallDate(plan: TrainingPlanDocument): string {
     const date = new Date(`${dashed}T12:00:00`);
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-    if (!Number.isNaN(date.valueOf()) && date >= today && date.getDay() === 1) return dashed;
+    if (!Number.isNaN(date.valueOf()) && date >= today) return dashed;
   }
-  return mondayOnOrAfter();
+  return calendarDay();
 }
 
 export function TrainingPlanCalendarDialog({ api, plan, offline, requestedOperation, onClose, onComplete }: TrainingPlanCalendarDialogProps) {
@@ -56,10 +65,12 @@ export function TrainingPlanCalendarDialog({ api, plan, offline, requestedOperat
   const install = activeTrainingPlanCalendarInstall(plan);
   const operation = requestedOperation ?? (install && !(install.state === "partial" && install.lastOperation === "install") ? "remove" : "install");
   const [startDate, setStartDate] = useState(() => initialInstallDate(plan));
+  const [today] = useState(() => calendarDay());
   const [preview, setPreview] = useState<TrainingPlanCalendarPreview | null>(null);
   const [loading, setLoading] = useState(operation === "remove" && !offline);
   const [mutating, setMutating] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<{ title: string; message: string } | null>(null);
+  const startDateProblem = operation === "install" ? installDateProblem(startDate, today) : null;
 
   const conflictCount = useMemo(
     () => preview?.conflicts.reduce((sum, conflict) => sum + conflict.existing.length, 0) ?? 0,
@@ -67,7 +78,7 @@ export function TrainingPlanCalendarDialog({ api, plan, offline, requestedOperat
   );
 
   const loadPreview = async () => {
-    if (offline) return;
+    if (offline || startDateProblem) return;
     setLoading(true);
     setError(null);
     setPreview(null);
@@ -76,7 +87,7 @@ export function TrainingPlanCalendarDialog({ api, plan, offline, requestedOperat
         ? await api.previewTrainingPlanCalendar(plan.id, startDate)
         : await api.previewTrainingPlanCalendarRemoval(plan.id));
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
+      setError({ title: "Couldn’t preview calendar", message: userFacingError(cause) });
     } finally {
       setLoading(false);
     }
@@ -108,7 +119,7 @@ export function TrainingPlanCalendarDialog({ api, plan, offline, requestedOperat
         : await api.removeTrainingPlanFromCalendar(preview.previewId, true);
       onComplete(result);
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause));
+      setError({ title: "Calendar update needs attention", message: userFacingError(cause) });
       setPreview(null);
     } finally {
       setMutating(false);
@@ -124,11 +135,11 @@ export function TrainingPlanCalendarDialog({ api, plan, offline, requestedOperat
 
       {offline ? <div className="plan-calendar-offline"><AlertTriangle size={18} /><div><strong>Calendar actions are unavailable offline</strong><p>Reconnect to COROS, refresh the Training Library, and try again.</p></div></div> : null}
 
-      {!offline && operation === "install" && !preview ? <div className="plan-calendar-start"><label><span>Week 1 Monday</span><input autoFocus type="date" value={startDate} disabled={loading} onChange={(event) => setStartDate(event.target.value)} /></label><p>The preview checks exact dates and shows same-day workouts. Existing workouts are kept and this plan is added alongside them.</p><button type="button" className="primary-button" disabled={loading || !startDate} onClick={() => void loadPreview()}>{loading ? <LoaderCircle className="is-spinning" size={15} /> : <CalendarPlus size={15} />}{loading ? "Checking calendar..." : "Preview dates"}</button></div> : null}
+      {!offline && operation === "install" && !preview ? <div className="plan-calendar-start"><label><span>Plan start date</span><input autoFocus type="date" value={startDate} min={today} aria-invalid={Boolean(startDateProblem)} aria-describedby={startDateProblem ? "plan-calendar-date-error" : undefined} disabled={loading} onChange={(event) => { setStartDate(event.target.value); setError(null); }} />{startDateProblem ? <small id="plan-calendar-date-error" className="plan-calendar-date-error" role="alert">{startDateProblem}</small> : null}</label><p>Day 1 starts on the selected date. The preview checks exact dates and shows same-day workouts; existing workouts are kept.</p><button type="button" className="primary-button" disabled={loading || Boolean(startDateProblem)} onClick={() => void loadPreview()}>{loading ? <LoaderCircle className="is-spinning" size={15} /> : <CalendarPlus size={15} />}{loading ? "Checking calendar..." : "Preview dates"}</button></div> : null}
 
       {!offline && loading ? <div className="plan-calendar-loading"><LoaderCircle className="is-spinning" size={22} /><strong>Checking the COROS calendar</strong><p>Comparing plan dates with current scheduled workouts.</p></div> : null}
 
-      {error ? <div className="plan-calendar-error" role="alert"><AlertTriangle size={17} /><div><strong>Refresh required</strong><p>{error}</p></div><button type="button" className="ghost-button" disabled={loading || mutating} onClick={() => void loadPreview()}><RefreshCw size={14} /> Try again</button></div> : null}
+      {error ? <div className="plan-calendar-error" role="alert"><AlertTriangle size={17} /><div><strong>{error.title}</strong><p>{error.message}</p></div><button type="button" className="ghost-button" disabled={loading || mutating} onClick={() => void loadPreview()}><RefreshCw size={14} /> Try again</button></div> : null}
 
       {preview ? <div className="plan-calendar-preview">
         <div className="plan-calendar-summary"><span><strong>{preview.entries.length}</strong><small>{operation === "install" ? "workouts to add" : "future workouts to remove"}</small></span><span><strong>{displayDay(preview.startDate)}</strong><small>{operation === "install" ? "Week 1 starts" : "installed start"}</small></span><span className={conflictCount ? "has-conflict" : ""}><strong>{conflictCount}</strong><small>same-day conflicts</small></span></div>

--- a/src/training-library/TrainingPlanGenerator.tsx
+++ b/src/training-library/TrainingPlanGenerator.tsx
@@ -65,10 +65,7 @@ const STAGE_STEPS = [
   { id: "Validating workouts and dates", label: "Validating workouts" }
 ];
 
-function nextMonday(): string {
-  const date = new Date();
-  const days = (8 - date.getDay()) % 7 || 7;
-  date.setDate(date.getDate() + days);
+function calendarDay(date = new Date()): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
 }
 
@@ -78,9 +75,9 @@ function providerName(provider: ChatProvider): string {
   return "ChatGPT";
 }
 
-function isMonday(value: string): boolean {
+function isValidStartDate(value: string): boolean {
   const date = new Date(`${value}T12:00:00`);
-  return !Number.isNaN(date.valueOf()) && date.getDay() === 1;
+  return !Number.isNaN(date.valueOf()) && value >= calendarDay();
 }
 
 function generationPrompt(request: TrainingPlanGenerationRequest): string {
@@ -93,8 +90,9 @@ function generationPrompt(request: TrainingPlanGenerationRequest): string {
     `Difficulty: ${request.difficulty}`,
     `Length: exactly ${request.weeks} weeks`,
     `Sessions: exactly ${request.sessionsPerWeek} workouts per week`,
-    `Week 1 Monday: ${request.startDate}`,
-    `Available workout days (use only these): ${available}`,
+    `Plan start date (Day 1 of Week 1): ${request.startDate}`,
+    "Each plan week is a consecutive seven-day block beginning on the plan start date.",
+    `Available calendar weekdays (use only these): ${available}`,
     request.maxSessionMinutes ? `Maximum duration for every session: ${request.maxSessionMinutes} minutes` : "No explicit session-duration cap.",
     request.constraints?.trim() ? `Additional constraints: ${request.constraints.trim()}` : "No additional constraints.",
     "Every workout must have a schedule_date, explicit sport, and complete typed steps including repeats, targets, and intensities. Set save_to_library to false.",
@@ -132,7 +130,7 @@ export function TrainingPlanGenerator({ api, onClose, onGenerated, onOpenCoach }
   const [difficulty, setDifficulty] = useState<TrainingPlanGenerationRequest["difficulty"]>("intermediate");
   const [weeks, setWeeks] = useState(8);
   const [sessionsPerWeek, setSessionsPerWeek] = useState(4);
-  const [startDate, setStartDate] = useState(nextMonday);
+  const [startDate, setStartDate] = useState(calendarDay);
   const [availableDays, setAvailableDays] = useState([0, 1, 2, 3, 4, 5, 6]);
   const [maxSessionMinutes, setMaxSessionMinutes] = useState("");
   const [constraints, setConstraints] = useState("");
@@ -161,7 +159,7 @@ export function TrainingPlanGenerator({ api, onClose, onGenerated, onOpenCoach }
     request.goal && request.sports.length && request.availableDayIndexes.length &&
     request.weeks >= 1 && request.weeks <= 24 &&
     request.sessionsPerWeek >= 1 && request.sessionsPerWeek <= Math.min(7, request.availableDayIndexes.length) &&
-    isMonday(request.startDate) &&
+    isValidStartDate(request.startDate) &&
     (request.maxSessionMinutes === undefined || request.maxSessionMinutes > 0)
   );
 
@@ -183,7 +181,7 @@ export function TrainingPlanGenerator({ api, onClose, onGenerated, onOpenCoach }
     const total = Number.isFinite(weeks * sessionsPerWeek) ? weeks * sessionsPerWeek : 0;
     return {
       total,
-      range: end ? `${dayFmt.format(start)} – ${fullFmt.format(end)}` : "Pick a Week 1 Monday"
+      range: end ? `${dayFmt.format(start)} – ${fullFmt.format(end)}` : "Pick a plan start date"
     };
   }, [sessionsPerWeek, startDate, weeks]);
 
@@ -325,7 +323,7 @@ export function TrainingPlanGenerator({ api, onClose, onGenerated, onOpenCoach }
     if (!request.sports.length) return "Pick at least one sport.";
     if (!request.availableDayIndexes.length) return "Pick at least one available day.";
     if (request.sessionsPerWeek > request.availableDayIndexes.length) return `Choose at least ${request.sessionsPerWeek} available days.`;
-    if (!isMonday(request.startDate)) return "Week 1 must start on a Monday.";
+    if (!isValidStartDate(request.startDate)) return "Choose today or a future start date.";
     return "Check the highlighted fields above.";
   })();
   return (
@@ -412,10 +410,10 @@ export function TrainingPlanGenerator({ api, onClose, onGenerated, onOpenCoach }
                 <Stepper value={sessionsPerWeek} min={1} max={Math.min(7, availableDays.length || 1)} disabled={generating} decreaseLabel="Fewer sessions per week" increaseLabel="More sessions per week" onChange={setSessionsPerWeek} />
               </label>
               <label>
-                <span>Week 1 Monday</span>
+                <span>Plan start date</span>
                 <span className="plan-generator-date">
                   <CalendarDays size={14} />
-                  <input type="date" value={startDate} disabled={generating} onChange={(event) => setStartDate(event.target.value)} />
+                  <input type="date" value={startDate} min={calendarDay()} disabled={generating} onChange={(event) => setStartDate(event.target.value)} />
                 </span>
               </label>
             </div>
@@ -439,7 +437,7 @@ export function TrainingPlanGenerator({ api, onClose, onGenerated, onOpenCoach }
               </div>
             </fieldset>
             {sessionsPerWeek > availableDays.length ? <p className="plan-generator-inline-error" role="alert">Choose at least {sessionsPerWeek} available days.</p> : null}
-            {!isMonday(startDate) ? <p className="plan-generator-inline-error" role="alert">Week 1 must start on a Monday.</p> : null}
+            {!isValidStartDate(startDate) ? <p className="plan-generator-inline-error" role="alert">Choose today or a future start date.</p> : null}
 
             <div className="plan-generator-grid is-bottom">
               <label>

--- a/src/training-library/trainingLibrary.css
+++ b/src/training-library/trainingLibrary.css
@@ -5416,6 +5416,8 @@
 }
 
 .plan-calendar-loading strong { color: var(--text-primary); font-size: 13px; }
+.plan-calendar-start input[aria-invalid="true"] { border-color: var(--warning-border); }
+.plan-calendar-date-error { color: var(--warning-text); font-size: 10.5px; font-weight: 400; }
 .plan-calendar-offline,
 .plan-calendar-error { display: flex; align-items: flex-start; gap: 10px; padding: 14px; border: 1px solid var(--warning-border); border-radius: var(--radius-sm); color: var(--warning-text); background: var(--warning-bg); }
 .plan-calendar-offline strong,


### PR DESCRIPTION
## What changed

- add standalone workout drafting alongside multi-workout training plans
- add COROS exercise catalog search, token-aware exercise matching, and stricter Strength/HYROX validation
- preserve and restore structured workout draft sources in chat history
- expand workout upload destinations and editing support, including strength sets and recovery controls
- refresh chat draft cards, response controls, editor layouts, and related training-plan UI
- extend coverage across chat, workout building, intensity encoding, and the training library

## Why

The coach workflow previously treated one-off workouts like plans, could lose structured workout data after chat persistence, and lacked a reliable way to resolve exact COROS exercises before drafting Strength or HYROX sessions. The editor and draft-card UI also did not expose all of the new structured controls and destinations.

## Impact

Athletes can now draft, review, edit, and save a single workout or a full plan with more reliable COROS exercise selection and richer destination choices. Existing persisted draft cards recover their editable workout source when the separate coach draft store still contains it.

## Validation

- `npm run build`
- `node scripts/test-chat-history-store.mjs`
- `node scripts/test-chat-service.mjs`
- `node scripts/test-chat-workout-tools.mjs`
- `node scripts/test-coros-workout-builder.mjs`
- `node scripts/test-workout-intensity-codec.mjs`
- `ELECTRON_RUN_AS_NODE=1 electron scripts/test-training-library.mjs`

All checks passed. Vite reported its existing large-chunk advisory during the production build.
